### PR TITLE
docs: aggiornamento completo + documentazione online

### DIFF
--- a/docs/geo-fix.md
+++ b/docs/geo-fix.md
@@ -1,0 +1,103 @@
+# geo fix Command
+
+`geo fix` audits a URL and generates all missing files in one shot: robots.txt patches, llms.txt, JSON-LD schemas, meta tag recommendations, and AI discovery templates.
+
+---
+
+## Usage
+
+```bash
+# Preview what would be generated (dry-run, default)
+geo fix --url https://yoursite.com
+
+# Write fix files to disk
+geo fix --url https://yoursite.com --apply
+
+# Target only specific categories
+geo fix --url https://yoursite.com --only robots,llms
+geo fix --url https://yoursite.com --only schema,meta
+```
+
+---
+
+## What It Generates
+
+| Category | File | Description |
+|----------|------|-------------|
+| **robots** | `robots.txt` | Patch adding missing AI bot entries |
+| **llms** | `llms.txt` | Structured AI index from sitemap |
+| **schema** | `schema-*.json` | WebSite, Organization, FAQPage as needed |
+| **meta** | `meta-tags.html` | Description, canonical, Open Graph snippets |
+| **ai-discovery** | `ai/summary.json` | Site summary for AI systems |
+| **ai-discovery** | `ai/faq.json` | Structured FAQ for AI |
+
+---
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--url` | (required) | URL of the site to fix |
+| `--apply` | `false` | Write files to disk (default is dry-run preview) |
+| `--only` | all | Comma-separated categories: `robots,llms,schema,meta` |
+| `--output-dir` | `.` | Directory to write fix files |
+
+---
+
+## Example Output (Dry-Run)
+
+```
+🛠️ GEO Fix Plan — https://yoursite.com
+Score before: 52/100
+
+📄 robots.txt patch (append to existing):
+   User-agent: GPTBot
+   Allow: /
+   User-agent: ClaudeBot
+   Allow: /
+   User-agent: PerplexityBot
+   Allow: /
+
+📄 llms.txt (new file):
+   # Your Site Name
+   > Brief description of your site
+   ## Main Pages
+   - [Home](https://yoursite.com): Main page
+   - [Blog](https://yoursite.com/blog): Articles
+   ...
+
+📄 schema-website.json:
+   {"@context": "https://schema.org", "@type": "WebSite", ...}
+
+📄 meta-tags.html:
+   <meta name="description" content="...">
+   <link rel="canonical" href="...">
+
+📄 ai/summary.json:
+   {"name": "Your Site", "description": "...", "url": "..."}
+
+Estimated score after fixes: 85/100 (+33 points)
+
+Use --apply to write these files to disk.
+```
+
+---
+
+## Using with MCP
+
+The `geo_fix` MCP tool provides the same functionality:
+
+```
+"Fix my site's GEO issues" → calls geo_fix tool
+```
+
+Returns the complete fix plan as JSON, which AI assistants can then help you implement.
+
+---
+
+## Tips
+
+- **Always preview first** — run without `--apply` to review what will be generated
+- **Combine with audit** — run `geo audit` first to understand the full picture
+- **Iterate** — fix one category at a time with `--only` if you prefer incremental changes
+- **Version control** — commit existing files before running `--apply`

--- a/docs/geo-methods.md
+++ b/docs/geo-methods.md
@@ -1,6 +1,8 @@
-# The 9 Princeton GEO Methods
+# The 11 GEO Methods
 
-Research-backed content optimization techniques for AI citation visibility, from the Princeton KDD 2024 study.
+Research-backed content optimization techniques for AI citation visibility.
+
+> **Methods 1–9** from the Princeton KDD 2024 study (Aggarwal et al.). **Methods 10–11** informed by AutoGEO ICLR 2026 and Stanford 2025 research.
 
 ---
 
@@ -187,6 +189,58 @@ Instead: use Fluency Optimization + Cite Sources + Statistics.
 
 ---
 
+## Method 10 — Answer-First Structure
+
+**Measured impact: +25% AI visibility** (AutoGEO, ICLR 2026)
+
+Place the key conclusion or answer in the first 150 characters after every H2 heading. AI engines extract content from the opening of each section to build answers — if your conclusion is buried in the third paragraph, it may never be surfaced.
+
+**Apply when:** Writing any informational or how-to content. Especially effective for query-driven pages (FAQ, guides, tutorials).
+
+```diff
+- ## How to Choose a Mortgage Rate
+- There are many factors to consider when choosing a mortgage.
+- First, you need to understand how rates work. Banks set rates
+- based on central bank policy. After analyzing your situation...
+- The best choice for most buyers is a fixed rate below 5%.
+
++ ## How to Choose a Mortgage Rate
++ A fixed rate below 5% is the best choice for most buyers.
++ Banks set rates based on central bank policy, and understanding
++ how this works helps you negotiate better terms.
+```
+
+Structure: **Answer → Context → Detail**. The first sentence after each H2 should be extractable as a standalone answer. Think of it as the "TL;DR" for that section.
+
+---
+
+## Method 11 — Passage Density
+
+**Measured impact: +23% AI visibility** (Stanford, 2025)
+
+Write paragraphs of 50–150 words, each containing at least one concrete data point (number, date, measurement, percentage). AI retrieval systems chunk content into passages — dense, self-contained paragraphs are more likely to be selected and cited than long, sprawling blocks of text.
+
+**Apply when:** Reviewing any page with paragraphs over 200 words or paragraphs that lack specific data.
+
+```diff
+- WordPress powers a lot of websites. It's a popular CMS that
+- many people use for their blogs and business sites. The platform
+- has been around for a long time and continues to grow. Many
+- developers build plugins and themes for it, making it versatile
+- for different use cases. Companies of all sizes rely on it.
+
++ WordPress powers 43.1% of all websites globally (W3Techs, 2025),
++ serving over 835 million sites. The platform processes 70 million
++ new posts per month and supports 55,000+ plugins in its official
++ directory. Enterprise adopters include Time, TechCrunch, and the
++ White House — sites handling 50M+ monthly pageviews on WordPress
++ infrastructure.
+```
+
+Each paragraph should pass the "citation test": could an AI engine quote this paragraph as a standalone answer? If not, add a concrete fact or split it.
+
+---
+
 ## Implementation Strategy
 
 ### Phase 1 — Quick Wins (Days 1–3)
@@ -219,6 +273,8 @@ Focus on the two highest-ROI methods first.
 | Quotation Addition | ⭐⭐⭐ | ⭐⭐⭐ | ⭐⭐ | ⭐⭐⭐ | ⭐ |
 | Authoritative Tone | ⭐⭐⭐ | ⭐⭐⭐ | ⭐⭐ | ⭐⭐ | ⭐ |
 | Fluency Optimization | ⭐⭐ | ⭐⭐ | ⭐⭐ | ⭐⭐ | ⭐⭐⭐ |
+| Answer-First Structure | ⭐⭐⭐ | ⭐⭐⭐ | ⭐⭐⭐ | ⭐⭐ | ⭐⭐⭐ |
+| Passage Density | ⭐⭐⭐ | ⭐⭐⭐ | ⭐⭐⭐ | ⭐⭐ | ⭐⭐ |
 | Easy-to-Understand | ⭐⭐ | ⭐⭐⭐ | ⭐ | ⭐ | ⭐⭐⭐ |
 | Technical Terms | ⭐⭐⭐ | ⭐⭐ | ⭐⭐⭐ | ⭐ | ⭐ |
 | Unique Words | ⭐ | ⭐ | ⭐⭐ | ⭐⭐ | ⭐⭐ |

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,8 +14,12 @@ This documentation covers every tool and concept in the toolkit. → [README](..
 | [Generating llms.txt](llms-txt.md) | Auto-generate `/llms.txt` from your sitemap for AI crawlers |
 | [Schema Injector](schema-injector.md) | Generate and inject JSON-LD structured data into your pages |
 | [Using SKILL.md as AI Context](ai-context.md) | Use the toolkit with Claude, ChatGPT, Gemini, Cursor, Windsurf |
-| [The 9 Princeton GEO Methods](geo-methods.md) | Research-backed content optimization methods from KDD 2024 |
-| [AI Bots Reference](ai-bots-reference.md) | Complete list of AI crawlers and `robots.txt` configuration |
+| [The 11 GEO Methods](geo-methods.md) | Research-backed content optimization methods (KDD 2024 + ICLR 2026) |
+| [AI Bots Reference](ai-bots-reference.md) | Complete list of 24 AI crawlers and `robots.txt` configuration |
+| [Scoring Rubric](scoring-rubric.md) | How the GEO Score (0–100) is computed across 7 categories |
+| [geo fix Command](geo-fix.md) | Automatic fix generation — robots.txt, llms.txt, schema, meta |
+| [MCP Server](mcp-server.md) | Use GEO Optimizer as an MCP server in Claude Code, Cursor, etc. |
+| [CI/CD Integration](ci-cd.md) | Run GEO audits in GitHub Actions, GitLab CI, and other pipelines |
 | [Troubleshooting](troubleshooting.md) | Solutions to 10 common installation and runtime problems |
 
 ---

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -1,0 +1,315 @@
+# MCP Server
+
+GEO Optimizer exposes its core functionality as an [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server, making all tools available inside AI coding assistants like Claude Code, Cursor, and Windsurf.
+
+---
+
+## Installation
+
+Install with the `mcp` extra:
+
+```bash
+pip install geo-optimizer-skill[mcp]
+```
+
+This installs the `geo-mcp` entry point alongside the `mcp` Python SDK.
+
+---
+
+## Setup
+
+### Claude Code
+
+```bash
+claude mcp add geo-optimizer -- geo-mcp
+```
+
+That's it. The tools are immediately available in your Claude Code session.
+
+### Cursor
+
+Add to your `.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "geo-optimizer": {
+      "command": "geo-mcp",
+      "args": []
+    }
+  }
+}
+```
+
+### Windsurf / Generic MCP Client
+
+Any MCP client that supports stdio transport can connect:
+
+```bash
+geo-mcp
+```
+
+The server runs on stdio transport by default. No port configuration needed.
+
+### Direct Python Invocation
+
+```bash
+python -m geo_optimizer.mcp.server
+```
+
+---
+
+## Tools (8)
+
+### 1. `geo_audit`
+
+Run a complete GEO audit on a website. Analyzes 7 areas: robots.txt, llms.txt, JSON-LD schema, SEO meta tags, content quality, signals, and AI discovery. Returns a score 0–100 with detailed breakdown and recommendations.
+
+| Argument | Type | Required | Description |
+|----------|------|----------|-------------|
+| `url` | string | yes | URL of the site to audit |
+
+**Example output (abbreviated):**
+
+```json
+{
+  "url": "https://example.com",
+  "score": 72,
+  "band": "good",
+  "score_breakdown": {
+    "robots": 18,
+    "llms": 6,
+    "schema": 16,
+    "meta": 14,
+    "content": 10,
+    "signals": 5,
+    "ai_discovery": 3
+  },
+  "recommendations": [
+    "Add llms-full.txt for comprehensive AI indexing",
+    "Add FAQPage schema for better AI extraction"
+  ]
+}
+```
+
+### 2. `geo_fix`
+
+Generate automatic GEO fixes for a website. Audits the site and produces corrective artifacts: robots.txt patches, llms.txt content, missing JSON-LD schemas, and HTML meta tag snippets.
+
+| Argument | Type | Required | Description |
+|----------|------|----------|-------------|
+| `url` | string | yes | URL of the site to optimize |
+| `only` | string | no | Filter categories (comma-separated): `robots`, `llms`, `schema`, `meta`. Empty = all |
+
+**Example output (abbreviated):**
+
+```json
+{
+  "fixes": [
+    {
+      "category": "robots",
+      "description": "Create robots.txt with access for all 24 AI bots",
+      "file_name": "robots.txt",
+      "action": "create"
+    },
+    {
+      "category": "llms",
+      "description": "Generate llms.txt from sitemap (42 URLs)",
+      "file_name": "llms.txt",
+      "action": "create"
+    }
+  ],
+  "score_before": 34,
+  "score_estimated_after": 78
+}
+```
+
+### 3. `geo_llms_generate`
+
+Generate complete llms.txt content for a website. Discovers the sitemap, categorizes URLs by content type, and produces a structured markdown file following the [llmstxt.org](https://llmstxt.org) specification.
+
+| Argument | Type | Required | Description |
+|----------|------|----------|-------------|
+| `url` | string | yes | Base URL of the site |
+
+**Example output:**
+
+```markdown
+# Example Site
+
+> A brief description of the site for AI search engines.
+
+## Documentation
+
+- [Getting Started](https://example.com/docs/getting-started)
+- [API Reference](https://example.com/docs/api)
+
+## Blog & Articles
+
+- [How We Built X](https://example.com/blog/how-we-built-x)
+```
+
+### 4. `geo_citability`
+
+Analyze content citability using the 11 GEO methods (Princeton KDD 2024 + AutoGEO ICLR 2026). Evaluates the page content and returns a citability score 0–100 with per-method breakdown.
+
+| Argument | Type | Required | Description |
+|----------|------|----------|-------------|
+| `url` | string | yes | URL of the page to analyze |
+
+**Example output (abbreviated):**
+
+```json
+{
+  "url": "https://example.com/blog/post",
+  "score": 65,
+  "methods": {
+    "quotation_addition": { "score": 8, "max": 10 },
+    "statistics_addition": { "score": 10, "max": 12 },
+    "fluency_optimization": { "score": 9, "max": 12 },
+    "cite_sources": { "score": 6, "max": 10 },
+    "answer_first": { "score": 7, "max": 10 },
+    "passage_density": { "score": 5, "max": 10 }
+  },
+  "suggestions": [
+    "Add 2-3 direct quotes from domain experts",
+    "Add inline citations to authoritative sources"
+  ]
+}
+```
+
+### 5. `geo_schema_validate`
+
+Validate a JSON-LD schema against schema.org requirements. Checks that all required fields are present for the given schema type.
+
+| Argument | Type | Required | Description |
+|----------|------|----------|-------------|
+| `json_string` | string | yes | JSON-LD string to validate (max 512 KB) |
+| `schema_type` | string | no | Schema type (e.g. `website`, `faqpage`). Auto-detected if empty |
+
+**Example output:**
+
+```json
+{
+  "valid": true,
+  "error": null,
+  "schema_type": "website"
+}
+```
+
+### 6. `geo_compare`
+
+Compare GEO scores across multiple websites (max 5). Returns a ranked comparison with score, band, and per-category breakdown.
+
+| Argument | Type | Required | Description |
+|----------|------|----------|-------------|
+| `urls` | string | yes | Comma-separated URLs (e.g. `"site1.com, site2.com"`) |
+
+**Example output:**
+
+```json
+{
+  "comparison": [
+    { "url": "https://site1.com", "score": 82, "band": "good" },
+    { "url": "https://site2.com", "score": 45, "band": "foundation" }
+  ],
+  "total_sites": 2
+}
+```
+
+### 7. `geo_ai_discovery`
+
+Check AI discovery endpoints on a website. Verifies the presence of `/.well-known/ai.txt`, `/ai/summary.json`, `/ai/faq.json`, and `/ai/service.json` based on the [geo-checklist.dev](https://geo-checklist.dev) emerging standard.
+
+| Argument | Type | Required | Description |
+|----------|------|----------|-------------|
+| `url` | string | yes | URL to check |
+
+**Example output:**
+
+```json
+{
+  "well_known_ai_txt": true,
+  "ai_summary_json": true,
+  "ai_faq_json": false,
+  "ai_service_json": false,
+  "score": 4,
+  "max_score": 6
+}
+```
+
+### 8. `geo_check_bots`
+
+Check which AI bots can access a website via robots.txt. Returns per-bot status (allowed/blocked/missing) with 3-tier classification (training/search/user) and citation bot verification.
+
+| Argument | Type | Required | Description |
+|----------|------|----------|-------------|
+| `url` | string | yes | URL to check |
+
+**Example output (abbreviated):**
+
+```json
+{
+  "url": "https://example.com",
+  "robots_found": true,
+  "citation_bots_ok": true,
+  "bots": {
+    "OAI-SearchBot": { "description": "OpenAI (ChatGPT search citations)", "status": "allowed", "tier": "search" },
+    "ClaudeBot": { "description": "Anthropic (Claude citations)", "status": "allowed", "tier": "search" },
+    "GPTBot": { "description": "OpenAI (ChatGPT training)", "status": "blocked", "tier": "training" }
+  },
+  "summary": { "allowed": 20, "blocked": 2, "missing": 2 }
+}
+```
+
+---
+
+## Resources (5)
+
+MCP resources provide read-only reference data. Access them via the `geo://` URI scheme.
+
+| URI | Description |
+|-----|-------------|
+| `geo://ai-bots` | List of all 24 tracked AI bots with 3-tier classification (training/search/user) and citation bot identification |
+| `geo://score-bands` | GEO score band definitions (critical, foundation, good, excellent) with ranges |
+| `geo://methods` | The 11 citability methods with measured impact data and max scores |
+| `geo://changelog` | Latest changes from CHANGELOG.md (first 50 lines) |
+| `geo://ai-discovery-spec` | AI discovery endpoint specification (geo-checklist.dev standard) with required fields and JSON schemas |
+
+---
+
+## Usage Examples
+
+### Claude Code — Full Site Audit
+
+```
+> Use geo_audit to check https://mysite.com and tell me what to fix first.
+```
+
+Claude will call the `geo_audit` tool, parse the results, and give you prioritized recommendations in natural language.
+
+### Claude Code — Generate and Validate Schema
+
+```
+> Generate a WebSite JSON-LD schema for mysite.com, then validate it with geo_schema_validate.
+```
+
+### Cursor — Compare Competitors
+
+```
+> Use geo_compare to compare mysite.com against competitor1.com and competitor2.com.
+> Show me where I'm losing points.
+```
+
+### Fix Workflow
+
+```
+> Run geo_fix on https://mysite.com with only=robots,llms.
+> Show me the generated files.
+```
+
+---
+
+## Security
+
+All URL inputs are validated against SSRF attacks before making any HTTP requests. Private IPs, localhost, and internal network addresses are rejected. HTTP response size is capped at 10 MB.

--- a/docs/scoring-rubric.md
+++ b/docs/scoring-rubric.md
@@ -1,6 +1,6 @@
 # GEO Scoring Rubric
 
-This document explains how the GEO Score (0–100) is computed. Based on the Princeton KDD 2024 research paper on Generative Engine Optimization.
+How the GEO Score (0–100) is computed. Based on the Princeton KDD 2024 research on Generative Engine Optimization, extended with AutoGEO ICLR 2026 and geo-checklist.dev signals.
 
 ---
 
@@ -8,60 +8,94 @@ This document explains how the GEO Score (0–100) is computed. Based on the Pri
 
 | Band | Range | Meaning |
 |------|-------|---------|
-| **Critical** | 0–40 | AI engines cannot reliably cite you |
-| **Foundation** | 41–70 | Partially visible — key signals missing |
-| **Good** | 71–90 | Well-optimized, AI-accessible |
-| **Excellent** | 91–100 | Fully optimized for GEO |
+| **Excellent** | 86–100 | Fully optimized for AI citation engines |
+| **Good** | 68–85 | Well-optimized, minor gaps remain |
+| **Foundation** | 36–67 | Partially visible — key signals missing |
+| **Critical** | 0–35 | AI engines cannot reliably discover or cite you |
 
 ---
 
-## Categories and Weights (v3.0)
+## Categories and Weights (v3.14)
 
-The total score is the sum of all points earned across 5 categories, capped at 100.
+The total score is the sum of all points earned across **7 categories**, capped at 100.
 
-### 1. robots.txt — max 20 pts
+### 1. robots.txt — max 18 pts
 
 | Signal | Points | Condition |
 |--------|--------|-----------|
 | `robots_found` | 5 | File exists and is reachable |
-| `robots_citation_ok` | 15 | All 3 citation bots allowed (OAI-SearchBot, ClaudeBot, PerplexityBot) |
-| `robots_some_allowed` | 8 | At least some AI bots allowed (partial credit, not cumulative with citation_ok) |
+| `robots_citation_ok` | 13 | All 4 citation bots allowed (OAI-SearchBot, ClaudeBot, Claude-SearchBot, PerplexityBot) |
+| `robots_some_allowed` | 10 | At least some AI bots allowed (partial credit — **not cumulative** with `citation_ok`) |
 
-> **Citation bots** are the most critical: OAI-SearchBot, ClaudeBot, PerplexityBot drive real-time citations in ChatGPT, Claude, and Perplexity.
+> **Citation bots** are the most critical: OAI-SearchBot, ClaudeBot, Claude-SearchBot, and PerplexityBot drive real-time citations in ChatGPT, Claude, and Perplexity. The `robots_some_allowed` score is awarded only when citation bots are not fully covered — it acts as partial credit for sites that allow some AI bots via wildcard rules.
 
-### 2. llms.txt — max 20 pts
-
-| Signal | Points | Condition |
-|--------|--------|-----------|
-| `llms_found` | 10 | `/llms.txt` exists at site root |
-| `llms_h1` | 3 | File has a top-level H1 heading |
-| `llms_sections` | 4 | File has H2 content sections |
-| `llms_links` | 3 | File contains at least one URL link |
-
-### 3. Schema JSON-LD — max 25 pts
+### 2. llms.txt — max 18 pts
 
 | Signal | Points | Condition |
 |--------|--------|-----------|
-| `schema_website` | 10 | `WebSite` schema present in page `<head>` |
-| `schema_faq` | 10 | `FAQPage` schema present |
-| `schema_webapp` | 5 | `WebApplication` schema present |
+| `llms_found` | 6 | `/llms.txt` exists at site root |
+| `llms_h1` | 2 | File has a top-level H1 heading |
+| `llms_sections` | 2 | File has H2 content sections |
+| `llms_links` | 2 | File contains at least one URL link |
+| `llms_depth` | 2 | Word count ≥ 1,000 (substantial index) |
+| `llms_depth_high` | 2 | Word count ≥ 5,000 (comprehensive index) |
+| `llms_full` | 2 | `llms-full.txt` also exists at site root |
 
-### 4. Meta Tags — max 20 pts
+> Quality is now graduated: a minimal llms.txt scores 6 pts, but a deep, well-structured file with a companion `llms-full.txt` can earn all 18.
+
+### 3. Schema JSON-LD — max 22 pts
+
+| Signal | Points | Condition |
+|--------|--------|-----------|
+| `schema_any_valid` | 2 | Any valid JSON-LD schema found in the page |
+| `schema_richness` | 3 | Schema contains 5+ relevant attributes (Growth Marshal 2026) |
+| `schema_faq` | 5 | `FAQPage` schema present |
+| `schema_article` | 3 | `Article` or `BlogPosting` schema present |
+| `schema_organization` | 3 | `Organization` schema present |
+| `schema_website` | 3 | `WebSite` schema present |
+| `schema_sameas` | 3 | `sameAs` links to authoritative domains (Wikipedia, Wikidata, LinkedIn, etc.) |
+
+> The `schema_sameas` signal rewards knowledge graph connections. Authoritative domains: wikipedia.org, wikidata.org, linkedin.com, crunchbase.com, github.com, twitter.com/x.com, facebook.com.
+
+### 4. Meta Tags — max 14 pts
 
 | Signal | Points | Condition |
 |--------|--------|-----------|
 | `meta_title` | 5 | `<title>` tag present and non-empty |
-| `meta_description` | 8 | `<meta name="description">` present |
+| `meta_description` | 2 | `<meta name="description">` present |
 | `meta_canonical` | 3 | `<link rel="canonical">` present |
 | `meta_og` | 4 | Open Graph tags present (`og:title`, `og:description`) |
 
-### 5. Content Quality — max 15 pts
+### 5. Content Quality — max 14 pts
 
 | Signal | Points | Condition |
 |--------|--------|-----------|
-| `content_h1` | 4 | Page has at least one `<h1>` heading |
-| `content_numbers` | 6 | Page contains statistics (numbers, percentages) |
-| `content_links` | 5 | Page contains external citation links |
+| `content_h1` | 2 | Page has at least one `<h1>` heading |
+| `content_numbers` | 2 | Page contains statistics (numbers, percentages) |
+| `content_links` | 2 | Page contains external citation links |
+| `content_word_count` | 2 | Page has ≥ 300 words of substantive content |
+| `content_heading_hierarchy` | 2 | Has H2 + H3 headings in correct hierarchy |
+| `content_lists_or_tables` | 2 | Contains `<ul>`, `<ol>`, or `<table>` elements |
+| `content_front_loading` | 2 | Key information appears in the first 30% of the content |
+
+### 6. Signals — max 8 pts (new)
+
+| Signal | Points | Condition |
+|--------|--------|-----------|
+| `signals_lang` | 3 | `<html lang="...">` attribute is set |
+| `signals_rss` | 3 | RSS or Atom feed is discoverable |
+| `signals_freshness` | 2 | `dateModified` in schema or `Last-Modified` HTTP header present |
+
+### 7. AI Discovery — max 6 pts (new)
+
+Based on the [geo-checklist.dev](https://geo-checklist.dev) emerging standard.
+
+| Signal | Points | Condition |
+|--------|--------|-----------|
+| `ai_discovery_well_known` | 2 | `/.well-known/ai.txt` is present |
+| `ai_discovery_summary` | 2 | `/ai/summary.json` is present and valid |
+| `ai_discovery_faq` | 1 | `/ai/faq.json` is present |
+| `ai_discovery_service` | 1 | `/ai/service.json` is present |
 
 ---
 
@@ -69,30 +103,14 @@ The total score is the sum of all points earned across 5 categories, capped at 1
 
 | Category | Max Points |
 |----------|-----------|
-| robots.txt | 20 |
-| llms.txt | 20 |
-| Schema JSON-LD | 25 |
-| Meta Tags | 20 |
-| Content Quality | 15 |
+| robots.txt | 18 |
+| llms.txt | 18 |
+| Schema JSON-LD | 22 |
+| Meta Tags | 14 |
+| Content Quality | 14 |
+| Signals | 8 |
+| AI Discovery | 6 |
 | **Total** | **100** |
-
----
-
-## Princeton GEO Methods ROI
-
-Research-backed methods ranked by citation rate improvement:
-
-| Method | Citation Boost | Priority |
-|--------|---------------|----------|
-| Cite Sources | +115% | High |
-| Statistics & Numbers | +40% | High |
-| Quotations | +40% | High |
-| Fluency Optimization | +17% | Medium |
-| Easy to Understand | +14% | Medium |
-| Keywords | +11% | Low |
-| Authoritative Tone | +9% | Low |
-
-Source: *GEO: Generative Engine Optimization*, Aggarwal et al., Princeton KDD 2024.
 
 ---
 
@@ -100,5 +118,6 @@ Source: *GEO: Generative Engine Optimization*, Aggarwal et al., Princeton KDD 20
 
 | Version | Change |
 |---------|--------|
-| v3.0.0 | `schema_website` aumentato a 10 pts, `meta_description` a 8 pts, `content_numbers` a 6 pts |
-| v1.5.0 | Pesi originali del documento precedente |
+| v3.14 | 7 categories (added Signals + AI Discovery), `schema_richness` + `schema_sameas`, graduated llms.txt scoring, content structure checks, bands adjusted |
+| v3.0.0 | 5 categories, `schema_website` 10 pts, `meta_description` 8 pts |
+| v1.5.0 | Original weights |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ async = [
 web = [
     "fastapi>=0.110.0,<1.0",
     "uvicorn[standard]>=0.27.0,<1.0",
+    "markdown>=3.5.0,<4.0",
 ]
 mcp = [
     "mcp>=1.0.0",

--- a/src/geo_optimizer/web/app.py
+++ b/src/geo_optimizer/web/app.py
@@ -302,6 +302,113 @@ async def research_page():
     return template_path.read_text(encoding="utf-8")
 
 
+# ─── Documentazione online (Markdown → HTML) ─────────────────────────────────
+
+# Mappa slug → titolo per la sidebar e i meta tag
+_DOCS_PAGES = {
+    "index": "Documentation",
+    "getting-started": "Getting Started",
+    "geo-audit": "GEO Audit Script",
+    "geo-fix": "geo fix Command",
+    "llms-txt": "Generating llms.txt",
+    "schema-injector": "Schema Injector",
+    "mcp-server": "MCP Server",
+    "ai-context": "Using as AI Context",
+    "geo-methods": "The 11 GEO Methods",
+    "ai-bots-reference": "AI Bots Reference",
+    "ci-cd": "CI/CD Integration",
+    "scoring-rubric": "Scoring Rubric",
+    "troubleshooting": "Troubleshooting",
+}
+
+
+@app.get("/docs/", response_class=HTMLResponse)
+async def docs_index():
+    """Documentation index — redirect to the main docs page."""
+    return await docs_page("index")
+
+
+@app.get("/docs/{slug}", response_class=HTMLResponse)
+async def docs_page(slug: str):
+    """Render a documentation page from docs/*.md as styled HTML."""
+    import re as _re
+
+    # Validazione slug: solo alfanumerici e trattini (previene path traversal)
+    if not _re.match(r"^[a-z0-9\-]+$", slug):
+        raise HTTPException(status_code=404, detail="Page not found")
+
+    # Cerca il file markdown nella directory docs/
+    docs_dir = Path(__file__).resolve().parent.parent.parent.parent / "docs"
+    md_path = docs_dir / f"{slug}.md"
+
+    if not md_path.exists():
+        raise HTTPException(status_code=404, detail="Page not found")
+
+    # Converti Markdown in HTML
+    md_content = md_path.read_text(encoding="utf-8")
+    html_content = _markdown_to_html(md_content)
+
+    # Costruisci sidebar con link a tutte le pagine
+    sidebar_links = []
+    for page_slug, page_title in _DOCS_PAGES.items():
+        if page_slug == "index":
+            continue
+        active = " active" if page_slug == slug else ""
+        sidebar_links.append(f'<a href="/docs/{page_slug}" class="{active}">{page_title}</a>')
+    sidebar_html = "\n".join(sidebar_links)
+
+    # Titolo e descrizione dalla mappa
+    title = _DOCS_PAGES.get(slug, slug.replace("-", " ").title())
+    description = f"GEO Optimizer documentation: {title}"
+
+    # Carica template e sostituisci placeholder
+    template_path = Path(__file__).parent / "templates" / "docs.html"
+    template = template_path.read_text(encoding="utf-8")
+    html = (
+        template.replace("__TITLE__", title)
+        .replace("__DESCRIPTION__", description)
+        .replace("__SLUG__", slug)
+        .replace("__SIDEBAR__", sidebar_html)
+        .replace("__CONTENT__", html_content)
+    )
+    return html
+
+
+def _markdown_to_html(md: str) -> str:
+    """Converti Markdown in HTML. Usa la libreria markdown se disponibile, altrimenti regex base."""
+    try:
+        import markdown
+
+        return markdown.markdown(
+            md,
+            extensions=["tables", "fenced_code", "toc"],
+            output_format="html",
+        )
+    except ImportError:
+        # Fallback: conversione base con regex
+        import re
+
+        html = md
+        # Headers
+        html = re.sub(r"^### (.+)$", r"<h3>\1</h3>", html, flags=re.MULTILINE)
+        html = re.sub(r"^## (.+)$", r"<h2>\1</h2>", html, flags=re.MULTILINE)
+        html = re.sub(r"^# (.+)$", r"<h1>\1</h1>", html, flags=re.MULTILINE)
+        # Code blocks
+        html = re.sub(r"```(\w*)\n(.*?)```", r"<pre><code>\2</code></pre>", html, flags=re.DOTALL)
+        # Inline code
+        html = re.sub(r"`([^`]+)`", r"<code>\1</code>", html)
+        # Bold
+        html = re.sub(r"\*\*(.+?)\*\*", r"<strong>\1</strong>", html)
+        # Links
+        html = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", r'<a href="\2">\1</a>', html)
+        # Paragraphs
+        html = re.sub(r"\n\n", r"</p><p>", html)
+        html = f"<p>{html}</p>"
+        # Horizontal rules
+        html = re.sub(r"<p>---</p>", "<hr>", html)
+        return html
+
+
 @app.get("/compare", response_class=HTMLResponse)
 async def compare_page(request: Request):
     """Compare GEO scores of two websites side by side."""

--- a/src/geo_optimizer/web/templates/compare.html
+++ b/src/geo_optimizer/web/templates/compare.html
@@ -54,6 +54,7 @@ button:disabled{opacity:.5;cursor:not-allowed}
         <a href="/roadmap">Roadmap</a>
         <a href="/research">Research</a>
         <a href="/compare">Compare</a>
+        <a href="/docs/">Docs</a>
     </nav>
 
     <h1>Compare GEO Scores</h1>

--- a/src/geo_optimizer/web/templates/docs.html
+++ b/src/geo_optimizer/web/templates/docs.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>__TITLE__ — GEO Optimizer Docs</title>
+<meta name="description" content="__DESCRIPTION__">
+<link rel="canonical" href="https://geo-optimizer-web.onrender.com/docs/__SLUG__">
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+background:#0f172a;color:#e2e8f0;min-height:100vh;padding:2rem}
+.container{max-width:750px;margin:0 auto}
+.nav{text-align:center;margin-bottom:2rem}
+.nav a{color:#60a5fa;text-decoration:none;margin:0 .5rem;font-size:.9rem}
+.sidebar{background:#1e293b;border-radius:8px;padding:1rem;margin-bottom:2rem}
+.sidebar a{color:#94a3b8;text-decoration:none;display:block;padding:.3rem .5rem;border-radius:4px;font-size:.85rem}
+.sidebar a:hover,.sidebar a.active{color:#60a5fa;background:#334155}
+.content{line-height:1.8}
+.content h1{font-size:2rem;margin:1.5rem 0 .75rem;background:linear-gradient(135deg,#60a5fa,#a78bfa);
+-webkit-background-clip:text;-webkit-text-fill-color:transparent}
+.content h2{font-size:1.5rem;margin:1.5rem 0 .5rem;color:#f8fafc;border-bottom:1px solid #334155;padding-bottom:.3rem}
+.content h3{font-size:1.2rem;margin:1.25rem 0 .5rem;color:#e2e8f0}
+.content p{margin:.75rem 0;color:#cbd5e1}
+.content a{color:#60a5fa;text-decoration:none}
+.content a:hover{text-decoration:underline}
+.content code{background:#334155;padding:.15rem .4rem;border-radius:4px;font-size:.9rem;color:#e2e8f0}
+.content pre{background:#1e293b;padding:1rem;border-radius:8px;overflow-x:auto;margin:.75rem 0}
+.content pre code{background:none;padding:0}
+.content table{width:100%;border-collapse:collapse;margin:.75rem 0}
+.content th{background:#334155;padding:.5rem .75rem;text-align:left;font-size:.85rem;color:#94a3b8}
+.content td{padding:.5rem .75rem;border-bottom:1px solid #1e293b;font-size:.9rem}
+.content ul,.content ol{margin:.5rem 0 .5rem 1.5rem;color:#cbd5e1}
+.content li{margin:.25rem 0}
+.content blockquote{border-left:3px solid #a78bfa;padding:.5rem 1rem;margin:.75rem 0;background:#1e293b;border-radius:0 8px 8px 0;color:#94a3b8}
+.content hr{border:none;border-top:1px solid #334155;margin:1.5rem 0}
+.content strong{color:#f8fafc}
+.footer{text-align:center;margin-top:3rem;color:#64748b;font-size:.85rem}
+.footer a{color:#60a5fa;text-decoration:none}
+</style>
+</head>
+<body>
+<div class="container">
+    <nav class="nav">
+        <a href="/">← Audit Tool</a>
+        <a href="/roadmap">Roadmap</a>
+        <a href="/research">Research</a>
+        <a href="/compare">Compare</a>
+        <a href="/docs/">Docs</a>
+    </nav>
+
+    <div class="sidebar" id="sidebar">__SIDEBAR__</div>
+
+    <div class="content">__CONTENT__</div>
+
+    <div class="footer">
+        <p><a href="https://github.com/auriti-labs/geo-optimizer-skill">GitHub</a> ·
+           <a href="https://pypi.org/project/geo-optimizer-skill/">PyPI</a> ·
+           <a href="https://github.com/auriti-labs/geo-optimizer-skill/blob/main/docs/__SLUG__.md">Edit on GitHub</a></p>
+    </div>
+</div>
+</body>
+</html>

--- a/src/geo_optimizer/web/templates/index.html
+++ b/src/geo_optimizer/web/templates/index.html
@@ -49,6 +49,7 @@ border-bottom:1px solid #334155}
         <a href="/roadmap" style="color:#60a5fa;text-decoration:none;margin:0 .75rem;font-size:.9rem">Roadmap</a>
         <a href="/research" style="color:#60a5fa;text-decoration:none;margin:0 .75rem;font-size:.9rem">Research</a>
         <a href="/compare" style="color:#60a5fa;text-decoration:none;margin:0 .75rem;font-size:.9rem">Compare</a>
+        <a href="/docs/" style="color:#60a5fa;text-decoration:none;margin:0 .75rem;font-size:.9rem">Docs</a>
     </nav>
     <h1>GEO Optimizer</h1>
     <p class="subtitle">Audit your website's visibility to AI search engines</p>

--- a/src/geo_optimizer/web/templates/research.html
+++ b/src/geo_optimizer/web/templates/research.html
@@ -41,6 +41,7 @@ h1{font-size:2.2rem;margin-bottom:.5rem;background:linear-gradient(135deg,#60a5f
         <a href="/roadmap">Roadmap</a>
         <a href="/research">Research</a>
         <a href="/compare">Compare</a>
+        <a href="/docs/">Docs</a>
     </nav>
 
     <h1>Research Foundation</h1>

--- a/src/geo_optimizer/web/templates/roadmap.html
+++ b/src/geo_optimizer/web/templates/roadmap.html
@@ -41,6 +41,7 @@ h1{font-size:2.2rem;margin-bottom:.5rem;background:linear-gradient(135deg,#60a5f
         <a href="/roadmap">Roadmap</a>
         <a href="/research">Research</a>
         <a href="/compare">Compare</a>
+        <a href="/docs/">Docs</a>
     </nav>
 
     <h1>Roadmap</h1>


### PR DESCRIPTION
### Documentazione aggiornata
- `scoring-rubric.md` — 7 categorie, pesi v3.14
- `geo-methods.md` — 11 metodi (era 9)
- `index.md` — tutti i link

### Nuove pagine
- `mcp-server.md` — 8 tool + 5 resource MCP
- `geo-fix.md` — comando geo fix

### Rendering online
- **`/docs/`** — documentazione navigabile direttamente nel browser
- Sidebar con tutte le pagine
- Markdown → HTML con libreria `markdown`
- Stesso style del resto del sito

710 test passano.