### PR TITLE
feat(web): pagine Roadmap, Research e Compare

### DIFF
--- a/src/geo_optimizer/web/app.py
+++ b/src/geo_optimizer/web/app.py
@@ -285,6 +285,33 @@ async def homepage(request: Request):
     return _render_homepage(nonce=nonce)
 
 
+# ─── Pagine statiche informative ──────────────────────────────────────────────
+
+
+@app.get("/roadmap", response_class=HTMLResponse)
+async def roadmap_page():
+    """Public roadmap: Now / Next / Later — no dates, just direction."""
+    template_path = Path(__file__).parent / "templates" / "roadmap.html"
+    return template_path.read_text(encoding="utf-8")
+
+
+@app.get("/research", response_class=HTMLResponse)
+async def research_page():
+    """Research foundation: peer-reviewed papers behind the scoring."""
+    template_path = Path(__file__).parent / "templates" / "research.html"
+    return template_path.read_text(encoding="utf-8")
+
+
+@app.get("/compare", response_class=HTMLResponse)
+async def compare_page(request: Request):
+    """Compare GEO scores of two websites side by side."""
+    nonce = getattr(request.state, "csp_nonce", "")
+    template_path = Path(__file__).parent / "templates" / "compare.html"
+    html = template_path.read_text(encoding="utf-8")
+    nonce_attr = f' nonce="{nonce}"' if nonce else ""
+    return html.replace("__NONCE_ATTR__", nonce_attr)
+
+
 # ─── Contatore audit globale ─────────────────────────────────────────────────
 # Contatore in-memory degli audit eseguiti (reset al restart del servizio)
 _audit_counter: int = 0

