### PR TITLE
fix(web): CSP blocca bottone Audit — rimuovere onclick inline

### DIFF
--- a/src/geo_optimizer/web/templates/index.html
+++ b/src/geo_optimizer/web/templates/index.html
@@ -49,7 +49,7 @@ border-bottom:1px solid #334155}
 
     <div class="form-group">
         <input type="url" id="url-input" placeholder="https://example.com" required>
-        <button id="btn" onclick="runAudit()">Audit</button>
+        <button id="btn">Audit</button>
     </div>
 
     <div class="spinner" id="spinner">Analyzing...</div>
@@ -169,6 +169,8 @@ async function runAudit() {
     }
 }
 
+// Event listener per il bottone Audit (al posto di onclick inline, bloccato dalla CSP)
+document.getElementById('btn').addEventListener('click', runAudit);
 document.getElementById('url-input').addEventListener('keypress', function(e) {
     if (e.key === 'Enter') runAudit();
 });


### PR DESCRIPTION
L'handler `onclick="runAudit()"` violava la CSP (nonce richiesto). Sostituito con `addEventListener` nel blocco `<script>` che ha il nonce.