### PR TITLE
feat(web): contatori social proof nella homepage

### DIFF
--- a/src/geo_optimizer/web/app.py
+++ b/src/geo_optimizer/web/app.py
@@ -285,10 +285,62 @@ async def homepage(request: Request):
     return _render_homepage(nonce=nonce)
 
 
+# ─── Contatore audit globale ─────────────────────────────────────────────────
+# Contatore in-memory degli audit eseguiti (reset al restart del servizio)
+_audit_counter: int = 0
+
+
 @app.get("/health")
 async def health():
     """Health check for monitoring."""
     return {"status": "ok", "version": __version__}
+
+
+@app.get("/api/stats")
+async def stats():
+    """Public stats: GitHub stars, PyPI downloads, audit count.
+
+    Fetches GitHub and PyPI data with in-memory cache (1h TTL).
+    Used by the homepage for social proof counters.
+    """
+    import time as _time
+
+    import httpx
+
+    cache_key = "_stats_cache"
+    cache_ttl = 3600  # 1 ora
+
+    # Cache semplice in-memory tramite attributo della funzione
+    cached = getattr(stats, cache_key, None)
+    if cached and (_time.time() - cached["ts"]) < cache_ttl:
+        # Aggiorna solo il contatore audit (sempre fresco)
+        cached["data"]["audits_run"] = _audit_counter
+        return cached["data"]
+
+    result = {"github_stars": 0, "pypi_downloads_month": 0, "audits_run": _audit_counter}
+
+    async with httpx.AsyncClient(timeout=5.0) as client:
+        # GitHub stars
+        try:
+            r = await client.get(
+                "https://api.github.com/repos/Auriti-Labs/geo-optimizer-skill",
+                headers={"Accept": "application/vnd.github.v3+json"},
+            )
+            if r.status_code == 200:
+                result["github_stars"] = r.json().get("stargazers_count", 0)
+        except Exception:
+            pass
+
+        # PyPI downloads ultimo mese
+        try:
+            r = await client.get("https://pypistats.org/api/packages/geo-optimizer-skill/recent")
+            if r.status_code == 200:
+                result["pypi_downloads_month"] = r.json().get("data", {}).get("last_month", 0)
+        except Exception:
+            pass
+
+    setattr(stats, cache_key, {"data": result, "ts": _time.time()})
+    return result
 
 
 # ─── Pydantic model for POST body validation ─────────────────────────────────
@@ -549,6 +601,10 @@ async def _run_audit(url: str) -> JSONResponse:
 
     # Serialize result
     data = _audit_result_to_dict(result)
+
+    # Incrementa contatore audit globale
+    global _audit_counter
+    _audit_counter += 1
 
     # Save to cache
     report_id = await _set_cached(url, data)

--- a/src/geo_optimizer/web/templates/index.html
+++ b/src/geo_optimizer/web/templates/index.html
@@ -38,6 +38,8 @@ border-bottom:1px solid #334155}
 .error{color:#ef4444;margin-top:1rem;display:none}
 .report-link{margin-top:1rem;text-align:center}
 .report-link a{color:#60a5fa;text-decoration:none;font-size:.9rem}
+.stats{display:flex;justify-content:center;gap:1.5rem;margin-bottom:1.5rem;flex-wrap:wrap}
+.stat{background:#1e293b;padding:.4rem .8rem;border-radius:6px;font-size:.85rem;color:#94a3b8}
 </style>
 </head>
 <body>
@@ -63,10 +65,17 @@ border-bottom:1px solid #334155}
         <div class="report-link" id="report-link"></div>
     </div>
 
+    <div class="stats" id="stats-bar">
+        <span class="stat" id="stat-stars">⭐ <span id="stars-count">—</span> stars</span>
+        <span class="stat" id="stat-downloads">📦 <span id="downloads-count">—</span> downloads/mo</span>
+        <span class="stat" id="stat-audits">🔍 <span id="audits-count">—</span> audits run</span>
+    </div>
+
     <div class="links">
         <p>CLI: <code>pip install geo-optimizer-skill</code></p>
         <p><a href="https://github.com/auriti-labs/geo-optimizer-skill">GitHub</a> &middot;
-           <a href="/docs">API Docs</a></p>
+           <a href="/docs">API Docs</a> &middot;
+           <a href="https://github.com/auriti-labs/geo-optimizer-skill/issues">Issues</a></p>
     </div>
 </div>
 
@@ -163,6 +172,19 @@ async function runAudit() {
 document.getElementById('url-input').addEventListener('keypress', function(e) {
     if (e.key === 'Enter') runAudit();
 });
+
+// Carica le statistiche all'avvio della pagina
+(async function loadStats() {
+    try {
+        const res = await fetch('/api/stats');
+        if (!res.ok) return;
+        const data = await res.json();
+        const fmt = (n) => n >= 1000 ? (n/1000).toFixed(1) + 'k' : String(n);
+        document.getElementById('stars-count').textContent = fmt(data.github_stars);
+        document.getElementById('downloads-count').textContent = fmt(data.pypi_downloads_month);
+        document.getElementById('audits-count').textContent = fmt(data.audits_run);
+    } catch (e) { /* silenzioso se le stats non sono disponibili */ }
+})();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Cosa fa questa PR

Aggiunge contatori di social proof nella homepage della web demo.

### Nuovo endpoint `/api/stats`
Ritorna:
```json
{"github_stars": 13, "pypi_downloads_month": 1393, "audits_run": 42}
```
- GitHub stars via API pubblica (cache 1h)
- PyPI downloads via pypistats.org (cache 1h)
- Contatore audit in-memory (incrementato ad ogni audit riuscito)

### Homepage
Barra con 3 contatori: ⭐ stars · 📦 downloads/mo · 🔍 audits run

### Screenshot
La barra appare tra il form di audit e i link footer.