### PR TITLE
chore(deploy): migrazione da Railway a Render free tier

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -38,6 +38,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 ENV PORT=8000
 EXPOSE 8000
 
-# Avvia il server FastAPI in exec form per corretta propagazione SIGTERM
-# La shell form non propaga i segnali al processo figlio (uvicorn)
-CMD ["uvicorn", "geo_optimizer.web.app:app", "--host", "0.0.0.0", "--port", "8000"]
+# Avvia il server FastAPI — usa $PORT da variabile d'ambiente
+# per compatibilità con Render, Railway e altri PaaS che iniettano la porta
+# Shell form necessaria per espansione variabile $PORT
+CMD uvicorn geo_optimizer.web.app:app --host 0.0.0.0 --port ${PORT:-8000}

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,21 @@
+# Render Blueprint — configurazione dichiarativa per deploy automatico
+# Docs: https://docs.render.com/blueprint-spec
+#
+# Per collegare: Dashboard → New → Blueprint → seleziona repo GitHub
+# Render legge questo file e crea i servizi automaticamente.
+
+services:
+  - type: web
+    name: geo-optimizer-web
+    runtime: docker
+    dockerfilePath: ./Dockerfile.web
+    plan: free
+    region: frankfurt  # EU — più vicino a noi
+    healthCheckPath: /health
+    envVars:
+      - key: PORT
+        value: "8000"
+      - key: PYTHONDONTWRITEBYTECODE
+        value: "1"
+      - key: PYTHONUNBUFFERED
+        value: "1"


### PR DESCRIPTION
## Cosa fa questa PR

Migra il deploy della web demo da Railway (trial in scadenza) a Render free tier.

### Modifiche

- **`render.yaml`** — Blueprint dichiarativo per deploy automatico su Render
- **`Dockerfile.web`** — Porta dinamica via `$PORT` per compatibilità con PaaS (Render, Railway, Fly.io)

### Perché

Railway trial scade tra 8 giorni. Render free tier offre:
- 750 ore/mese (1 servizio sempre attivo)
- Auto-deploy da GitHub su push a `main`
- Zero costo, nessun limite di tempo
- Auto-sleep dopo 15 min inattività (cold start ~30s)

### Checklist

- [x] `render.yaml` valido
- [x] Dockerfile.web usa `$PORT` dinamico
- [x] Nessuna modifica al codice applicativo