### PR TITLE
fix(web): includere template HTML nel pacchetto — risolve 500 homepage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ where = ["src"]
 
 [tool.setuptools.package-data]
 # Solo i file compilati .mo — i sorgenti .po non appartengono al pacchetto distribuito (#135)
-"geo_optimizer" = ["py.typed", "i18n/locales/*/LC_MESSAGES/*.mo"]
+"geo_optimizer" = ["py.typed", "i18n/locales/*/LC_MESSAGES/*.mo", "web/templates/*.html"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## Cosa fa questa PR

Risolve il 500 sulla homepage della web demo su Render.

### Problema

Il file `web/templates/index.html` non era incluso in `[tool.setuptools.package-data]`, quindi durante il `pip install` nel Docker build il template non veniva copiato. La funzione `_render_homepage()` faceva `template_path.read_text()` su un file inesistente → `FileNotFoundError` → 500.

### Fix

Aggiunto `"web/templates/*.html"` a `package-data` in `pyproject.toml`.

### Verifica

```bash
pip install --prefix=/tmp/test '.[web]'
find /tmp/test -name 'index.html' -path '*/templates/*'
# /tmp/test/.../geo_optimizer/web/templates/index.html ✅
```