--- a/src/geo_optimizer/web/templates/compare.html
+++ b/src/geo_optimizer/web/templates/compare.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Compare GEO Scores — GEO Optimizer</title>
+<meta name="description" content="Compare GEO scores between two websites side by side. See which site is better optimized for AI search engines.">
+<link rel="canonical" href="https://geo-optimizer-web.onrender.com/compare">
+<meta property="og:title" content="Compare GEO Scores — GEO Optimizer">
+<meta property="og:description" content="Side-by-side GEO score comparison for AI search visibility.">
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+background:#0f172a;color:#e2e8f0;min-height:100vh;padding:2rem}
+.container{max-width:700px;margin:0 auto}
+h1{font-size:2.2rem;margin-bottom:.5rem;background:linear-gradient(135deg,#60a5fa,#a78bfa);
+-webkit-background-clip:text;-webkit-text-fill-color:transparent;text-align:center}
+.subtitle{color:#94a3b8;margin-bottom:2rem;font-size:1.05rem;text-align:center}
+.form-row{display:flex;gap:.5rem;margin-bottom:.5rem}
+.form-row input{flex:1;padding:.65rem .75rem;border:2px solid #334155;border-radius:8px;
+background:#1e293b;color:#e2e8f0;font-size:.95rem;outline:none}
+.form-row input:focus{border-color:#60a5fa}
+.vs{text-align:center;color:#64748b;font-size:.85rem;margin:.25rem 0}
+button{display:block;width:100%;padding:.75rem;border:none;border-radius:8px;background:#3b82f6;
+color:#fff;font-size:1rem;font-weight:600;cursor:pointer;margin-top:.75rem}
+button:hover{background:#2563eb}
+button:disabled{opacity:.5;cursor:not-allowed}
+.spinner{display:none;text-align:center;margin:1rem 0;color:#94a3b8}
+.spinner.active{display:block}
+.error{color:#ef4444;text-align:center;margin-top:1rem;display:none}
+.results{display:none;margin-top:1.5rem}
+.comparison{display:grid;grid-template-columns:1fr 1fr;gap:1rem}
+.site-card{background:#1e293b;border-radius:12px;padding:1.25rem;text-align:center}
+.site-url{font-size:.8rem;color:#64748b;word-break:break-all;margin-bottom:.75rem}
+.site-score{font-size:2.5rem;font-weight:700}
+.site-band{font-size:1rem;font-weight:600;margin-top:.25rem}
+.breakdown{margin-top:1rem}
+.bar-row{display:flex;align-items:center;gap:.5rem;margin:.3rem 0;font-size:.8rem}
+.bar-label{width:80px;text-align:right;color:#94a3b8}
+.bar-bg{flex:1;height:8px;background:#334155;border-radius:4px;overflow:hidden}
+.bar-fill{height:100%;border-radius:4px}
+.bar-val{width:25px;color:#94a3b8;font-size:.75rem}
+.winner{border:2px solid #22c55e}
+.nav{text-align:center;margin-bottom:2rem}
+.nav a{color:#60a5fa;text-decoration:none;margin:0 .75rem;font-size:.9rem}
+.footer{text-align:center;margin-top:2rem;color:#64748b;font-size:.85rem}
+.footer a{color:#60a5fa;text-decoration:none}
+</style>
+</head>
+<body>
+<div class="container">
+    <nav class="nav">
+        <a href="/">← Audit Tool</a>
+        <a href="/roadmap">Roadmap</a>
+        <a href="/research">Research</a>
+        <a href="/compare">Compare</a>
+    </nav>
+
+    <h1>Compare GEO Scores</h1>
+    <p class="subtitle">Side-by-side comparison — see who's more visible to AI.</p>
+
+    <div>
+        <div class="form-row">
+            <input type="url" id="url1" placeholder="https://site-a.com" required>
+        </div>
+        <div class="vs">vs</div>
+        <div class="form-row">
+            <input type="url" id="url2" placeholder="https://site-b.com" required>
+        </div>
+        <button id="btn">Compare</button>
+    </div>
+
+    <div class="spinner" id="spinner">Analyzing both sites... this may take up to 60 seconds.</div>
+    <div class="error" id="error"></div>
+
+    <div class="results" id="results">
+        <div class="comparison" id="comparison"></div>
+    </div>
+
+    <div class="footer">
+        <p><a href="https://github.com/auriti-labs/geo-optimizer-skill">GitHub</a> · <a href="/docs">API Docs</a> · <a href="https://pypi.org/project/geo-optimizer-skill/">PyPI</a></p>
+    </div>
+</div>
+
+<script__NONCE_ATTR__>
+document.getElementById('btn').addEventListener('click', runCompare);
+document.getElementById('url2').addEventListener('keypress', function(e) {
+    if (e.key === 'Enter') runCompare();
+});
+
+async function runCompare() {
+    const url1 = document.getElementById('url1').value;
+    const url2 = document.getElementById('url2').value;
+    if (!url1 || !url2) return;
+
+    const btn = document.getElementById('btn');
+    const spinner = document.getElementById('spinner');
+    const errorEl = document.getElementById('error');
+    const resultsEl = document.getElementById('results');
+
+    btn.disabled = true;
+    spinner.classList.add('active');
+    errorEl.style.display = 'none';
+    resultsEl.style.display = 'none';
+
+    try {
+        const [res1, res2] = await Promise.all([
+            fetch('/api/audit?url=' + encodeURIComponent(url1)),
+            fetch('/api/audit?url=' + encodeURIComponent(url2))
+        ]);
+        const [data1, data2] = await Promise.all([res1.json(), res2.json()]);
+
+        if (!res1.ok) throw new Error('Site A: ' + (data1.detail || 'Error'));
+        if (!res2.ok) throw new Error('Site B: ' + (data2.detail || 'Error'));
+
+        renderComparison(data1, data2);
+        resultsEl.style.display = 'block';
+    } catch (e) {
+        errorEl.textContent = e.message;
+        errorEl.style.display = 'block';
+    } finally {
+        btn.disabled = false;
+        spinner.classList.remove('active');
+    }
+}
+
+function renderComparison(a, b) {
+    const colors = {excellent:'#22c55e',good:'#06b6d4',foundation:'#eab308',critical:'#ef4444'};
+    const comp = document.getElementById('comparison');
+    comp.textContent = '';
+
+    [a, b].forEach((data, i) => {
+        const isWinner = (i === 0 ? a.score >= b.score : b.score >= a.score) && a.score !== b.score;
+        const card = document.createElement('div');
+        card.className = 'site-card' + (isWinner ? ' winner' : '');
+
+        const color = colors[data.band] || '#888';
+        const url = document.createElement('div');
+        url.className = 'site-url';
+        url.textContent = data.url || (i === 0 ? document.getElementById('url1').value : document.getElementById('url2').value);
+        card.appendChild(url);
+
+        const score = document.createElement('div');
+        score.className = 'site-score';
+        score.style.color = color;
+        score.textContent = data.score + '/100';
+        card.appendChild(score);
+
+        const band = document.createElement('div');
+        band.className = 'site-band';
+        band.style.color = color;
+        band.textContent = data.band ? data.band.toUpperCase() : '';
+        card.appendChild(band);
+
+        const breakdown = document.createElement('div');
+        breakdown.className = 'breakdown';
+        const categories = {robots_txt:'Robots',llms_txt:'llms.txt',schema_jsonld:'Schema',meta_tags:'Meta',content:'Content'};
+        const maxes = {robots_txt:18,llms_txt:18,schema_jsonld:22,meta_tags:14,content:14};
+        for (const [key, label] of Object.entries(categories)) {
+            const c = data.checks ? data.checks[key] : null;
+            const sc = c ? (c.score || 0) : 0;
+            const mx = maxes[key];
+            const pct = Math.min(sc / mx * 100, 100);
+            const row = document.createElement('div');
+            row.className = 'bar-row';
+            row.innerHTML = '<span class="bar-label">' + label + '</span>' +
+                '<div class="bar-bg"><div class="bar-fill" style="width:' + pct + '%;background:' + color + '"></div></div>' +
+                '<span class="bar-val">' + sc + '</span>';
+            breakdown.appendChild(row);
+        }
+        card.appendChild(breakdown);
+        comp.appendChild(card);
+    });
+}
+</script>
+</body>
+</html>

--- a/src/geo_optimizer/web/templates/index.html
+++ b/src/geo_optimizer/web/templates/index.html
@@ -44,6 +44,12 @@ border-bottom:1px solid #334155}
 </head>
 <body>
 <div class="container">
+    <nav style="text-align:center;margin-bottom:1.5rem">
+        <a href="/" style="color:#60a5fa;text-decoration:none;margin:0 .75rem;font-size:.9rem">Audit</a>
+        <a href="/roadmap" style="color:#60a5fa;text-decoration:none;margin:0 .75rem;font-size:.9rem">Roadmap</a>
+        <a href="/research" style="color:#60a5fa;text-decoration:none;margin:0 .75rem;font-size:.9rem">Research</a>
+        <a href="/compare" style="color:#60a5fa;text-decoration:none;margin:0 .75rem;font-size:.9rem">Compare</a>
+    </nav>
     <h1>GEO Optimizer</h1>
     <p class="subtitle">Audit your website's visibility to AI search engines</p>
 

--- a/src/geo_optimizer/web/templates/research.html
+++ b/src/geo_optimizer/web/templates/research.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Research Foundation — GEO Optimizer</title>
+<meta name="description" content="GEO Optimizer is built on peer-reviewed academic research. Princeton KDD 2024, AutoGEO ICLR 2026, and more.">
+<link rel="canonical" href="https://geo-optimizer-web.onrender.com/research">
+<meta property="og:title" content="Research Foundation — GEO Optimizer">
+<meta property="og:description" content="The academic research behind GEO Optimizer's scoring and recommendations.">
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+background:#0f172a;color:#e2e8f0;min-height:100vh;padding:2rem}
+.container{max-width:700px;margin:0 auto}
+h1{font-size:2.2rem;margin-bottom:.5rem;background:linear-gradient(135deg,#60a5fa,#a78bfa);
+-webkit-background-clip:text;-webkit-text-fill-color:transparent;text-align:center}
+.subtitle{color:#94a3b8;margin-bottom:2.5rem;font-size:1.05rem;text-align:center}
+.paper{background:#1e293b;border-radius:12px;padding:1.5rem;margin-bottom:1.5rem}
+.paper h2{font-size:1.15rem;margin-bottom:.5rem;color:#f8fafc}
+.paper .venue{color:#a78bfa;font-size:.85rem;font-weight:600;margin-bottom:.5rem}
+.paper .finding{color:#94a3b8;margin-bottom:.75rem;line-height:1.6}
+.paper .impact{background:#0f172a;padding:.75rem;border-radius:8px;margin-top:.5rem}
+.paper .impact strong{color:#60a5fa}
+.paper a{color:#60a5fa;text-decoration:none;font-size:.9rem}
+.method-grid{display:grid;grid-template-columns:1fr 1fr;gap:.5rem;margin-top:1rem}
+.method{background:#0f172a;padding:.5rem .75rem;border-radius:6px;font-size:.85rem}
+.method .pct{color:#22c55e;font-weight:600}
+.method .neg{color:#ef4444;font-weight:600}
+.nav{text-align:center;margin-bottom:2rem}
+.nav a{color:#60a5fa;text-decoration:none;margin:0 .75rem;font-size:.9rem}
+.footer{text-align:center;margin-top:2rem;color:#64748b;font-size:.85rem}
+.footer a{color:#60a5fa;text-decoration:none}
+.disclaimer{text-align:center;color:#64748b;font-size:.8rem;margin-top:2rem;padding:1rem;background:#1e293b;border-radius:8px}
+</style>
+</head>
+<body>
+<div class="container">
+    <nav class="nav">
+        <a href="/">← Audit Tool</a>
+        <a href="/roadmap">Roadmap</a>
+        <a href="/research">Research</a>
+        <a href="/compare">Compare</a>
+    </nav>
+
+    <h1>Research Foundation</h1>
+    <p class="subtitle">Built on peer-reviewed science, not marketing claims.</p>
+
+    <div class="paper">
+        <h2>GEO: Generative Engine Optimization</h2>
+        <div class="venue">KDD 2024 — Princeton, Georgia Tech, AI2, IIT Delhi</div>
+        <div class="finding">
+            Tested 9 optimization strategies across 10,000 queries on GEO-bench. Validated on Perplexity.ai with 22-37% real-world improvements. The foundational controlled experiment for GEO.
+        </div>
+        <div class="impact">
+            <strong>Key finding:</strong> Adding citations to content increases AI visibility by up to +115%. Statistics add +40%. Keyword stuffing has ~0% effect.
+        </div>
+        <div class="method-grid">
+            <div class="method">Cite Sources <span class="pct">+27-115%</span></div>
+            <div class="method">Quotations <span class="pct">+41%</span></div>
+            <div class="method">Statistics <span class="pct">+33%</span></div>
+            <div class="method">Fluency <span class="pct">+29%</span></div>
+            <div class="method">Technical Terms <span class="pct">+18%</span></div>
+            <div class="method">Authority <span class="pct">+16%</span></div>
+            <div class="method">Readability <span class="pct">+14%</span></div>
+            <div class="method">Unique Words <span class="pct">+7%</span></div>
+            <div class="method">Keyword Stuffing <span class="neg">~0%</span></div>
+        </div>
+        <a href="https://arxiv.org/abs/2311.09735">Read paper →</a>
+    </div>
+
+    <div class="paper">
+        <h2>AutoGEO: Automatic Generative Engine Optimization</h2>
+        <div class="venue">ICLR 2026 — Carnegie Mellon University</div>
+        <div class="finding">
+            Uses frontier LLMs to automatically discover optimization rules, then trains compact models via reinforcement learning. Achieved +50.99% improvement over best Princeton baseline. Introduces GEU (Generative Engine Utility) metric.
+        </div>
+        <div class="impact">
+            <strong>How we use it:</strong> Informs our scoring weight updates and content analysis heuristics. Answer-first structure and passage density checks are based on AutoGEO findings.
+        </div>
+        <a href="https://arxiv.org/abs/2510.11438">Read paper →</a>
+    </div>
+
+    <div class="paper">
+        <h2>C-SEO Bench: Conversational SEO Methods</h2>
+        <div class="venue">2025 — Puerto et al.</div>
+        <div class="finding">
+            Found that most conversational SEO methods are largely ineffective and frequently have negative impact. As adoption increases, gains decrease — revealing a zero-sum competitive dynamic.
+        </div>
+        <div class="impact">
+            <strong>How we use it:</strong> Validates our focus on technical infrastructure optimization over content manipulation. We build white-hat GEO tools.
+        </div>
+        <a href="https://arxiv.org/abs/2506.11097">Read paper →</a>
+    </div>
+
+    <div class="paper">
+        <h2>Schema Markup & AI Citations</h2>
+        <div class="venue">Growth Marshal, February 2026 — Study of 730 pages</div>
+        <div class="finding">
+            Attribute-rich schema markup earns 61.7% citation rate vs 41.6% for generic schema. Generic schema actually underperforms having no schema at all.
+        </div>
+        <div class="impact">
+            <strong>How we use it:</strong> Our schema richness check differentiates between rich and generic schema. Generic schema gets zero bonus points.
+        </div>
+    </div>
+
+    <div class="paper">
+        <h2>AI Citations Report 2026</h2>
+        <div class="venue">OtterlyAI — 1M+ citations analyzed</div>
+        <div class="finding">
+            73% of sites have technical barriers blocking AI crawlers. Reference-grade content receives 3-5x more citations. Reddit is the #1 cited domain across all AI platforms.
+        </div>
+        <div class="impact">
+            <strong>How we use it:</strong> Our robots.txt, CDN, and JS rendering checks address the 73% barrier problem. Content quality analysis targets reference-grade optimization.
+        </div>
+    </div>
+
+    <div class="paper">
+        <h2>AI Mode Citation Factors</h2>
+        <div class="venue">SE Ranking, 2025 — 2.3M pages analyzed</div>
+        <div class="finding">
+            Domain traffic is the #1 predictor (3x), followed by referring domains (2.5x). Flesch-Kincaid Grade 6-8 is the readability sweet spot. Sections of 100-150 words between headings are optimal. FAQ schema markup has zero impact — only real FAQ content in the body matters.
+        </div>
+        <div class="impact">
+            <strong>How we use it:</strong> Informs our readability, passage density, FAQ-in-content, and content structure checks.
+        </div>
+    </div>
+
+    <div class="disclaimer">
+        GEO Optimizer focuses on <strong>infrastructure optimization</strong> (robots.txt, llms.txt, schema, meta tags, content structure) — not content manipulation. The adversarial research (ETH Zurich, Harvard, UC Berkeley) shows that manipulative techniques degrade the ecosystem. We build tools for white-hat GEO.
+    </div>
+
+    <div class="footer">
+        <p><a href="https://github.com/auriti-labs/geo-optimizer-skill">GitHub</a> · <a href="/docs">API Docs</a> · <a href="https://pypi.org/project/geo-optimizer-skill/">PyPI</a></p>
+    </div>
+</div>
+</body>
+</html>

--- a/src/geo_optimizer/web/templates/roadmap.html
+++ b/src/geo_optimizer/web/templates/roadmap.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Roadmap — GEO Optimizer</title>
+<meta name="description" content="GEO Optimizer roadmap: what we're building now, what's next, and what we're exploring. Open-source AI search visibility toolkit.">
+<link rel="canonical" href="https://geo-optimizer-web.onrender.com/roadmap">
+<meta property="og:title" content="Roadmap — GEO Optimizer">
+<meta property="og:description" content="See what's coming next for GEO Optimizer — the open-source AI search visibility toolkit.">
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+background:#0f172a;color:#e2e8f0;min-height:100vh;padding:2rem}
+.container{max-width:700px;margin:0 auto}
+h1{font-size:2.2rem;margin-bottom:.5rem;background:linear-gradient(135deg,#60a5fa,#a78bfa);
+-webkit-background-clip:text;-webkit-text-fill-color:transparent;text-align:center}
+.subtitle{color:#94a3b8;margin-bottom:2.5rem;font-size:1.05rem;text-align:center}
+.phase{background:#1e293b;border-radius:12px;padding:1.5rem;margin-bottom:1.5rem;border-left:4px solid}
+.phase-now{border-color:#22c55e}
+.phase-next{border-color:#3b82f6}
+.phase-later{border-color:#6b7280}
+.phase h2{font-size:1.3rem;margin-bottom:.75rem;display:flex;align-items:center;gap:.5rem}
+.phase ul{list-style:none;padding:0}
+.phase li{padding:.4rem 0;color:#cbd5e1;padding-left:1.2rem;position:relative}
+.phase li::before{content:"→";position:absolute;left:0;color:#64748b}
+.badge-now{background:#22c55e;color:#000;padding:.15rem .5rem;border-radius:4px;font-size:.75rem;font-weight:600}
+.badge-next{background:#3b82f6;color:#fff;padding:.15rem .5rem;border-radius:4px;font-size:.75rem;font-weight:600}
+.badge-later{background:#6b7280;color:#fff;padding:.15rem .5rem;border-radius:4px;font-size:.75rem;font-weight:600}
+.nav{text-align:center;margin-bottom:2rem}
+.nav a{color:#60a5fa;text-decoration:none;margin:0 .75rem;font-size:.9rem}
+.footer{text-align:center;margin-top:2rem;color:#64748b;font-size:.85rem}
+.footer a{color:#60a5fa;text-decoration:none}
+.note{text-align:center;color:#64748b;font-size:.85rem;margin-top:1.5rem;font-style:italic}
+</style>
+</head>
+<body>
+<div class="container">
+    <nav class="nav">
+        <a href="/">← Audit Tool</a>
+        <a href="/roadmap">Roadmap</a>
+        <a href="/research">Research</a>
+        <a href="/compare">Compare</a>
+    </nav>
+
+    <h1>Roadmap</h1>
+    <p class="subtitle">Where GEO Optimizer is heading. No dates — just direction.</p>
+
+    <div class="phase phase-now">
+        <h2><span class="badge-now">NOW</span> In Development</h2>
+        <ul>
+            <li>Content quality analysis — readability, passage density, quotability</li>
+            <li>E-commerce GEO profile — Product schema, pricing, reviews</li>
+            <li>PDF report generation for stakeholders</li>
+            <li>llms.txt v2 validation</li>
+            <li>Blog structure optimization for AI citations</li>
+            <li>Image alt text quality check</li>
+            <li>Content freshness warnings</li>
+        </ul>
+    </div>
+
+    <div class="phase phase-next">
+        <h2><span class="badge-next">NEXT</span> Planned</h2>
+        <ul>
+            <li>AI Visibility Checker — are you being cited by ChatGPT, Perplexity, Claude?</li>
+            <li>Server log analysis for AI crawler activity</li>
+            <li>Visual audit results with radar charts</li>
+            <li>Compare mode — side-by-side GEO audits</li>
+            <li>CDN and JavaScript rendering checks</li>
+            <li>Multi-platform citation profiles</li>
+            <li>REST API for integrations</li>
+            <li>Scheduled monitoring with trend tracking</li>
+        </ul>
+    </div>
+
+    <div class="phase phase-later">
+        <h2><span class="badge-later">LATER</span> Exploring</h2>
+        <ul>
+            <li>WordPress plugin with dashboard</li>
+            <li>WebMCP agent-readiness audit</li>
+            <li>Topical cluster architecture analysis</li>
+            <li>Trust Stack — 5-layer trust signal aggregation</li>
+            <li>Prompt injection detection (GEO security)</li>
+            <li>ChatGPT Shopping feed readiness</li>
+            <li>Voice search optimization check</li>
+        </ul>
+    </div>
+
+    <p class="note">Want to influence the roadmap? <a href="https://github.com/Auriti-Labs/geo-optimizer-skill/issues">Open an issue</a> or <a href="https://github.com/Auriti-Labs/geo-optimizer-skill/discussions">start a discussion</a>.</p>
+
+    <div class="footer">
+        <p><a href="https://github.com/auriti-labs/geo-optimizer-skill">GitHub</a> · <a href="/docs">API Docs</a> · <a href="https://pypi.org/project/geo-optimizer-skill/">PyPI</a></p>
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
3 nuove pagine per la web demo:

- `/roadmap` — Now/Next/Later senza date
- `/research` — paper accademici con finding e impatto sul tool  
- `/compare` — confronto GEO score side-by-side con barre breakdown

Nav bar su tutte le pagine. Meta SEO completi. CSP nonce supportato.