### PR TITLE
fix(web): docs online — includere markdown nel pacchetto per Docker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ where = ["src"]
 
 [tool.setuptools.package-data]
 # Solo i file compilati .mo — i sorgenti .po non appartengono al pacchetto distribuito (#135)
-"geo_optimizer" = ["py.typed", "i18n/locales/*/LC_MESSAGES/*.mo", "web/templates/*.html"]
+"geo_optimizer" = ["py.typed", "i18n/locales/*/LC_MESSAGES/*.mo", "web/templates/*.html", "web/docs/*.md"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/geo_optimizer/web/app.py
+++ b/src/geo_optimizer/web/app.py
@@ -337,9 +337,14 @@ async def docs_page(slug: str):
     if not _re.match(r"^[a-z0-9\-]+$", slug):
         raise HTTPException(status_code=404, detail="Page not found")
 
-    # Cerca il file markdown nella directory docs/
-    docs_dir = Path(__file__).resolve().parent.parent.parent.parent / "docs"
+    # Cerca il file markdown: prima nella directory web/docs/ (pacchetto installato),
+    # poi nella root docs/ del progetto (sviluppo locale)
+    docs_dir = Path(__file__).resolve().parent / "docs"
     md_path = docs_dir / f"{slug}.md"
+    if not md_path.exists():
+        # Fallback: directory docs/ nella root del progetto (per sviluppo locale)
+        docs_dir = Path(__file__).resolve().parent.parent.parent.parent / "docs"
+        md_path = docs_dir / f"{slug}.md"
 
     if not md_path.exists():
         raise HTTPException(status_code=404, detail="Page not found")

--- a/src/geo_optimizer/web/docs/ai-bots-reference.md
+++ b/src/geo_optimizer/web/docs/ai-bots-reference.md
@@ -1,0 +1,276 @@
+# AI Bots Reference
+
+Complete reference for AI crawler user-agents and `robots.txt` configuration strategies.
+
+---
+
+## Citation Bots vs Training Bots
+
+This is the most important distinction in GEO robot configuration.
+
+| Type | What they do | GEO impact | Example |
+|------|-------------|-----------|---------|
+| **Citation bots** | Crawl and index your content for use in AI-generated answers | 🔴 Critical — blocking these = not being cited | `OAI-SearchBot`, `ClaudeBot`, `PerplexityBot` |
+| **Training bots** | Collect data to train AI models (offline process) | ⚠️ Optional — blocking doesn't affect citations | `GPTBot`, `anthropic-ai`, `CCBot` |
+
+**Key insight:** You can block training bots (if you have IP concerns) while still allowing citation bots. Blocking `GPTBot` does not prevent ChatGPT from citing you — `OAI-SearchBot` is the relevant bot for citations.
+
+---
+
+## Complete Bot Table
+
+### 🔴 Critical Citation Bots
+
+These three bots directly determine whether AI search engines cite your site. **Never block them.**
+
+| Bot | Vendor | Type | Purpose | Crawl Frequency |
+|-----|--------|------|---------|----------------|
+| `OAI-SearchBot` | OpenAI | **Citation** | ChatGPT Search index — determines citation eligibility | Daily |
+| `ClaudeBot` | Anthropic | **Citation** | Claude.ai real-time web citations | On-demand + regular crawl |
+| `PerplexityBot` | Perplexity | **Citation** | Perplexity AI citation index | Several times per week |
+
+### OpenAI (ChatGPT)
+
+| Bot | Type | Purpose | Crawl Frequency |
+|-----|------|---------|----------------|
+| `GPTBot` | Training | ChatGPT model training data | Frequent |
+| `OAI-SearchBot` | **Citation** | ChatGPT Search citations | Daily |
+| `ChatGPT-User` | On-demand | Fetched when a ChatGPT user requests a page | As needed |
+
+### Anthropic (Claude)
+
+| Bot | Type | Purpose | Crawl Frequency |
+|-----|------|---------|----------------|
+| `anthropic-ai` | Training | Claude model training | Periodic |
+| `ClaudeBot` | **Citation** | Claude.ai web citations | On-demand + regular |
+| `claude-web` | Crawl | General Claude web crawling | Periodic |
+
+### Perplexity AI
+
+| Bot | Type | Purpose | Crawl Frequency |
+|-----|------|---------|----------------|
+| `PerplexityBot` | **Citation** | Perplexity index and citation source | Several times/week |
+| `Perplexity-User` | On-demand | Fetched when a user clicks a Perplexity citation | As needed |
+
+### Google AI (Gemini)
+
+| Bot | Type | Purpose | Crawl Frequency |
+|-----|------|---------|----------------|
+| `Google-Extended` | Training + AI Overviews | Gemini training and Google AI Overviews | Frequent |
+| `Googlebot` | Search + Citation | Traditional Google Search and AI-assisted results | Very frequent |
+
+Note: `Google-Extended` is a `robots.txt` token, not a separate user-agent. Blocking it removes your site from Google AI Overviews.
+
+### Microsoft (Copilot)
+
+| Bot | Type | Purpose | Crawl Frequency |
+|-----|------|---------|----------------|
+| `Bingbot` | Search + Citation | Bing Search index; Copilot uses this index | Frequent |
+
+There is no separate `CopilotBot` — Copilot reads the Bing index, so allowing `Bingbot` = allowing Copilot.
+
+### Apple (Siri)
+
+| Bot | Type | Purpose | Crawl Frequency |
+|-----|------|---------|----------------|
+| `Applebot` | Search | Siri, Spotlight Search, Safari Suggestions | Periodic |
+| `Applebot-Extended` | Training | Apple Intelligence training data | Periodic |
+
+### Meta (Facebook AI)
+
+| Bot | Type | Purpose | Crawl Frequency |
+|-----|------|---------|----------------|
+| `FacebookBot` | Preview | Facebook/Instagram link preview | On-demand |
+| `meta-externalagent` | Backup | Meta backup fetcher | Periodic |
+
+### Other AI Bots
+
+| Bot | Vendor | Type | Purpose |
+|-----|--------|------|---------|
+| `Bytespider` | ByteDance/TikTok | AI + Rec | TikTok recommendations and AI features |
+| `DuckAssistBot` | DuckDuckGo | Citation | DuckAssist AI answers |
+| `cohere-ai` | Cohere | Training | Cohere language model training |
+| `AI2Bot` | Allen Institute | Academic | Semantic Scholar, research AI |
+| `CCBot` | Common Crawl | Training | Open dataset used by many models |
+
+---
+
+## robots.txt — Ready to Copy
+
+Full GEO-optimized `robots.txt` block. Replace `https://yoursite.com/sitemap.xml` with your actual sitemap URL.
+
+```
+# ═══════════════════════════════════════════════
+#   AI SEARCH & CITATION BOTS — Allow All
+#   GEO-Optimized robots.txt
+#   Updated: 2026-02
+# ═══════════════════════════════════════════════
+
+# ——— OpenAI ———
+User-agent: GPTBot
+Allow: /
+User-agent: OAI-SearchBot
+Allow: /
+User-agent: ChatGPT-User
+Allow: /
+
+# ——— Anthropic (Claude) ———
+User-agent: anthropic-ai
+Allow: /
+User-agent: ClaudeBot
+Allow: /
+User-agent: claude-web
+Allow: /
+
+# ——— Perplexity ———
+User-agent: PerplexityBot
+Allow: /
+User-agent: Perplexity-User
+Allow: /
+
+# ——— Google AI (Gemini + AI Overviews) ———
+User-agent: Google-Extended
+Allow: /
+
+# ——— Microsoft (Copilot via Bing) ———
+User-agent: Bingbot
+Allow: /
+
+# ——— Apple (Siri / Apple Intelligence) ———
+User-agent: Applebot
+Allow: /
+User-agent: Applebot-Extended
+Allow: /
+
+# ——— Meta (AI) ———
+User-agent: FacebookBot
+Allow: /
+User-agent: meta-externalagent
+Allow: /
+
+# ——— ByteDance/TikTok ———
+User-agent: Bytespider
+Allow: /
+
+# ——— DuckDuckGo AI ———
+User-agent: DuckAssistBot
+Allow: /
+
+# ——— Cohere ———
+User-agent: cohere-ai
+Allow: /
+
+# ——— Academic / Open ———
+User-agent: AI2Bot
+Allow: /
+User-agent: CCBot
+Allow: /
+
+# ——— Traditional Search (always keep) ———
+User-agent: Googlebot
+Allow: /
+User-agent: *
+Allow: /
+
+Sitemap: https://yoursite.com/sitemap.xml
+```
+
+---
+
+## Strategy: Allow Citations, Block Training
+
+If you want to appear in AI answers but prevent your content from being used as training data:
+
+```
+# ─── Training bots — blocked ──────────────────
+User-agent: GPTBot
+Disallow: /
+
+User-agent: anthropic-ai
+Disallow: /
+
+User-agent: Google-Extended
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
+User-agent: Applebot-Extended
+Disallow: /
+
+# ─── Citation bots — allowed ──────────────────
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Bingbot
+Allow: /
+
+User-agent: Googlebot
+Allow: /
+
+User-agent: *
+Allow: /
+
+Sitemap: https://yoursite.com/sitemap.xml
+```
+
+Note: `robots.txt` is an honor system. Well-behaved bots respect it; scraper bots may not. For actual training data protection, consider additional legal or technical measures.
+
+---
+
+## Verify Bot Access
+
+Simulate a bot's HTTP request to check what your server returns:
+
+```bash
+# Simulate OAI-SearchBot (ChatGPT citations)
+curl -A "OAI-SearchBot/1.0 (+https://openai.com/searchbot)" https://yoursite.com/robots.txt
+
+# Simulate ClaudeBot
+curl -A "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; ClaudeBot/1.0; +claudebot@anthropic.com)" https://yoursite.com
+
+# Simulate PerplexityBot
+curl -A "PerplexityBot/1.0 (+https://perplexity.ai/bot)" https://yoursite.com
+
+# Simulate GPTBot
+curl -A "GPTBot/1.2 (+https://openai.com/gptbot)" https://yoursite.com/robots.txt
+```
+
+If you get a 403 or 401 for citation bots, they can't index your site.
+
+---
+
+## Monitor Bots in Server Logs
+
+Check if AI bots are actively crawling your site:
+
+```bash
+# Search nginx access logs for all major AI bots
+grep -E "GPTBot|OAI-SearchBot|ClaudeBot|PerplexityBot|Google-Extended|anthropic-ai" \
+  /var/log/nginx/access.log
+
+# Count hits per bot (last 7 days)
+grep -oE "GPTBot|OAI-SearchBot|ClaudeBot|PerplexityBot|Google-Extended" \
+  /var/log/nginx/access.log | sort | uniq -c | sort -rn
+
+# Apache equivalent
+grep -E "GPTBot|OAI-SearchBot|ClaudeBot|PerplexityBot" \
+  /var/log/apache2/access.log | awk '{print $1, $7}' | head -50
+```
+
+For managed hosting without log access, check **Google Search Console → Settings → Crawl Stats** — it shows `Googlebot` and `Google-Extended` activity. For other bots, there is no equivalent dashboard; server logs are the only reliable source.
+
+---
+
+## Resources
+
+- OpenAI bot docs: [openai.com/gptbot](https://openai.com/gptbot)
+- Anthropic bot docs: [anthropic.com/legal/aup](https://www.anthropic.com/legal/aup)
+- Perplexity bot docs: [docs.perplexity.ai/guides/perplexity-bot](https://docs.perplexity.ai/guides/perplexity-bot)
+- Google crawlers: [developers.google.com/search/docs/crawling-indexing/google-common-crawlers](https://developers.google.com/search/docs/crawling-indexing/google-common-crawlers)

--- a/src/geo_optimizer/web/docs/ai-context.md
+++ b/src/geo_optimizer/web/docs/ai-context.md
@@ -1,0 +1,235 @@
+# AI Context Files — Platform Guide
+
+GEO Optimizer provides platform-specific context files in the `ai-context/` folder. Each file is optimized for its platform's format and character limits.
+
+> **TL;DR:** See `SKILL.md` for the quick-reference table. This doc has step-by-step setup for each platform.
+
+---
+
+## Claude Projects
+
+**File:** `ai-context/claude-project.md`  
+**Limit:** No practical limit — full context loaded  
+**What you get:** Full workflow, 9 Princeton methods with impact %, all scripts with flags, framework examples (Astro, Next.js, WordPress), GEO checklist, robots.txt block, llms.txt templates, JSON-LD schema examples
+
+### Setup
+
+1. Go to [claude.ai](https://claude.ai) → click **Projects** in the sidebar
+2. Click **+ New Project** (e.g. "GEO Optimizer")
+3. Click **Add content** → **Upload file** → select `ai-context/claude-project.md`
+4. Start a new conversation inside the Project
+
+Claude will have persistent GEO context across every conversation in that Project.
+
+### What to expect
+
+- Immediate, specific advice without needing to re-explain what GEO is
+- Ready-to-paste robots.txt blocks, llms.txt, and schema JSON
+- The AI will start every site analysis with the audit command
+- Framework-specific schema code (Astro, Next.js, WordPress, PHP)
+
+---
+
+## ChatGPT Custom GPT (GPT Builder)
+
+**File:** `ai-context/chatgpt-custom-gpt.md`  
+**Limit:** 8,000 characters for system prompt  
+**File size:** ~4,500 characters — well within limit  
+**Requires:** ChatGPT Plus, Team, or Enterprise (paid plan)
+
+### Setup
+
+1. Go to [chat.openai.com](https://chat.openai.com) → click your avatar → **My GPTs**
+2. Click **Create a GPT** → go to the **Configure** tab
+3. In the **Instructions** field, paste the full contents of `ai-context/chatgpt-custom-gpt.md`
+4. Give the GPT a name (e.g. "GEO Optimizer") and save
+
+### What to expect
+
+- Compressed but complete GEO knowledge: workflow, all 9 methods, schema templates
+- Starts every site query with the audit command
+- Generates ready-to-paste code blocks
+- Slightly less verbose than Claude Projects version (due to space constraints)
+
+> **Note:** Custom GPTs require a paid ChatGPT plan. If you're on the free plan, use Custom Instructions instead.
+
+---
+
+## ChatGPT Custom Instructions
+
+**File:** `ai-context/chatgpt-instructions.md`  
+**Limit:** 1,500 characters per field (2 fields = 3,000 max)  
+**File size:** ~800 characters — fits in a single field  
+**Requires:** Free or paid ChatGPT account
+
+> ⚠️ **Honest limitation:** Custom Instructions have a 1,500 character limit per field. The file covers only the essentials: role, workflow steps, script commands, and top 3 methods. For full context (all 9 methods, schema templates, framework examples), use the Custom GPT file (requires paid plan) or Claude Projects (free with account).
+
+### Setup
+
+1. Go to [chat.openai.com](https://chat.openai.com) → click your avatar → **Customize ChatGPT**
+2. Under **"What would you like ChatGPT to know about you?"** paste the contents of `ai-context/chatgpt-instructions.md`
+3. Save. Active for all new conversations.
+
+### What to expect
+
+- ChatGPT will understand GEO context without re-explaining every time
+- Knows the 3 script commands and top 3 Princeton methods
+- Does NOT have the full 9-method table, schema templates, or framework examples
+- For complex tasks, paste relevant sections from `ai-context/claude-project.md` directly into the chat
+
+---
+
+## Cursor
+
+**File:** `ai-context/cursor.mdc`  
+**Format:** `.mdc` with YAML frontmatter  
+**Limit:** No character limit  
+**Activation:** Rules load when files match the `globs` pattern
+
+### Setup
+
+```bash
+mkdir -p .cursor/rules
+cp ~/geo-optimizer-skill/ai-context/cursor.mdc .cursor/rules/geo-optimizer.mdc
+```
+
+Or copy manually:
+1. In your project root, create `.cursor/rules/` directory
+2. Copy `ai-context/cursor.mdc` → `.cursor/rules/geo-optimizer.mdc`
+3. Cursor loads the rule automatically when you open matching files
+
+The `globs` pattern activates the rule for: `*.html`, `*.astro`, `*.tsx`, `*.jsx`, `*.php`, `robots.txt`, `llms.txt`, `*.json`
+
+### What to expect
+
+- Cursor AI (Cmd+K, Cmd+L, inline chat) will follow GEO rules when editing matching files
+- Imperative "Always/Never" format integrates well with Cursor's rule system
+- Suggests correct schema types for each page type automatically
+- Reminds you to run the audit command before making recommendations
+
+### Frontmatter reference
+
+```yaml
+description: "GEO Optimizer — make websites cited by AI search engines..."
+globs: "**/*.html,**/*.astro,**/*.tsx,..."
+alwaysApply: false  # Only applies when matching files are open
+```
+
+Change `alwaysApply: true` to load the rule in every Cursor session regardless of file type.
+
+---
+
+## Windsurf
+
+**File:** `ai-context/windsurf.md`  
+**Format:** Plain Markdown — NO YAML frontmatter  
+**Limit:** ~12,000 chars (UI activation)  
+**Activation:** Configured via Windsurf UI → Customizations → Rules (4 modes: Always On, Glob, Model Decision, Manual)
+
+> ⚠️ **Windsurf does NOT read YAML frontmatter** from rule files — activation mode is configured in the Windsurf UI, not in this file. If you add YAML frontmatter here, Cascade reads it as literal text.
+
+### Setup
+
+```bash
+mkdir -p .windsurf/rules
+cp ~/geo-optimizer-skill/ai-context/windsurf.md .windsurf/rules/geo-optimizer.md
+```
+
+Or copy manually:
+1. In your project root, create `.windsurf/rules/` directory
+2. Copy `ai-context/windsurf.md` → `.windsurf/rules/geo-optimizer.md`
+3. Open Windsurf → **Customizations** (top-right slider icon) → **Rules**
+4. Find `geo-optimizer.md` in the list and set the activation mode
+
+### Activation modes (Windsurf UI)
+
+| Mode | When to use |
+|------|-------------|
+| **Always On** | Rule is injected into every Cascade AI context — most reliable |
+| **Glob** | Rule activates only when files matching a pattern are open (e.g. `**/*.html`) |
+| **Model Decision** | Cascade decides when the rule is relevant |
+| **Manual** | You manually enable/disable the rule per session |
+
+> ⚠️ **Known Windsurf bug (2025):** complex glob patterns sometimes fail to activate rules. If glob doesn't work, use "Always On" as fallback.
+
+### What to expect
+
+- Same GEO "Always/Never" rules as the Cursor file — same content, UI-managed activation
+- Windsurf Cascade will follow GEO rules when editing HTML/Astro/robots.txt files
+- Activation is controlled via the UI panel, not via frontmatter in the file
+
+---
+
+## Kiro
+
+**File:** `ai-context/kiro-steering.md`  
+**Format:** Markdown with YAML frontmatter  
+**Limit:** No character limit  
+**Activation:** `inclusion: fileMatch` — loads only when matching files are open
+
+### Setup
+
+```bash
+mkdir -p .kiro/steering
+cp ~/geo-optimizer-skill/ai-context/kiro-steering.md .kiro/steering/geo-optimizer.md
+```
+
+Or copy manually:
+1. In your project root, create `.kiro/steering/` directory
+2. Copy `ai-context/kiro-steering.md` → `.kiro/steering/geo-optimizer.md`
+3. Kiro loads the steering file automatically when files matching the pattern are open
+
+### What to expect
+
+- Same rules as Cursor/Windsurf — GEO "Always/Never" rules apply when editing HTML/Astro/robots.txt files
+- `fileMatch` inclusion means the steering doc is only loaded when relevant files are open (efficient)
+- Kiro will suggest correct schema types, remind you to run the audit command, and follow GEO best practices
+
+### Frontmatter reference
+
+```yaml
+---
+inclusion: fileMatch
+fileMatchPattern:
+  - "**/*.html"
+  - "**/*.astro"
+  - "**/*.tsx"
+  - "**/*.jsx"
+  - "**/*.php"
+  - "**/robots.txt"
+  - "**/llms.txt"
+  - "**/*.json"
+---
+```
+
+`inclusion: fileMatch` with a `fileMatchPattern` array is the Kiro equivalent of Cursor's `globs` — the steering file is only injected into context when one of the matching files is active.
+
+---
+
+## Platform Comparison
+
+| Platform | Context quality | Setup effort | Cost | Persistence |
+|----------|----------------|--------------|------|-------------|
+| Claude Projects | ⭐⭐⭐⭐⭐ Full | Upload file | Free account | Project-scoped |
+| ChatGPT Custom GPT | ⭐⭐⭐⭐ Compressed | Paste in builder | Paid plan | GPT-scoped |
+| ChatGPT Custom Instructions | ⭐⭐ Essentials only | Paste in settings | Free account | Account-wide |
+| Cursor | ⭐⭐⭐⭐ Rules format | Copy file | Free | Project-scoped |
+| Windsurf | ⭐⭐⭐⭐ Rules format | Copy file | Free | Project-scoped (UI activation) |
+| Kiro | ⭐⭐⭐⭐ Rules format | Copy file | Free | Project-scoped (fileMatch activation) |
+
+## Updating context files
+
+When the GEO Optimizer toolkit is updated, re-copy the relevant files:
+
+```bash
+# Update all IDE rule files
+cp ~/geo-optimizer-skill/ai-context/cursor.mdc .cursor/rules/geo-optimizer.mdc
+cp ~/geo-optimizer-skill/ai-context/windsurf.md .windsurf/rules/geo-optimizer.md
+cp ~/geo-optimizer-skill/ai-context/kiro-steering.md .kiro/steering/geo-optimizer.md
+
+# For Claude/ChatGPT: re-upload/re-paste the updated file manually
+```
+
+---
+
+*GEO Optimizer by Juan Camilo Auriti — https://github.com/auriti-labs/geo-optimizer-skill*

--- a/src/geo_optimizer/web/docs/ci-cd.md
+++ b/src/geo_optimizer/web/docs/ci-cd.md
@@ -1,0 +1,207 @@
+# CI/CD Integration
+
+Run GEO audits automatically in your CI/CD pipeline. Catch regressions before they hit production.
+
+## Quick Start (GitHub Actions)
+
+Add this to `.github/workflows/geo-audit.yml`:
+
+```yaml
+name: GEO Audit
+on: [push]
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Auriti-Labs/geo-optimizer-skill@v1
+        with:
+          url: https://yoursite.com
+```
+
+That's it. The action installs Python, installs `geo-optimizer-skill`, runs the audit, and reports the score.
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `url` | ✅ | — | URL to audit |
+| `threshold` | ❌ | `0` | Minimum score (0-100). Fails if score is below. |
+| `format` | ❌ | `json` | Output format: `json`, `sarif`, `junit`, `text` |
+| `output-file` | ❌ | `geo-report` | Base name for the output file (no extension) |
+| `fail-on-warning` | ❌ | `false` | Fail on warnings too |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `score` | GEO citability score (0-100) |
+| `band` | Score band: `critical`, `foundation`, `good`, `excellent` |
+| `report-path` | Path to the generated report file |
+
+## Examples
+
+### Enforce a minimum score
+
+```yaml
+- uses: Auriti-Labs/geo-optimizer-skill@v1
+  with:
+    url: https://yoursite.com
+    threshold: 70
+```
+
+The step fails if the score drops below 70.
+
+### SARIF upload (GitHub Security tab)
+
+```yaml
+- uses: Auriti-Labs/geo-optimizer-skill@v1
+  with:
+    url: https://yoursite.com
+    format: sarif
+```
+
+When `format: sarif`, results automatically appear in the **Security** tab of your repo under Code Scanning alerts.
+
+> **Note:** SARIF upload requires `security-events: write` permission.
+
+### Post results as a PR comment
+
+```yaml
+- uses: Auriti-Labs/geo-optimizer-skill@v1
+  id: geo
+  with:
+    url: https://yoursite.com
+
+- uses: actions/github-script@v7
+  if: github.event_name == 'pull_request'
+  with:
+    script: |
+      const score = '${{ steps.geo.outputs.score }}';
+      const band = '${{ steps.geo.outputs.band }}';
+      const emoji = score >= 80 ? '🟢' : score >= 60 ? '🟡' : '🔴';
+      await github.rest.issues.createComment({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: context.issue.number,
+        body: `## ${emoji} GEO Audit Results\n\n| Metric | Value |\n|--------|-------|\n| Score | **${score}**/100 |\n| Band | \`${band}\` |\n\n_Powered by [GEO Optimizer](https://github.com/Auriti-Labs/geo-optimizer-skill)_`
+      });
+```
+
+### JUnit output (for CI dashboards)
+
+```yaml
+- uses: Auriti-Labs/geo-optimizer-skill@v1
+  with:
+    url: https://yoursite.com
+    format: junit
+    output-file: geo-results
+
+- uses: dorny/test-reporter@v1
+  with:
+    name: GEO Audit
+    path: geo-results.xml
+    reporter: java-junit
+```
+
+### Scheduled weekly audit
+
+```yaml
+name: Weekly GEO Audit
+on:
+  schedule:
+    - cron: "0 6 * * 1"  # Every Monday at 6 AM UTC
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Auriti-Labs/geo-optimizer-skill@v1
+        id: geo
+        with:
+          url: https://yoursite.com
+          threshold: 60
+
+      - name: Summary
+        run: |
+          echo "## GEO Score: ${{ steps.geo.outputs.score }}/100" >> "$GITHUB_STEP_SUMMARY"
+```
+
+## Platform Support
+
+The action runs on all GitHub-hosted runners:
+
+- ✅ `ubuntu-latest`
+- ✅ `macos-latest`
+- ✅ `windows-latest`
+
+Python 3.9+ is supported.
+
+---
+
+## GitLab CI
+
+```yaml
+geo-audit:
+  image: python:3.12-slim
+  stage: test
+  script:
+    - pip install geo-optimizer-skill
+    - geo audit --url https://yoursite.com --format json --output geo-report.json
+    - |
+      SCORE=$(python3 -c "import json; print(json.load(open('geo-report.json'))['score'])")
+      echo "GEO Score: ${SCORE}/100"
+      if [ "${SCORE}" -lt 60 ]; then
+        echo "Score below threshold!"
+        exit 1
+      fi
+  artifacts:
+    paths:
+      - geo-report.json
+    expire_in: 30 days
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - if: $CI_COMMIT_BRANCH == "main"
+```
+
+## Jenkins
+
+```groovy
+pipeline {
+    agent any
+    stages {
+        stage('GEO Audit') {
+            steps {
+                sh '''
+                    pip install geo-optimizer-skill
+                    geo audit --url https://yoursite.com --format json --output geo-report.json
+                '''
+                script {
+                    def report = readJSON file: 'geo-report.json'
+                    echo "GEO Score: ${report.score}/100 (${report.band})"
+                    if (report.score < 60) {
+                        error "GEO score ${report.score} is below threshold 60"
+                    }
+                }
+            }
+            post {
+                always {
+                    archiveArtifacts artifacts: 'geo-report.json'
+                }
+            }
+        }
+    }
+}
+```
+
+## Generic CI (any platform)
+
+The core is just two commands:
+
+```bash
+pip install geo-optimizer-skill
+geo audit --url https://yoursite.com --format json --output report.json
+```
+
+Parse the JSON to get `score` (integer 0-100) and `band` (string). Use these to gate deployments or trigger alerts.

--- a/src/geo_optimizer/web/docs/geo-audit.md
+++ b/src/geo_optimizer/web/docs/geo-audit.md
@@ -1,0 +1,199 @@
+# GEO Audit Script
+
+`geo audit` scores your website from 0 to 100 across five GEO dimensions and tells you exactly what to fix.
+
+---
+
+## What It Checks
+
+| Area | What is audited |
+|------|----------------|
+| **robots.txt** | 13 AI bots — are they allowed or missing? |
+| **llms.txt** | Present at site root? Has content and links? |
+| **Schema JSON-LD** | WebSite, WebApplication, FAQPage, Article detected? |
+| **Meta tags** | Title, description, canonical, Open Graph |
+| **Content quality** | Headings count, statistics, external citations |
+
+---
+
+## Usage
+
+```bash
+# Standard audit
+geo audit --url https://yoursite.com
+
+# --verbose flag is coming soon (currently has no effect)
+```
+
+### Flags
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--url` | ✅ Yes | Full URL of the site to audit (must include `https://`) |
+| `--verbose` | No | Coming soon — currently has no effect |
+
+---
+
+## Output Explained
+
+Each line in the output maps to a specific check. Here's how to read it:
+
+```diff
+▸ ROBOTS.TXT
++ ✅ GPTBot          allowed  (OpenAI — ChatGPT training)
++ ✅ OAI-SearchBot   allowed  (OpenAI — ChatGPT citations)  ← critical
+- ❌ ClaudeBot        MISSING                               ← critical
+- ❌ PerplexityBot    MISSING                               ← critical
++ ✅ Google-Extended  allowed  (Gemini + AI Overviews)
+- ❌ anthropic-ai     MISSING
+- ❌ ChatGPT-User     MISSING
+```
+
+```diff
+▸ LLMS.TXT
+- ❌ Not found at https://yoursite.com/llms.txt
+```
+
+```diff
+▸ SCHEMA JSON-LD
++ ✅ WebSite schema
+- ❌ FAQPage schema missing     ← next step
+- ❌ WebApplication schema missing
+```
+
+```diff
+▸ META TAGS
++ ✅ Title (62 chars)
++ ✅ Meta description (142 chars)
++ ✅ Canonical URL
+- ❌ Open Graph tags missing (og:title, og:image)
+```
+
+```diff
+▸ CONTENT QUALITY
++ ✅ 18 headings
+- ❌ 1 statistic  (target: 5+)
+- ❌ 0 external citations  (target: 3+)
+```
+
+---
+
+## GEO Score Breakdown
+
+The score is calculated from five weighted categories:
+
+| Category | Max Points | How it's scored |
+|----------|-----------|-----------------|
+| robots.txt | 20 | Full points if all 3 citation bots (OAI-SearchBot, ClaudeBot, PerplexityBot) are allowed; partial for other bots |
+| llms.txt | 20 | 10pt for presence, 10pt for having H1, sections, and links |
+| Schema JSON-LD | 25 | 10pt WebSite (essential), 10pt FAQPage (high value), 5pt WebApplication (bonus for tools) |
+| Meta tags | 20 | 5pt each: title, description, canonical, OG tags |
+| Content quality | 15 | 4pt for H1, 6pt for numerical statistics, 5pt for external citations |
+
+**Score bands:**
+
+| Score | Label | Meaning |
+|-------|-------|---------|
+| 91–100 | 🏆 Excellent | Fully optimized for AI citations |
+| 71–90 | ✅ Good | Strong foundation, apply Princeton content methods |
+| 41–70 | ⚠️ Foundation | Core elements present, schema/content gaps remain |
+| 0–40 | ❌ Critical | Missing essential elements — start with robots.txt and llms.txt |
+
+---
+
+## What Each ❌ Means and How to Fix It
+
+| Problem | Fix | Docs |
+|---------|-----|------|
+| AI bot MISSING in robots.txt | Add the bot's `User-agent` block with `Allow: /` | [AI Bots Reference](ai-bots-reference.md) |
+| llms.txt not found | Generate with `geo llms`, place at site root | [Generating llms.txt](llms-txt.md) |
+| FAQPage schema missing | Generate with `geo schema --type faq` | [Schema Injector](schema-injector.md) |
+| WebSite schema missing | Generate with `geo schema --type website` | [Schema Injector](schema-injector.md) |
+| Meta description missing | Add `<meta name="description" content="...">` to `<head>` | — |
+| Open Graph tags missing | Add `og:title`, `og:description`, `og:image` to `<head>` | — |
+| Low statistics count | Add specific numbers, %, dates to page content | [GEO Methods](geo-methods.md#method-2--statistics) |
+| 0 external citations | Link to authoritative sources (papers, .gov, .edu) | [GEO Methods](geo-methods.md#method-1--cite-sources) |
+
+---
+
+## Example Outputs
+
+### Score 55/100 — Unoptimized Site
+
+```
+╔══════════════════════════════════════════════════════════╗
+  GEO AUDIT — https://example.com
+╚══════════════════════════════════════════════════════════╝
+
+⏳ Fetching homepage...  200 OK | 22,418 bytes
+
+▸ ROBOTS.TXT ─────────────────────────────────────────────
+  ✅ GPTBot          allowed
+  ❌ OAI-SearchBot   MISSING   ← critical
+  ❌ ClaudeBot        MISSING   ← critical
+  ❌ PerplexityBot    MISSING   ← critical
+  ✅ Googlebot        allowed
+
+▸ LLMS.TXT ───────────────────────────────────────────────
+  ❌ Not found at https://example.com/llms.txt
+
+▸ SCHEMA JSON-LD ─────────────────────────────────────────
+  ✅ WebSite schema
+  ❌ FAQPage schema missing
+  ❌ WebApplication schema missing
+
+▸ META TAGS ──────────────────────────────────────────────
+  ✅ Title
+  ✅ Meta description
+  ❌ Canonical URL missing
+  ❌ Open Graph tags missing
+
+▸ CONTENT QUALITY ────────────────────────────────────────
+  ✅ 9 headings
+  ❌ 1 statistic  (target: 5+)
+  ❌ 0 external citations  (target: 3+)
+
+──────────────────────────────────────────────────────────
+  GEO SCORE   [███████████░░░░░░░░░]   55 / 100   ⚠️  FOUNDATION
+──────────────────────────────────────────────────────────
+```
+
+### Score 85/100 — Optimized Site
+
+```
+╔══════════════════════════════════════════════════════════╗
+  GEO AUDIT — https://example.com
+╚══════════════════════════════════════════════════════════╝
+
+⏳ Fetching homepage...  200 OK | 50,251 bytes
+
+▸ ROBOTS.TXT ─────────────────────────────────────────────
+  ✅ GPTBot          allowed  (OpenAI — ChatGPT training)
+  ✅ OAI-SearchBot   allowed  (OpenAI — ChatGPT citations)  ← critical
+  ✅ ClaudeBot        allowed  (Anthropic — Claude)          ← critical
+  ✅ PerplexityBot    allowed  (Perplexity AI)               ← critical
+  ✅ Google-Extended  allowed  (Gemini + AI Overviews)
+  ✅ anthropic-ai     allowed
+  ✅ ChatGPT-User     allowed
+  ✅ All critical citation bots configured
+
+▸ LLMS.TXT ───────────────────────────────────────────────
+  ✅ Found  (6,517 bytes · 46 links · 6 sections)
+
+▸ SCHEMA JSON-LD ─────────────────────────────────────────
+  ✅ WebSite schema
+  ✅ WebApplication schema
+  ⚠️  FAQPage schema missing  ← next step
+
+▸ META TAGS ──────────────────────────────────────────────
+  ✅ Title · Meta description · Canonical · OG tags
+
+▸ CONTENT QUALITY ────────────────────────────────────────
+  ✅ 31 headings  ·  15 statistics  ·  2 external citations
+
+──────────────────────────────────────────────────────────
+  GEO SCORE   [█████████████████░░░]   85 / 100   ✅ GOOD
+──────────────────────────────────────────────────────────
+```
+
+The missing FAQPage schema (−8pt) and one external citation (−2pt) are the gap between 85 and 100.

--- a/src/geo_optimizer/web/docs/geo-fix.md
+++ b/src/geo_optimizer/web/docs/geo-fix.md
@@ -1,0 +1,103 @@
+# geo fix Command
+
+`geo fix` audits a URL and generates all missing files in one shot: robots.txt patches, llms.txt, JSON-LD schemas, meta tag recommendations, and AI discovery templates.
+
+---
+
+## Usage
+
+```bash
+# Preview what would be generated (dry-run, default)
+geo fix --url https://yoursite.com
+
+# Write fix files to disk
+geo fix --url https://yoursite.com --apply
+
+# Target only specific categories
+geo fix --url https://yoursite.com --only robots,llms
+geo fix --url https://yoursite.com --only schema,meta
+```
+
+---
+
+## What It Generates
+
+| Category | File | Description |
+|----------|------|-------------|
+| **robots** | `robots.txt` | Patch adding missing AI bot entries |
+| **llms** | `llms.txt` | Structured AI index from sitemap |
+| **schema** | `schema-*.json` | WebSite, Organization, FAQPage as needed |
+| **meta** | `meta-tags.html` | Description, canonical, Open Graph snippets |
+| **ai-discovery** | `ai/summary.json` | Site summary for AI systems |
+| **ai-discovery** | `ai/faq.json` | Structured FAQ for AI |
+
+---
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--url` | (required) | URL of the site to fix |
+| `--apply` | `false` | Write files to disk (default is dry-run preview) |
+| `--only` | all | Comma-separated categories: `robots,llms,schema,meta` |
+| `--output-dir` | `.` | Directory to write fix files |
+
+---
+
+## Example Output (Dry-Run)
+
+```
+🛠️ GEO Fix Plan — https://yoursite.com
+Score before: 52/100
+
+📄 robots.txt patch (append to existing):
+   User-agent: GPTBot
+   Allow: /
+   User-agent: ClaudeBot
+   Allow: /
+   User-agent: PerplexityBot
+   Allow: /
+
+📄 llms.txt (new file):
+   # Your Site Name
+   > Brief description of your site
+   ## Main Pages
+   - [Home](https://yoursite.com): Main page
+   - [Blog](https://yoursite.com/blog): Articles
+   ...
+
+📄 schema-website.json:
+   {"@context": "https://schema.org", "@type": "WebSite", ...}
+
+📄 meta-tags.html:
+   <meta name="description" content="...">
+   <link rel="canonical" href="...">
+
+📄 ai/summary.json:
+   {"name": "Your Site", "description": "...", "url": "..."}
+
+Estimated score after fixes: 85/100 (+33 points)
+
+Use --apply to write these files to disk.
+```
+
+---
+
+## Using with MCP
+
+The `geo_fix` MCP tool provides the same functionality:
+
+```
+"Fix my site's GEO issues" → calls geo_fix tool
+```
+
+Returns the complete fix plan as JSON, which AI assistants can then help you implement.
+
+---
+
+## Tips
+
+- **Always preview first** — run without `--apply` to review what will be generated
+- **Combine with audit** — run `geo audit` first to understand the full picture
+- **Iterate** — fix one category at a time with `--only` if you prefer incremental changes
+- **Version control** — commit existing files before running `--apply`

--- a/src/geo_optimizer/web/docs/geo-methods.md
+++ b/src/geo_optimizer/web/docs/geo-methods.md
@@ -1,0 +1,291 @@
+# The 11 GEO Methods
+
+Research-backed content optimization techniques for AI citation visibility.
+
+> **Methods 1–9** from the Princeton KDD 2024 study (Aggarwal et al.). **Methods 10–11** informed by AutoGEO ICLR 2026 and Stanford 2025 research.
+
+---
+
+## Background
+
+**Paper:** "GEO: Generative Engine Optimization" — Aggarwal et al., KDD 2024  
+**Link:** [arxiv.org/abs/2311.09735](https://arxiv.org/abs/2311.09735)  
+**Dataset:** [generative-engines.com/GEO](https://generative-engines.com/GEO/)  
+**Methodology:** 10,000 real queries across diverse domains on Perplexity.ai; GPT-4 simulated responses
+
+The study measured three signals: word count overlap (how much of your content appears in the AI response), rank position (where your source is cited), and citation frequency.
+
+**Key finding:** Certain content modifications significantly increase the probability of being cited. The top method produces up to +115% visibility for rank-5 citation positions.
+
+---
+
+## Method 1 — Cite Sources
+
+**Measured impact: +30–115% AI visibility**
+
+Link to authoritative external sources inline in your content. This is the single highest-impact method in the study. AI engines use citations as a trust signal: if your page already cites authoritative sources, it looks more credible and is more likely to be cited itself.
+
+**Apply when:** Making any factual claim — statistics, cause-effect statements, comparisons, medical or financial advice.
+
+```diff
+- Fixed-rate mortgages are safer during periods of inflation.
++ According to the [Federal Reserve](https://federalreserve.gov), fixed-rate mortgages
++ better protect borrowers during inflationary periods exceeding 3%, as they lock in
++ the rate before central bank adjustments take effect.
+```
+
+Prefer linking to: academic papers, government domains (`.gov`, `.edu`), industry reports, official vendor documentation.
+
+---
+
+## Method 2 — Statistics
+
+**Measured impact: +40% average AI visibility**
+
+Replace vague claims with specific, verifiable numerical data. AI engines prefer content with concrete facts — numbers, percentages, dates, study results — because they are easy to extract and verify.
+
+**Apply when:** Describing frequency, scale, comparison, cost, or performance of anything.
+
+```diff
+- Many Americans invest in mutual funds.
++ 34.2% of Americans hold mutual fund shares (Morningstar, 2024),
++ with total assets under management exceeding $23 trillion —
++ up from $19.6 trillion in 2020.
+```
+
+Always specify the source and year. Avoid statistics older than 3 years unless they are historical baselines.
+
+---
+
+## Method 3 — Quotation Addition
+
+**Measured impact: +30–40% AI visibility**
+
+Include direct quotes from domain experts, researchers, or official documents. Quotation marks signal attribution and verifiability, which AI engines interpret as a quality signal.
+
+**Apply when:** Covering YMYL (Your Money, Your Life) topics — finance, health, legal. Also effective for history and science.
+
+```diff
+- A fixed rate is a good choice when market rates are low.
++ "A fixed rate is the right choice when market rates fall below the historical
++ 10-year average," notes John Smith, Head of Mortgage Lending at Bloomberg (2024).
++ "Locking in a low rate protects borrowers from the volatility typical of
++ central bank tightening cycles."
+```
+
+Format: `"Quote" — Name, Role, Organization, Year`
+
+---
+
+## Method 4 — Authoritative Tone
+
+**Measured impact: +6–12% average AI visibility**
+
+Write with an expert voice. Eliminate vague hedging language and replace it with precise, structured explanations. Use the format: definition → how it works → practical implications.
+
+**Apply when:** Explaining any technical concept, process, or recommendation.
+
+```diff
+- A mortgage might be right for you if you need to buy a house and you
+- don't have all the money.
++ A mortgage is a long-term financing instrument (15–30 years) secured by
++ a lien on the property. The monthly payment covers principal reduction
++ and interest calculated on the agreed rate — fixed (constant APR) or
++ variable (indexed to SOFR or Euribor with a bank spread).
+```
+
+Eliminate: "often", "generally", "might", "could be", "in some cases". Replace with precise scope statements: "in 80% of cases", "for loans above $500,000", "when the LTV exceeds 80%".
+
+---
+
+## Method 5 — Fluency Optimization
+
+**Measured impact: +15–30% AI visibility**
+
+Improve text flow and readability. LLMs extract information more reliably from well-structured, grammatically correct prose. Choppy or error-prone text is harder to parse and cite.
+
+**Apply when:** Revising any existing page — this is a universal improvement.
+
+```diff
+- The mortgage calculation, which is done by the bank, depends on the rate.
+- The rate can be fixed or variable. You need to choose.
++ The monthly payment calculation depends primarily on the rate type selected.
++ A fixed rate guarantees stable payments throughout the loan term, while a
++ variable rate adjusts periodically based on market benchmarks such as SOFR
++ — meaning payments can increase or decrease over time.
+```
+
+Target: sentences of 15–25 words. Use logical connectives: "therefore", "however", "consequently", "in particular". Each paragraph should have a clear topic sentence.
+
+---
+
+## Method 6 — Easy-to-Understand
+
+**Measured impact: +8–15% AI visibility**
+
+Simplify without losing precision. AI engines can more reliably extract and paraphrase content that is clearly explained. Add brief in-context definitions for technical terms.
+
+**Apply when:** Your audience includes non-experts, or when you cover jargon-heavy topics.
+
+```diff
+- The loan-to-value ratio influences the LTV of collateral guarantees.
++ The loan-to-value ratio (LTV) measures how much of the property price
++ you are borrowing. An LTV of 80% means you finance 80% of the home's
++ value, with the remaining 20% as your down payment. Most lenders
++ require private mortgage insurance (PMI) for LTVs above 80%.
+```
+
+Two-level structure: plain explanation first, technical details second. Add a glossary section for pages with 5+ domain-specific terms.
+
+---
+
+## Method 7 — Unique Words
+
+**Measured impact: +5–8% AI visibility**
+
+Vary vocabulary. Avoid repeating the same term in consecutive sentences; use contextually appropriate synonyms. A varied vocabulary signals content quality to language models.
+
+**Apply when:** Reviewing finished content for over-repetition. Lower priority than methods 1–6.
+
+```diff
+- The calculator calculates your mortgage calculation automatically.
+- You can calculate different calculation scenarios.
++ The calculator computes your mortgage payment automatically.
++ You can model different repayment scenarios and compare outcomes.
+```
+
+Note: this method has lower impact than the others — prioritize it last.
+
+---
+
+## Method 8 — Technical Terms
+
+**Measured impact: +5–10% for specialized queries**
+
+Use correct, industry-standard terminology. Relevant for expert users searching with technical vocabulary. Works best in combination with Authoritative and Cite Sources.
+
+**Apply when:** Your audience includes professionals or experts; for finance, health, science, legal content.
+
+```diff
+- The loan interest rate changes based on the market.
++ The loan's variable APR (Annual Percentage Rate) adjusts quarterly
++ based on the SOFR 3-month benchmark plus the bank's credit spread,
++ following standard French amortization for each recalculated period.
+```
+
+Include official acronyms with their full form on first use: `APR (Annual Percentage Rate)`, `LTV (Loan-to-Value)`, `EBITDA`.
+
+---
+
+## Method 9 — Keyword Stuffing ⚠️
+
+**Measured impact: Neutral or NEGATIVE**
+
+The Princeton study tested keyword density manipulation — forcefully repeating target keywords throughout the content. The result: no significant improvement in AI visibility, and in some cases a net negative effect by degrading fluency scores.
+
+This is a carryover from traditional SEO. **Do not apply it for GEO.**
+
+Instead: use Fluency Optimization + Cite Sources + Statistics.
+
+---
+
+## Method 10 — Answer-First Structure
+
+**Measured impact: +25% AI visibility** (AutoGEO, ICLR 2026)
+
+Place the key conclusion or answer in the first 150 characters after every H2 heading. AI engines extract content from the opening of each section to build answers — if your conclusion is buried in the third paragraph, it may never be surfaced.
+
+**Apply when:** Writing any informational or how-to content. Especially effective for query-driven pages (FAQ, guides, tutorials).
+
+```diff
+- ## How to Choose a Mortgage Rate
+- There are many factors to consider when choosing a mortgage.
+- First, you need to understand how rates work. Banks set rates
+- based on central bank policy. After analyzing your situation...
+- The best choice for most buyers is a fixed rate below 5%.
+
++ ## How to Choose a Mortgage Rate
++ A fixed rate below 5% is the best choice for most buyers.
++ Banks set rates based on central bank policy, and understanding
++ how this works helps you negotiate better terms.
+```
+
+Structure: **Answer → Context → Detail**. The first sentence after each H2 should be extractable as a standalone answer. Think of it as the "TL;DR" for that section.
+
+---
+
+## Method 11 — Passage Density
+
+**Measured impact: +23% AI visibility** (Stanford, 2025)
+
+Write paragraphs of 50–150 words, each containing at least one concrete data point (number, date, measurement, percentage). AI retrieval systems chunk content into passages — dense, self-contained paragraphs are more likely to be selected and cited than long, sprawling blocks of text.
+
+**Apply when:** Reviewing any page with paragraphs over 200 words or paragraphs that lack specific data.
+
+```diff
+- WordPress powers a lot of websites. It's a popular CMS that
+- many people use for their blogs and business sites. The platform
+- has been around for a long time and continues to grow. Many
+- developers build plugins and themes for it, making it versatile
+- for different use cases. Companies of all sizes rely on it.
+
++ WordPress powers 43.1% of all websites globally (W3Techs, 2025),
++ serving over 835 million sites. The platform processes 70 million
++ new posts per month and supports 55,000+ plugins in its official
++ directory. Enterprise adopters include Time, TechCrunch, and the
++ White House — sites handling 50M+ monthly pageviews on WordPress
++ infrastructure.
+```
+
+Each paragraph should pass the "citation test": could an AI engine quote this paragraph as a standalone answer? If not, add a concrete fact or split it.
+
+---
+
+## Implementation Strategy
+
+### Phase 1 — Quick Wins (Days 1–3)
+
+Focus on the two highest-ROI methods first.
+
+1. **Statistics** — Go through your top 5 pages. Find every vague claim ("many users", "significant improvement") and replace it with a specific number. Add the source and year.
+2. **Cite Sources** — Add 2–3 inline links to authoritative sources per page. Use `According to [Source](URL), ...` format.
+3. **Fluency** — Paste each page through Grammarly or LanguageTool. Fix errors and break up sentences over 40 words.
+
+### Phase 2 — Structural Optimization (Days 4–10)
+
+4. **Quotation Addition** — Find 1–2 quotable experts per topic. Add direct quotes with attribution.
+5. **Authoritative Tone** — Rewrite introductions and summaries using the definition → explanation → implication structure.
+6. **Technical Terms** — Audit your use of acronyms and jargon. Add full forms on first use.
+
+### Phase 3 — Fine Tuning (Ongoing)
+
+7. **Easy-to-Understand** — Add inline definitions for technical terms. Build a glossary page.
+8. **Unique Words** — Final pass to remove repeated words and vary vocabulary.
+
+---
+
+## Impact by Domain
+
+| Method | Finance | Health | Science | History | Media |
+|--------|---------|--------|---------|---------|-------|
+| Cite Sources | ⭐⭐⭐ | ⭐⭐⭐ | ⭐⭐⭐ | ⭐⭐ | ⭐⭐ |
+| Statistics | ⭐⭐⭐ | ⭐⭐⭐ | ⭐⭐⭐ | ⭐⭐ | ⭐⭐ |
+| Quotation Addition | ⭐⭐⭐ | ⭐⭐⭐ | ⭐⭐ | ⭐⭐⭐ | ⭐ |
+| Authoritative Tone | ⭐⭐⭐ | ⭐⭐⭐ | ⭐⭐ | ⭐⭐ | ⭐ |
+| Fluency Optimization | ⭐⭐ | ⭐⭐ | ⭐⭐ | ⭐⭐ | ⭐⭐⭐ |
+| Answer-First Structure | ⭐⭐⭐ | ⭐⭐⭐ | ⭐⭐⭐ | ⭐⭐ | ⭐⭐⭐ |
+| Passage Density | ⭐⭐⭐ | ⭐⭐⭐ | ⭐⭐⭐ | ⭐⭐ | ⭐⭐ |
+| Easy-to-Understand | ⭐⭐ | ⭐⭐⭐ | ⭐ | ⭐ | ⭐⭐⭐ |
+| Technical Terms | ⭐⭐⭐ | ⭐⭐ | ⭐⭐⭐ | ⭐ | ⭐ |
+| Unique Words | ⭐ | ⭐ | ⭐⭐ | ⭐⭐ | ⭐⭐ |
+| Keyword Stuffing | ❌ | ❌ | ❌ | ❌ | ❌ |
+
+⭐⭐⭐ High impact · ⭐⭐ Moderate · ⭐ Low · ❌ Avoid
+
+---
+
+## References
+
+- Paper: [https://arxiv.org/abs/2311.09735](https://arxiv.org/abs/2311.09735)
+- GEO-bench dataset: [https://generative-engines.com/GEO/](https://generative-engines.com/GEO/)
+- KDD 2024 Conference: August 25–29, 2024, Barcelona

--- a/src/geo_optimizer/web/docs/getting-started.md
+++ b/src/geo_optimizer/web/docs/getting-started.md
@@ -1,0 +1,155 @@
+# Getting Started
+
+Get the toolkit installed and run your first GEO audit in under 10 minutes.
+
+---
+
+## 1. What You Need
+
+| Requirement | Version | Notes |
+|-------------|---------|-------|
+| Python | 3.9+ | [python.org](https://python.org) |
+| git | any | [git-scm.com](https://git-scm.com) |
+| Website | — | Must be publicly accessible via HTTPS |
+
+Check your Python version:
+
+```bash
+python3 --version
+```
+
+---
+
+## 2. Install
+
+**One-liner (recommended):**
+
+```bash
+curl -sSL https://raw.githubusercontent.com/auriti-labs/geo-optimizer-skill/main/install.sh | bash
+```
+
+This script:
+1. Clones the repo to `~/geo-optimizer-skill`
+2. Creates a Python virtual environment at `~/geo-optimizer-skill/.venv`
+3. Installs dependencies (`requests`, `beautifulsoup4`, `lxml`) into the venv
+4. Creates a `./geo` wrapper script that activates the venv automatically before running any script
+
+You never need to activate the venv manually — `./geo` handles it.
+
+> **Custom install path?** The `--dir` flag cannot be used with `curl | bash` (the flag is intercepted by `bash`, not the script). Download first, then pass the flag:
+> ```bash
+> curl -sSL https://raw.githubusercontent.com/auriti-labs/geo-optimizer-skill/main/install.sh -o install.sh
+> bash install.sh --dir /custom/path
+> ```
+
+**Manual alternative** (if you prefer to inspect first):
+
+```bash
+git clone https://github.com/auriti-labs/geo-optimizer-skill.git ~/geo-optimizer-skill
+cd ~/geo-optimizer-skill
+bash install.sh
+```
+
+**Update anytime:**
+
+```bash
+bash ~/geo-optimizer-skill/update.sh
+```
+
+---
+
+## 3. Your First Audit
+
+```bash
+cd ~/geo-optimizer-skill
+geo audit --url https://yoursite.com
+```
+
+That's it. The script fetches your homepage, `robots.txt`, and checks for `/llms.txt`, JSON-LD schema, meta tags, and content signals.
+
+---
+
+## 4. Reading the Output
+
+The audit output is divided into 5 sections plus a final score.
+
+**Section 1 — ROBOTS.TXT**
+
+Shows which AI bots are explicitly configured in your `robots.txt`. Each bot is shown as allowed or missing.
+
+```
+▸ ROBOTS.TXT ─────────────────────────────────────────────
+  ✅ GPTBot          allowed  (OpenAI — ChatGPT training)
+  ✅ OAI-SearchBot   allowed  (OpenAI — ChatGPT citations)  ← critical
+  ❌ ClaudeBot        MISSING                               ← critical
+  ❌ PerplexityBot    MISSING                               ← critical
+```
+
+**Section 2 — LLMS.TXT**
+
+Checks whether `/llms.txt` exists at the root of your site and whether it has content.
+
+```
+▸ LLMS.TXT ───────────────────────────────────────────────
+  ❌ Not found at https://yoursite.com/llms.txt
+```
+
+**Section 3 — SCHEMA JSON-LD**
+
+Lists which schema types were found in the page's `<head>`.
+
+```
+▸ SCHEMA JSON-LD ─────────────────────────────────────────
+  ✅ WebSite schema
+  ❌ FAQPage schema missing
+  ❌ WebApplication schema missing
+```
+
+**Section 4 — META TAGS**
+
+Checks for title, meta description, canonical URL, and Open Graph tags.
+
+```
+▸ META TAGS ──────────────────────────────────────────────
+  ✅ Title · Meta description · Canonical · OG tags
+```
+
+**Section 5 — CONTENT QUALITY**
+
+Counts headings, statistics (numbers/percentages), and external citation links.
+
+```
+▸ CONTENT QUALITY ────────────────────────────────────────
+  ✅ 12 headings  ·  3 statistics  ·  0 external citations
+```
+
+**GEO Score:**
+
+```
+──────────────────────────────────────────────────────────
+  GEO SCORE   [████████░░░░░░░░░░░░]   55 / 100   ⚠️  NEEDS WORK
+──────────────────────────────────────────────────────────
+```
+
+Score ranges: `0–40` Critical · `41–70` Fair · `71–90` Good · `91–100` Excellent
+
+---
+
+## 5. What to Fix First
+
+Follow this priority order — each step has the highest ROI before moving to the next:
+
+1. **robots.txt** — Add all AI bots. Takes 5 minutes. Affects whether bots can crawl you at all. → [AI Bots Reference](ai-bots-reference.md)
+2. **llms.txt** — Generate it from your sitemap. Takes 2 minutes. → [Generating llms.txt](llms-txt.md)
+3. **Schema** — Add WebSite, FAQPage, WebApplication. → [Schema Injector](schema-injector.md)
+4. **Content** — Add statistics, external citations, expert quotes. → [The 9 Princeton GEO Methods](geo-methods.md)
+
+---
+
+## 6. Update
+
+```bash
+bash ~/geo-optimizer-skill/update.sh
+```
+
+Pulls the latest commits, updates dependencies, and keeps your `./geo` wrapper intact.

--- a/src/geo_optimizer/web/docs/index.md
+++ b/src/geo_optimizer/web/docs/index.md
@@ -1,0 +1,31 @@
+# GEO Optimizer — Documentation
+
+Optimize any website to be cited by ChatGPT, Perplexity, Claude, and Gemini.
+This documentation covers every tool and concept in the toolkit. → [README](../README.md)
+
+---
+
+## Navigation
+
+| Page | Description |
+|------|-------------|
+| [Getting Started](getting-started.md) | Install the toolkit and run your first audit in 5 minutes |
+| [GEO Audit Script](geo-audit.md) | Full reference for `geo audit` — flags, output, scoring |
+| [Generating llms.txt](llms-txt.md) | Auto-generate `/llms.txt` from your sitemap for AI crawlers |
+| [Schema Injector](schema-injector.md) | Generate and inject JSON-LD structured data into your pages |
+| [Using SKILL.md as AI Context](ai-context.md) | Use the toolkit with Claude, ChatGPT, Gemini, Cursor, Windsurf |
+| [The 11 GEO Methods](geo-methods.md) | Research-backed content optimization methods (KDD 2024 + ICLR 2026) |
+| [AI Bots Reference](ai-bots-reference.md) | Complete list of 24 AI crawlers and `robots.txt` configuration |
+| [Scoring Rubric](scoring-rubric.md) | How the GEO Score (0–100) is computed across 7 categories |
+| [geo fix Command](geo-fix.md) | Automatic fix generation — robots.txt, llms.txt, schema, meta |
+| [MCP Server](mcp-server.md) | Use GEO Optimizer as an MCP server in Claude Code, Cursor, etc. |
+| [CI/CD Integration](ci-cd.md) | Run GEO audits in GitHub Actions, GitLab CI, and other pipelines |
+| [Troubleshooting](troubleshooting.md) | Solutions to 10 common installation and runtime problems |
+
+---
+
+## Quick Navigation
+
+**Start here if you're new →** [Getting Started](getting-started.md)
+
+**Already installed? Run your first audit →** [GEO Audit Script](geo-audit.md)

--- a/src/geo_optimizer/web/docs/llms-txt.md
+++ b/src/geo_optimizer/web/docs/llms-txt.md
@@ -1,0 +1,208 @@
+# Generating llms.txt
+
+`geo llms` auto-generates an `/llms.txt` file from your sitemap so AI crawlers can understand your site's structure.
+
+---
+
+## What is llms.txt?
+
+`llms.txt` is a plain-text Markdown file placed at the root of your website (`https://yoursite.com/llms.txt`). It works like `robots.txt` but for AI language models: instead of telling crawlers what to block, it tells them what to read and how to understand your site.
+
+Spec: [llmstxt.org](https://llmstxt.org)
+
+A well-structured `llms.txt` helps AI crawlers:
+- Understand what your site is about before crawling individual pages
+- Discover your most important pages quickly
+- Categorize your content into logical sections
+- Extract a concise site summary for use in AI-generated answers
+
+---
+
+## Why It Matters
+
+AI crawlers (Perplexity, Claude, ChatGPT Search) use `llms.txt` as a trust and structure signal. Sites without it are treated as generic; sites with it are indexed more accurately. When a user asks an AI a question your site answers, having a well-structured `llms.txt` increases the probability of being cited.
+
+---
+
+## Usage
+
+```bash
+# Minimal — auto-detects sitemap from robots.txt
+geo llms --base-url https://yoursite.com
+
+# Full options
+geo llms \
+  --base-url https://yoursite.com \
+  --site-name "MySite" \
+  --description "Free online calculators for finance and math" \
+  --output ./public/llms.txt \
+  --sitemap https://yoursite.com/sitemap.xml \
+  --max-per-section 10 \
+  --fetch-titles
+```
+
+### All Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--base-url` | *(required)* | Root URL of the site (e.g. `https://yoursite.com`) |
+| `--output` | `./llms.txt` | Output file path |
+| `--sitemap` | auto-detected | Direct URL to the sitemap XML; skips auto-detection |
+| `--site-name` | derived from URL | Human-readable name for the site |
+| `--description` | none | Short description of the site (1–2 sentences) |
+| `--max-per-section` | `20` | Max URLs per content section |
+| `--fetch-titles` | false | Fetch each URL to extract its `<title>` tag (slower but richer output) |
+
+---
+
+## Sitemap Auto-Detection
+
+When `--sitemap` is not specified, the script:
+
+1. Fetches `https://yoursite.com/robots.txt`
+2. Looks for a `Sitemap:` directive
+3. If found, uses that URL as the sitemap
+4. If not found, tries `https://yoursite.com/sitemap.xml` as a fallback
+5. If the sitemap is a sitemap index (contains multiple sitemaps), it fetches and merges all of them
+
+If your sitemap is in a non-standard location, always pass `--sitemap` explicitly.
+
+---
+
+## Structure of the Generated File
+
+The script generates a structured Markdown file. Example output:
+
+```markdown
+# MySite
+
+> Free online calculators for finance, math, and health. Accurate, fast, no signup required.
+
+## Finance Tools
+
+- [Mortgage Calculator](https://yoursite.com/finance/mortgage): Calculate monthly payments for fixed and adjustable-rate mortgages
+- [Compound Interest Calculator](https://yoursite.com/finance/compound-interest): Compute growth over time with compound interest
+- [Loan Amortization](https://yoursite.com/finance/amortization): Full amortization schedule for any loan
+
+## Math
+
+- [Percentage Calculator](https://yoursite.com/math/percentage): Calculate percentages, increases, and decreases
+- [Fraction Simplifier](https://yoursite.com/math/fractions): Reduce fractions to their simplest form
+
+## Blog & Articles
+
+- [What is GEO?](https://yoursite.com/blog/what-is-geo): Introduction to Generative Engine Optimization
+- [robots.txt for AI Bots](https://yoursite.com/blog/robots-txt-ai): Complete guide to configuring AI crawlers
+
+## Optional
+
+- [About](https://yoursite.com/about)
+- [Contact](https://yoursite.com/contact)
+- [Privacy Policy](https://yoursite.com/privacy)
+```
+
+**Structure breakdown:**
+- `# H1` — your site name
+- `> blockquote` — your site description (parsed by AI as the summary)
+- `## H2 sections` — content categories (auto-detected from URL patterns)
+- `- [Title](URL): description` — links with optional descriptions
+- Links without descriptions go under `## Optional`
+
+---
+
+## Where to Put the File
+
+Place `llms.txt` at the root of your web server so it's accessible at `https://yoursite.com/llms.txt`.
+
+### Static Sites (Astro, Next.js, plain HTML)
+
+```bash
+# Astro
+geo llms --base-url https://yoursite.com --output ./public/llms.txt
+
+# Next.js (app router)
+geo llms --base-url https://yoursite.com --output ./public/llms.txt
+
+# Plain HTML
+geo llms --base-url https://yoursite.com --output ./llms.txt
+```
+
+After running: deploy as you normally would. The file will be served at `/llms.txt`.
+
+### WordPress
+
+```bash
+# Generate the file locally
+geo llms \
+  --base-url https://yoursite.com \
+  --sitemap https://yoursite.com/sitemap.xml \
+  --output llms.txt
+
+# Upload to WordPress root (where wp-config.php lives)
+scp llms.txt user@yourserver.com:/var/www/html/llms.txt
+```
+
+Or use a plugin like "WP Robots Txt" to serve a custom `llms.txt` via code.
+
+### Generic Site (any server)
+
+```bash
+# Generate
+geo llms --base-url https://yoursite.com --output llms.txt
+
+# Upload via FTP/SCP to the web root
+scp llms.txt user@yourserver.com:/var/www/yoursite.com/llms.txt
+```
+
+---
+
+## Verify It's Live
+
+```bash
+curl https://yoursite.com/llms.txt
+```
+
+Expected: Markdown content starting with `# YourSiteName`.
+
+If you get a 404, the file is not in the right location. Check your web root directory.
+
+---
+
+## Example for Specific Frameworks
+
+### Astro — with custom sitemap
+
+```bash
+geo llms \
+  --base-url https://yoursite.com \
+  --site-name "MySite" \
+  --description "Free tools and calculators" \
+  --sitemap https://yoursite.com/sitemap-index.xml \
+  --output ./public/llms.txt \
+  --max-per-section 15 \
+  --fetch-titles
+```
+
+### Next.js — standard setup
+
+```bash
+geo llms \
+  --base-url https://yoursite.com \
+  --site-name "MySite" \
+  --output ./public/llms.txt
+```
+
+### WordPress — with Yoast SEO sitemap
+
+```bash
+geo llms \
+  --base-url https://yoursite.com \
+  --sitemap https://yoursite.com/sitemap_index.xml \
+  --site-name "MySite" \
+  --description "Your WordPress site description" \
+  --output llms.txt
+```
+
+### Generic site — no sitemap
+
+If you have no sitemap, create a simple `llms.txt` manually following the structure above, or generate a sitemap first (many free tools exist online), then pass it with `--sitemap`.

--- a/src/geo_optimizer/web/docs/mcp-server.md
+++ b/src/geo_optimizer/web/docs/mcp-server.md
@@ -1,0 +1,315 @@
+# MCP Server
+
+GEO Optimizer exposes its core functionality as an [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server, making all tools available inside AI coding assistants like Claude Code, Cursor, and Windsurf.
+
+---
+
+## Installation
+
+Install with the `mcp` extra:
+
+```bash
+pip install geo-optimizer-skill[mcp]
+```
+
+This installs the `geo-mcp` entry point alongside the `mcp` Python SDK.
+
+---
+
+## Setup
+
+### Claude Code
+
+```bash
+claude mcp add geo-optimizer -- geo-mcp
+```
+
+That's it. The tools are immediately available in your Claude Code session.
+
+### Cursor
+
+Add to your `.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "geo-optimizer": {
+      "command": "geo-mcp",
+      "args": []
+    }
+  }
+}
+```
+
+### Windsurf / Generic MCP Client
+
+Any MCP client that supports stdio transport can connect:
+
+```bash
+geo-mcp
+```
+
+The server runs on stdio transport by default. No port configuration needed.
+
+### Direct Python Invocation
+
+```bash
+python -m geo_optimizer.mcp.server
+```
+
+---
+
+## Tools (8)
+
+### 1. `geo_audit`
+
+Run a complete GEO audit on a website. Analyzes 7 areas: robots.txt, llms.txt, JSON-LD schema, SEO meta tags, content quality, signals, and AI discovery. Returns a score 0–100 with detailed breakdown and recommendations.
+
+| Argument | Type | Required | Description |
+|----------|------|----------|-------------|
+| `url` | string | yes | URL of the site to audit |
+
+**Example output (abbreviated):**
+
+```json
+{
+  "url": "https://example.com",
+  "score": 72,
+  "band": "good",
+  "score_breakdown": {
+    "robots": 18,
+    "llms": 6,
+    "schema": 16,
+    "meta": 14,
+    "content": 10,
+    "signals": 5,
+    "ai_discovery": 3
+  },
+  "recommendations": [
+    "Add llms-full.txt for comprehensive AI indexing",
+    "Add FAQPage schema for better AI extraction"
+  ]
+}
+```
+
+### 2. `geo_fix`
+
+Generate automatic GEO fixes for a website. Audits the site and produces corrective artifacts: robots.txt patches, llms.txt content, missing JSON-LD schemas, and HTML meta tag snippets.
+
+| Argument | Type | Required | Description |
+|----------|------|----------|-------------|
+| `url` | string | yes | URL of the site to optimize |
+| `only` | string | no | Filter categories (comma-separated): `robots`, `llms`, `schema`, `meta`. Empty = all |
+
+**Example output (abbreviated):**
+
+```json
+{
+  "fixes": [
+    {
+      "category": "robots",
+      "description": "Create robots.txt with access for all 24 AI bots",
+      "file_name": "robots.txt",
+      "action": "create"
+    },
+    {
+      "category": "llms",
+      "description": "Generate llms.txt from sitemap (42 URLs)",
+      "file_name": "llms.txt",
+      "action": "create"
+    }
+  ],
+  "score_before": 34,
+  "score_estimated_after": 78
+}
+```
+
+### 3. `geo_llms_generate`
+
+Generate complete llms.txt content for a website. Discovers the sitemap, categorizes URLs by content type, and produces a structured markdown file following the [llmstxt.org](https://llmstxt.org) specification.
+
+| Argument | Type | Required | Description |
+|----------|------|----------|-------------|
+| `url` | string | yes | Base URL of the site |
+
+**Example output:**
+
+```markdown
+# Example Site
+
+> A brief description of the site for AI search engines.
+
+## Documentation
+
+- [Getting Started](https://example.com/docs/getting-started)
+- [API Reference](https://example.com/docs/api)
+
+## Blog & Articles
+
+- [How We Built X](https://example.com/blog/how-we-built-x)
+```
+
+### 4. `geo_citability`
+
+Analyze content citability using the 11 GEO methods (Princeton KDD 2024 + AutoGEO ICLR 2026). Evaluates the page content and returns a citability score 0–100 with per-method breakdown.
+
+| Argument | Type | Required | Description |
+|----------|------|----------|-------------|
+| `url` | string | yes | URL of the page to analyze |
+
+**Example output (abbreviated):**
+
+```json
+{
+  "url": "https://example.com/blog/post",
+  "score": 65,
+  "methods": {
+    "quotation_addition": { "score": 8, "max": 10 },
+    "statistics_addition": { "score": 10, "max": 12 },
+    "fluency_optimization": { "score": 9, "max": 12 },
+    "cite_sources": { "score": 6, "max": 10 },
+    "answer_first": { "score": 7, "max": 10 },
+    "passage_density": { "score": 5, "max": 10 }
+  },
+  "suggestions": [
+    "Add 2-3 direct quotes from domain experts",
+    "Add inline citations to authoritative sources"
+  ]
+}
+```
+
+### 5. `geo_schema_validate`
+
+Validate a JSON-LD schema against schema.org requirements. Checks that all required fields are present for the given schema type.
+
+| Argument | Type | Required | Description |
+|----------|------|----------|-------------|
+| `json_string` | string | yes | JSON-LD string to validate (max 512 KB) |
+| `schema_type` | string | no | Schema type (e.g. `website`, `faqpage`). Auto-detected if empty |
+
+**Example output:**
+
+```json
+{
+  "valid": true,
+  "error": null,
+  "schema_type": "website"
+}
+```
+
+### 6. `geo_compare`
+
+Compare GEO scores across multiple websites (max 5). Returns a ranked comparison with score, band, and per-category breakdown.
+
+| Argument | Type | Required | Description |
+|----------|------|----------|-------------|
+| `urls` | string | yes | Comma-separated URLs (e.g. `"site1.com, site2.com"`) |
+
+**Example output:**
+
+```json
+{
+  "comparison": [
+    { "url": "https://site1.com", "score": 82, "band": "good" },
+    { "url": "https://site2.com", "score": 45, "band": "foundation" }
+  ],
+  "total_sites": 2
+}
+```
+
+### 7. `geo_ai_discovery`
+
+Check AI discovery endpoints on a website. Verifies the presence of `/.well-known/ai.txt`, `/ai/summary.json`, `/ai/faq.json`, and `/ai/service.json` based on the [geo-checklist.dev](https://geo-checklist.dev) emerging standard.
+
+| Argument | Type | Required | Description |
+|----------|------|----------|-------------|
+| `url` | string | yes | URL to check |
+
+**Example output:**
+
+```json
+{
+  "well_known_ai_txt": true,
+  "ai_summary_json": true,
+  "ai_faq_json": false,
+  "ai_service_json": false,
+  "score": 4,
+  "max_score": 6
+}
+```
+
+### 8. `geo_check_bots`
+
+Check which AI bots can access a website via robots.txt. Returns per-bot status (allowed/blocked/missing) with 3-tier classification (training/search/user) and citation bot verification.
+
+| Argument | Type | Required | Description |
+|----------|------|----------|-------------|
+| `url` | string | yes | URL to check |
+
+**Example output (abbreviated):**
+
+```json
+{
+  "url": "https://example.com",
+  "robots_found": true,
+  "citation_bots_ok": true,
+  "bots": {
+    "OAI-SearchBot": { "description": "OpenAI (ChatGPT search citations)", "status": "allowed", "tier": "search" },
+    "ClaudeBot": { "description": "Anthropic (Claude citations)", "status": "allowed", "tier": "search" },
+    "GPTBot": { "description": "OpenAI (ChatGPT training)", "status": "blocked", "tier": "training" }
+  },
+  "summary": { "allowed": 20, "blocked": 2, "missing": 2 }
+}
+```
+
+---
+
+## Resources (5)
+
+MCP resources provide read-only reference data. Access them via the `geo://` URI scheme.
+
+| URI | Description |
+|-----|-------------|
+| `geo://ai-bots` | List of all 24 tracked AI bots with 3-tier classification (training/search/user) and citation bot identification |
+| `geo://score-bands` | GEO score band definitions (critical, foundation, good, excellent) with ranges |
+| `geo://methods` | The 11 citability methods with measured impact data and max scores |
+| `geo://changelog` | Latest changes from CHANGELOG.md (first 50 lines) |
+| `geo://ai-discovery-spec` | AI discovery endpoint specification (geo-checklist.dev standard) with required fields and JSON schemas |
+
+---
+
+## Usage Examples
+
+### Claude Code — Full Site Audit
+
+```
+> Use geo_audit to check https://mysite.com and tell me what to fix first.
+```
+
+Claude will call the `geo_audit` tool, parse the results, and give you prioritized recommendations in natural language.
+
+### Claude Code — Generate and Validate Schema
+
+```
+> Generate a WebSite JSON-LD schema for mysite.com, then validate it with geo_schema_validate.
+```
+
+### Cursor — Compare Competitors
+
+```
+> Use geo_compare to compare mysite.com against competitor1.com and competitor2.com.
+> Show me where I'm losing points.
+```
+
+### Fix Workflow
+
+```
+> Run geo_fix on https://mysite.com with only=robots,llms.
+> Show me the generated files.
+```
+
+---
+
+## Security
+
+All URL inputs are validated against SSRF attacks before making any HTTP requests. Private IPs, localhost, and internal network addresses are rejected. HTTP response size is capped at 10 MB.

--- a/src/geo_optimizer/web/docs/schema-injector.md
+++ b/src/geo_optimizer/web/docs/schema-injector.md
@@ -1,0 +1,444 @@
+# Schema Injector
+
+`geo schema` generates and injects JSON-LD structured data into HTML pages. It supports multiple schema types, framework-specific output, and in-place file injection.
+
+---
+
+## What is JSON-LD Schema?
+
+JSON-LD (JavaScript Object Notation for Linked Data) is a format for embedding machine-readable metadata in HTML pages. You add it inside a `<script type="application/ld+json">` tag in your `<head>`.
+
+AI search engines read JSON-LD schema to understand:
+- What type of page this is (tool, article, FAQ, organization)
+- What the page is about, without parsing the full body text
+- How to extract structured answers (especially from FAQPage)
+
+Without schema, AI engines have to guess your content's meaning. With schema, you tell them directly.
+
+---
+
+## The 3 Most Important Schema Types for GEO
+
+| Schema | GEO Priority | Where to use |
+|--------|-------------|--------------|
+| **FAQPage** | 🔴 Highest | Any page with Q&A, how-to, explainer content |
+| **WebApplication** | 🟠 High | Every tool, calculator, or interactive page |
+| **WebSite** | 🟡 Baseline | Global layout — all pages |
+
+FAQPage has the highest GEO impact because AI engines directly extract Q&A pairs to answer user questions — and cite your page as the source.
+
+---
+
+## Usage
+
+```bash
+# Analyze an HTML file — see what schema is present and what's missing
+geo schema --file index.html --analyze
+
+# Generate WebSite schema (print to stdout)
+geo schema --type website --name "MySite" --url https://yoursite.com
+
+# Generate FAQPage schema from a JSON file
+geo schema --type faq --faq-file faqs.json
+
+# Inject schema directly into an HTML file (creates .bak backup first)
+geo schema --file page.html --type website --name "MySite" --url https://yoursite.com --inject
+
+# Generate Astro BaseLayout snippet
+geo schema --type website --name "MySite" --url https://yoursite.com --astro
+```
+
+---
+
+## All Flags
+
+| Flag | Description |
+|------|-------------|
+| `--file` | Path to the HTML file to analyze or inject into |
+| `--analyze` | Analyze `--file` and print what schema is present / missing |
+| `--type` | Schema type to generate: `website`, `webapp`, `faq`, `article`, `organization`, `breadcrumb` |
+| `--name` | Site or page name |
+| `--url` | Canonical URL |
+| `--description` | Short description |
+| `--inject` | Inject generated schema directly into `--file` (modifies in place) |
+| `--faq-file` | Path to a JSON file with Q&A pairs (for `--type faq`) |
+| `--astro` | Output an Astro component snippet instead of raw HTML |
+
+---
+
+## Flag: --analyze
+
+Analyzes an existing HTML file and reports which schema types are present and which are missing.
+
+```bash
+geo schema --file index.html --analyze
+```
+
+Example output:
+
+```
+Analyzing: index.html
+─────────────────────────────────
+✅ WebSite schema found
+❌ FAQPage schema missing      ← high GEO impact
+❌ WebApplication schema missing
+❌ Article schema missing
+
+Suggestion: Add FAQPage schema — highest impact for AI citation visibility.
+Run: geo schema --file index.html --type faq --faq-file faqs.json --inject
+```
+
+---
+
+## Flag: --type
+
+Generates a specific schema type. Prints JSON-LD to stdout by default; combine with `--inject` to write directly to the file.
+
+```bash
+# WebSite
+geo schema --type website --name "MySite" --url https://yoursite.com --description "Free calculators"
+
+# WebApplication
+geo schema --type webapp --name "Mortgage Calculator" --url https://yoursite.com/mortgage --description "Calculate monthly payments"
+
+# FAQPage (from --faq-file)
+geo schema --type faq --faq-file faqs.json
+
+# Organization
+geo schema --type organization --name "MySite" --url https://yoursite.com
+
+# Article
+geo schema --type article --name "What is GEO?" --url https://yoursite.com/blog/geo --description "Introduction to GEO"
+
+# BreadcrumbList
+geo schema --type breadcrumb --url https://yoursite.com/finance/mortgage
+```
+
+---
+
+## Flag: --astro
+
+Generates a ready-to-paste snippet for Astro `BaseLayout.astro`. Supports conditional rendering based on props.
+
+```bash
+geo schema --type website --name "MySite" --url https://yoursite.com --astro
+```
+
+Output — complete Astro layout snippet:
+
+```astro
+---
+// Types
+interface FAQItem {
+  question: string;
+  answer: string;
+}
+
+interface Props {
+  title: string;
+  description: string;
+  url?: string;
+  isCalculator?: boolean;
+  faqItems?: FAQItem[];
+}
+
+const {
+  title,
+  description,
+  url = Astro.url.href,
+  isCalculator = false,
+  faqItems = [],
+} = Astro.props;
+
+const SITE_NAME = "MySite";
+const SITE_URL = "https://yoursite.com";
+---
+
+<head>
+  <meta charset="UTF-8" />
+  <title>{title}</title>
+  <meta name="description" content={description} />
+  <link rel="canonical" href={url} />
+
+  <!-- WebSite schema (all pages) -->
+  <script type="application/ld+json" set:html={JSON.stringify({
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "name": SITE_NAME,
+    "url": SITE_URL,
+    "description": description,
+  })} />
+
+  <!-- WebApplication schema (calculator pages only) -->
+  {isCalculator && (
+    <script type="application/ld+json" set:html={JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "WebApplication",
+      "name": title,
+      "url": url,
+      "description": description,
+      "applicationCategory": "UtilityApplication",
+      "operatingSystem": "Web",
+      "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+    })} />
+  )}
+
+  <!-- FAQPage schema (pages with FAQ content) -->
+  {faqItems.length > 0 && (
+    <script type="application/ld+json" set:html={JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": faqItems.map(item => ({
+        "@type": "Question",
+        "name": item.question,
+        "acceptedAnswer": { "@type": "Answer", "text": item.answer },
+      })),
+    })} />
+  )}
+</head>
+```
+
+Use it in a page:
+
+```astro
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+
+const faqItems = [
+  {
+    question: "How is the monthly mortgage payment calculated?",
+    answer: "The formula is M = P × (r(1+r)^n) / ((1+r)^n - 1), where P is the principal, r is the monthly rate, and n is the total number of payments.",
+  },
+  {
+    question: "What is the difference between fixed and adjustable rates?",
+    answer: "A fixed rate stays constant for the life of the loan. An adjustable rate is tied to a market index and can change periodically, usually after an initial fixed period.",
+  },
+];
+---
+
+<BaseLayout
+  title="Mortgage Calculator"
+  description="Calculate your monthly mortgage payment instantly."
+  isCalculator={true}
+  faqItems={faqItems}
+/>
+```
+
+---
+
+## Flag: --inject
+
+Injects the generated schema directly into the HTML file, inserting it before `</head>`. A backup (`.bak`) is created automatically.
+
+```bash
+geo schema \
+  --file index.html \
+  --type faq \
+  --faq-file faqs.json \
+  --inject
+```
+
+Output:
+
+```
+✅ Backup created: index.html.bak
+✅ FAQPage schema injected into index.html (before </head>)
+```
+
+If the file has no `</head>` tag, injection fails gracefully with an error. See [Troubleshooting](troubleshooting.md#9-inject-failed-no-head-tag) for the fix.
+
+---
+
+## Flag: --faq-file
+
+Reads Q&A pairs from a JSON file to generate FAQPage schema.
+
+Format of `faqs.json`:
+
+```json
+[
+  {
+    "question": "How is the monthly mortgage payment calculated?",
+    "answer": "The standard formula is M = P × (r(1+r)^n) / ((1+r)^n - 1). For a $200,000 loan at 6% over 30 years, the monthly payment is $1,199."
+  },
+  {
+    "question": "What is LTV (Loan-to-Value) ratio?",
+    "answer": "LTV measures how much of the property value you are financing. An LTV of 80% means you are borrowing 80% and providing 20% as a down payment."
+  },
+  {
+    "question": "Should I choose a fixed or variable rate?",
+    "answer": "Fixed rates offer payment stability for the full term. Variable rates may start lower but change with market benchmarks like SOFR. Choose fixed if you expect rates to rise or prefer predictability."
+  }
+]
+```
+
+```bash
+geo schema --type faq --faq-file faqs.json
+```
+
+---
+
+## Framework Examples
+
+### Astro — Full Integration
+
+See the `--astro` section above. Pass `isCalculator={true}` for tool pages and `faqItems={[...]}` for pages with Q&A.
+
+### Next.js (App Router)
+
+In `app/layout.tsx` (WebSite schema on all pages):
+
+```typescript
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  const websiteSchema = {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "name": "MySite",
+    "url": "https://yoursite.com",
+    "description": "Free online tools and calculators",
+  };
+
+  return (
+    <html lang="en">
+      <head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteSchema) }}
+        />
+      </head>
+      <body>{children}</body>
+    </html>
+  );
+}
+```
+
+In a tool page (WebApplication + FAQPage):
+
+```typescript
+export default function MortgagePage() {
+  const appSchema = {
+    "@context": "https://schema.org",
+    "@type": "WebApplication",
+    "name": "Mortgage Calculator",
+    "url": "https://yoursite.com/mortgage",
+    "description": "Calculate monthly mortgage payments for fixed and variable rates.",
+    "applicationCategory": "UtilityApplication",
+    "operatingSystem": "Web",
+    "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+  };
+
+  const faqSchema = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "How is a mortgage payment calculated?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Using the formula M = P × (r(1+r)^n) / ((1+r)^n - 1), where P is the loan amount, r the monthly rate, and n the number of payments.",
+        },
+      },
+    ],
+  };
+
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(appSchema) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+      {/* page content */}
+    </>
+  );
+}
+```
+
+### WordPress — functions.php
+
+Add WebSite schema to all pages and FAQPage to pages with an FAQ section:
+
+```php
+function add_geo_schema() {
+    $schema = [
+        '@context' => 'https://schema.org',
+        '@type'    => 'WebSite',
+        'name'     => get_bloginfo('name'),
+        'url'      => home_url('/'),
+        'description' => get_bloginfo('description'),
+    ];
+    echo '<script type="application/ld+json">' . wp_json_encode($schema) . '</script>' . "\n";
+}
+add_action('wp_head', 'add_geo_schema');
+```
+
+For FAQPage on specific pages, use a custom field or ACF repeater to store Q&A pairs and output them similarly.
+
+### HTML Static — Manual
+
+Add directly in the `<head>` of your HTML file:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>My Page</title>
+
+  <!-- WebSite schema -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "name": "MySite",
+    "url": "https://yoursite.com",
+    "description": "Free online calculators"
+  }
+  </script>
+
+  <!-- FAQPage schema -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "Your question here?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Your answer here, with specific details and numbers."
+        }
+      }
+    ]
+  }
+  </script>
+</head>
+```
+
+---
+
+## FAQPage Best Practices
+
+**How many questions?**
+- Minimum: 3 questions per page
+- Optimal: 5–8 questions
+- Maximum: 15 (more than 15 dilutes individual question weight)
+
+**How to write questions for maximum GEO impact:**
+- Write them as real user queries: *"How is X calculated?"* not *"X calculation"*
+- Be specific: *"What is the LTV ratio and how does it affect my mortgage?"* not *"What is LTV?"*
+- Include numbers in answers: *"A typical LTV is 80%, meaning you borrow 80% of the property value"*
+- Keep answers 2–5 sentences. Long answers reduce extraction clarity.
+- Include at least one statistic or concrete example in each answer
+
+**What makes an answer extractable by AI:**
+- Starts with a direct answer to the question (not a preamble)
+- Includes a specific number, formula, or comparison
+- Self-contained — can be understood without reading the rest of the page
+
+**Validate your schema:**
+
+```bash
+# Google's validator
+open https://validator.schema.org
+# Paste your JSON-LD or enter your URL
+```

--- a/src/geo_optimizer/web/docs/scoring-rubric.md
+++ b/src/geo_optimizer/web/docs/scoring-rubric.md
@@ -1,0 +1,123 @@
+# GEO Scoring Rubric
+
+How the GEO Score (0–100) is computed. Based on the Princeton KDD 2024 research on Generative Engine Optimization, extended with AutoGEO ICLR 2026 and geo-checklist.dev signals.
+
+---
+
+## Score Bands
+
+| Band | Range | Meaning |
+|------|-------|---------|
+| **Excellent** | 86–100 | Fully optimized for AI citation engines |
+| **Good** | 68–85 | Well-optimized, minor gaps remain |
+| **Foundation** | 36–67 | Partially visible — key signals missing |
+| **Critical** | 0–35 | AI engines cannot reliably discover or cite you |
+
+---
+
+## Categories and Weights (v3.14)
+
+The total score is the sum of all points earned across **7 categories**, capped at 100.
+
+### 1. robots.txt — max 18 pts
+
+| Signal | Points | Condition |
+|--------|--------|-----------|
+| `robots_found` | 5 | File exists and is reachable |
+| `robots_citation_ok` | 13 | All 4 citation bots allowed (OAI-SearchBot, ClaudeBot, Claude-SearchBot, PerplexityBot) |
+| `robots_some_allowed` | 10 | At least some AI bots allowed (partial credit — **not cumulative** with `citation_ok`) |
+
+> **Citation bots** are the most critical: OAI-SearchBot, ClaudeBot, Claude-SearchBot, and PerplexityBot drive real-time citations in ChatGPT, Claude, and Perplexity. The `robots_some_allowed` score is awarded only when citation bots are not fully covered — it acts as partial credit for sites that allow some AI bots via wildcard rules.
+
+### 2. llms.txt — max 18 pts
+
+| Signal | Points | Condition |
+|--------|--------|-----------|
+| `llms_found` | 6 | `/llms.txt` exists at site root |
+| `llms_h1` | 2 | File has a top-level H1 heading |
+| `llms_sections` | 2 | File has H2 content sections |
+| `llms_links` | 2 | File contains at least one URL link |
+| `llms_depth` | 2 | Word count ≥ 1,000 (substantial index) |
+| `llms_depth_high` | 2 | Word count ≥ 5,000 (comprehensive index) |
+| `llms_full` | 2 | `llms-full.txt` also exists at site root |
+
+> Quality is now graduated: a minimal llms.txt scores 6 pts, but a deep, well-structured file with a companion `llms-full.txt` can earn all 18.
+
+### 3. Schema JSON-LD — max 22 pts
+
+| Signal | Points | Condition |
+|--------|--------|-----------|
+| `schema_any_valid` | 2 | Any valid JSON-LD schema found in the page |
+| `schema_richness` | 3 | Schema contains 5+ relevant attributes (Growth Marshal 2026) |
+| `schema_faq` | 5 | `FAQPage` schema present |
+| `schema_article` | 3 | `Article` or `BlogPosting` schema present |
+| `schema_organization` | 3 | `Organization` schema present |
+| `schema_website` | 3 | `WebSite` schema present |
+| `schema_sameas` | 3 | `sameAs` links to authoritative domains (Wikipedia, Wikidata, LinkedIn, etc.) |
+
+> The `schema_sameas` signal rewards knowledge graph connections. Authoritative domains: wikipedia.org, wikidata.org, linkedin.com, crunchbase.com, github.com, twitter.com/x.com, facebook.com.
+
+### 4. Meta Tags — max 14 pts
+
+| Signal | Points | Condition |
+|--------|--------|-----------|
+| `meta_title` | 5 | `<title>` tag present and non-empty |
+| `meta_description` | 2 | `<meta name="description">` present |
+| `meta_canonical` | 3 | `<link rel="canonical">` present |
+| `meta_og` | 4 | Open Graph tags present (`og:title`, `og:description`) |
+
+### 5. Content Quality — max 14 pts
+
+| Signal | Points | Condition |
+|--------|--------|-----------|
+| `content_h1` | 2 | Page has at least one `<h1>` heading |
+| `content_numbers` | 2 | Page contains statistics (numbers, percentages) |
+| `content_links` | 2 | Page contains external citation links |
+| `content_word_count` | 2 | Page has ≥ 300 words of substantive content |
+| `content_heading_hierarchy` | 2 | Has H2 + H3 headings in correct hierarchy |
+| `content_lists_or_tables` | 2 | Contains `<ul>`, `<ol>`, or `<table>` elements |
+| `content_front_loading` | 2 | Key information appears in the first 30% of the content |
+
+### 6. Signals — max 8 pts (new)
+
+| Signal | Points | Condition |
+|--------|--------|-----------|
+| `signals_lang` | 3 | `<html lang="...">` attribute is set |
+| `signals_rss` | 3 | RSS or Atom feed is discoverable |
+| `signals_freshness` | 2 | `dateModified` in schema or `Last-Modified` HTTP header present |
+
+### 7. AI Discovery — max 6 pts (new)
+
+Based on the [geo-checklist.dev](https://geo-checklist.dev) emerging standard.
+
+| Signal | Points | Condition |
+|--------|--------|-----------|
+| `ai_discovery_well_known` | 2 | `/.well-known/ai.txt` is present |
+| `ai_discovery_summary` | 2 | `/ai/summary.json` is present and valid |
+| `ai_discovery_faq` | 1 | `/ai/faq.json` is present |
+| `ai_discovery_service` | 1 | `/ai/service.json` is present |
+
+---
+
+## Total Points Reference
+
+| Category | Max Points |
+|----------|-----------|
+| robots.txt | 18 |
+| llms.txt | 18 |
+| Schema JSON-LD | 22 |
+| Meta Tags | 14 |
+| Content Quality | 14 |
+| Signals | 8 |
+| AI Discovery | 6 |
+| **Total** | **100** |
+
+---
+
+## Changelog
+
+| Version | Change |
+|---------|--------|
+| v3.14 | 7 categories (added Signals + AI Discovery), `schema_richness` + `schema_sameas`, graduated llms.txt scoring, content structure checks, bands adjusted |
+| v3.0.0 | 5 categories, `schema_website` 10 pts, `meta_description` 8 pts |
+| v1.5.0 | Original weights |

--- a/src/geo_optimizer/web/docs/troubleshooting.md
+++ b/src/geo_optimizer/web/docs/troubleshooting.md
@@ -1,0 +1,288 @@
+# Troubleshooting
+
+Solutions to common installation and runtime problems.
+
+---
+
+## 1. `./geo: No such file or directory`
+
+**Cause:** `install.sh` did not complete successfully, or you're running from the wrong directory.
+
+**Fix:**
+
+```bash
+# Check you're in the right directory
+cd ~/geo-optimizer-skill
+ls -la geo
+
+# If ./geo doesn't exist, re-run the installer
+bash install.sh
+
+# If install.sh fails, create the wrapper manually
+cat > geo << 'EOF'
+#!/usr/bin/env bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/.venv/bin/activate"
+python3 "$@"
+EOF
+chmod +x geo
+```
+
+Then verify:
+
+```bash
+./geo --version
+```
+
+---
+
+## 2. `ModuleNotFoundError: requests`
+
+**Cause:** You ran a script directly with `python3` instead of using the `./geo` wrapper. The venv with dependencies is not activated.
+
+**Fix:** Always use `./geo` instead of `python3`:
+
+```diff
+- geo audit --url https://yoursite.com
++ geo audit --url https://yoursite.com
+```
+
+If you need to use the venv directly:
+
+```bash
+source ~/geo-optimizer-skill/.venv/bin/activate
+geo audit --url https://yoursite.com
+```
+
+Or reinstall dependencies into the venv:
+
+```bash
+cd ~/geo-optimizer-skill
+.venv/bin/pip install -r requirements.txt
+```
+
+---
+
+## 3. `--help shows a dependency error`
+
+**Cause:** You're running a version older than 1.3.0. Earlier versions imported dependencies at the top of the file, causing `--help` to fail if the venv wasn't active.
+
+**Fix:**
+
+```bash
+bash ~/geo-optimizer-skill/update.sh
+```
+
+After updating, `--help` will always work regardless of venv state:
+
+```bash
+geo audit --help
+geo llms --help
+geo schema --help
+```
+
+---
+
+## 4. `llms.txt generated but 0 links`
+
+**Cause:** The script couldn't find your sitemap. Auto-detection looks for a `Sitemap:` line in `robots.txt` and falls back to `/sitemap.xml`. If neither exists or both return 404, the output file will have no links.
+
+**Fix:** Pass the sitemap URL explicitly:
+
+```bash
+geo llms \
+  --base-url https://yoursite.com \
+  --sitemap https://yoursite.com/sitemap_index.xml \
+  --output ./llms.txt
+```
+
+Common sitemap paths to try:
+
+```bash
+curl -I https://yoursite.com/sitemap.xml
+curl -I https://yoursite.com/sitemap_index.xml
+curl -I https://yoursite.com/sitemap-index.xml
+curl -I https://yoursite.com/post-sitemap.xml     # WordPress/Yoast
+curl -I https://yoursite.com/page-sitemap.xml     # WordPress/Yoast
+```
+
+Use whichever returns `200 OK` as the `--sitemap` value.
+
+---
+
+## 5. `robots.txt bot shows as MISSING despite being there`
+
+**Cause A:** The bot entry has a comment on the same line, which is invalid `robots.txt` syntax.
+
+```diff
+- User-agent: ClaudeBot  # Anthropic citation bot
++ User-agent: ClaudeBot
++ Allow: /
+```
+
+`robots.txt` does not support inline comments. `#` must be on its own line.
+
+**Cause B:** Extra whitespace or a typo in the user-agent name.
+
+```diff
+- User-agent: Claudebot
++ User-agent: ClaudeBot
+```
+
+User-agent names are case-sensitive. `ClaudeBot` ≠ `Claudebot`.
+
+**Cause C:** A `Disallow: /` lower in the file overrides the specific Allow.
+
+```
+User-agent: ClaudeBot
+Allow: /          ← this works
+
+User-agent: *
+Disallow: /       ← but this doesn't override the above in most parsers
+```
+
+To be safe, place specific bot entries before the catch-all `User-agent: *` block.
+
+---
+
+## 6. `WebSite schema found but score is still low`
+
+**Cause:** WebSite schema is the baseline (worth ~8 points). The biggest GEO impact comes from FAQPage schema, which is worth another ~8 points and directly feeds into AI-generated answers.
+
+**Fix:** Add FAQPage schema to pages with Q&A content:
+
+```bash
+# Option 1: generate from a JSON file
+geo schema --type faq --faq-file faqs.json --file page.html --inject
+
+# Option 2: generate and print to copy manually
+geo schema --type faq --faq-file faqs.json
+```
+
+FAQPage schema alone can increase your score by 8 points. Combined with adding external citations (5 points) and a few more statistics (5 points), you can move from 70 to 85.
+
+See [Schema Injector](schema-injector.md) and [FAQPage best practices](schema-injector.md#faqpage-best-practices).
+
+---
+
+## 7. `sitemap.xml returns 404`
+
+**Cause:** Your sitemap is not at the standard `/sitemap.xml` path, or hasn't been generated.
+
+**Fix — find your sitemap:**
+
+```bash
+# Check robots.txt for Sitemap: directive
+curl https://yoursite.com/robots.txt | grep -i sitemap
+
+# Try common WordPress paths
+curl -I https://yoursite.com/sitemap_index.xml
+curl -I https://yoursite.com/wp-sitemap.xml
+curl -I https://yoursite.com/post-sitemap.xml
+
+# Try common Next.js / Astro paths
+curl -I https://yoursite.com/server-sitemap.xml
+curl -I https://yoursite.com/sitemap-0.xml
+```
+
+Once found, pass it explicitly:
+
+```bash
+geo llms \
+  --base-url https://yoursite.com \
+  --sitemap https://yoursite.com/wp-sitemap.xml
+```
+
+**Fix — generate a sitemap:**
+
+If you have no sitemap at all, generate one first. For Astro, use `@astrojs/sitemap`. For Next.js, use `next-sitemap`. For WordPress, use the Yoast SEO plugin. For generic sites, use an online tool or [xml-sitemaps.com](https://www.xml-sitemaps.com).
+
+---
+
+## 8. `Timeout error on --url`
+
+**Cause:** The target site is slow to respond, or temporarily unreachable.
+
+> ⚠️ Note: `--verbose` is not yet implemented — it currently has no effect.
+
+**Common fixes:**
+
+```bash
+# Test if the site is reachable
+curl -I https://yoursite.com
+
+# Test from a different network or VPN if you suspect IP blocking
+# Check if the site returns 200 or a redirect chain (3xx)
+curl -L -I https://yoursite.com
+```
+
+If the site consistently times out, wait a few minutes and retry. The audit script does not cache results.
+
+---
+
+## 9. `inject failed: no <head> tag`
+
+**Cause:** The HTML file passed to `--inject` does not have a standard `</head>` closing tag, which the injector uses as the insertion point.
+
+**Fix — manual injection:**
+
+Open your HTML file and add the schema block manually, just before the closing `</head>` tag:
+
+```html
+  <!-- GEO Schema -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [...]
+  }
+  </script>
+</head>
+```
+
+Generate the schema JSON first (without `--inject`):
+
+```bash
+geo schema --type faq --faq-file faqs.json
+```
+
+Copy the output and paste it manually into your file.
+
+**Alternative:** If your file is a template (Jinja2, Twig, PHP), add the schema to the base layout where the `</head>` tag lives.
+
+---
+
+## 10. Install on Windows
+
+**Issue:** `install.sh` is a bash script and does not run natively on Windows.
+
+**Solution: Use WSL2 (Windows Subsystem for Linux)**
+
+```powershell
+# Run in PowerShell as Administrator
+wsl --install
+```
+
+After WSL2 installs and you restart:
+
+```bash
+# Inside the WSL terminal (Ubuntu by default)
+curl -sSL https://raw.githubusercontent.com/auriti-labs/geo-optimizer-skill/main/install.sh | bash
+cd ~/geo-optimizer-skill
+geo audit --url https://yoursite.com
+```
+
+WSL2 gives you a full Linux environment. Python 3.8+ is included by default in Ubuntu 20.04+.
+
+If you prefer not to use WSL2, you can run the Python scripts directly in a Windows environment:
+
+```powershell
+git clone https://github.com/auriti-labs/geo-optimizer-skill.git
+cd geo-optimizer-skill
+python -m venv .venv
+.venv\Scripts\activate
+pip install -r requirements.txt
+geo audit --url https://yoursite.com
+```
+
+Note: the `./geo` wrapper does not work on Windows. Use `python scripts\<script>.py` directly with the venv activated.


### PR DESCRIPTION
Fix: /docs/ dava 404 in produzione. I file docs/ erano fuori dal pacchetto Python installato nel Docker. Copiati in web/docs/ e aggiunto fallback path.