### PR TITLE
feat: Batch 3+4 — 8 check misti per v3.15.0

### DIFF
--- a/src/geo_optimizer/core/audit.py
+++ b/src/geo_optimizer/core/audit.py
@@ -139,11 +139,15 @@ def audit_llms_txt(base_url: str) -> LlmsTxtResult:
     h2_lines = [line for line in lines if line.startswith("## ")]
     if h2_lines:
         result.has_sections = True
+    # #247: conta sezioni H2 per Policy Intelligence
+    result.sections_count = len(h2_lines)
 
     # Check markdown links
     links = re.findall(r"\[([^\]]+)\]\(([^)]+)\)", content)
     if links:
         result.has_links = True
+    # #247: conta link per Policy Intelligence
+    result.links_count = len(links)
 
     # Check /llms-full.txt (llmstxt.org spec — optional extended version)
     full_url = urljoin(base_url, "/llms-full.txt")
@@ -248,6 +252,27 @@ def audit_schema(soup, url: str) -> SchemaResult:
             result.schema_richness_score = 1
         else:
             result.schema_richness_score = 0
+
+    # #232: E-commerce GEO Profile — analizza ricchezza Product schema
+    if result.has_product:
+        for schema_obj in result.raw_schemas:
+            schema_type = schema_obj.get("@type", "")
+            types = schema_type if isinstance(schema_type, list) else [schema_type]
+            if "Product" in types:
+                offers = schema_obj.get("offers") or schema_obj.get("offer", {})
+                if isinstance(offers, list):
+                    offers = offers[0] if offers else {}
+                result.ecommerce_signals = {
+                    "has_price": bool(offers.get("price") or offers.get("lowPrice")),
+                    "has_availability": bool(offers.get("availability")),
+                    "has_brand": bool(schema_obj.get("brand")),
+                    "has_image": bool(schema_obj.get("image")),
+                    "has_reviews": bool(schema_obj.get("aggregateRating") or schema_obj.get("review")),
+                }
+                result.ecommerce_signals["complete"] = all(
+                    result.ecommerce_signals[k] for k in result.ecommerce_signals if k != "complete"
+                )
+                break
 
     return result
 
@@ -488,14 +513,36 @@ def _audit_ai_discovery_from_responses(r_ai_txt, r_summary, r_faq, r_service) ->
     return result
 
 
-def build_recommendations(base_url, robots, llms, schema, meta, content, ai_discovery=None) -> list:
-    """Build a prioritized list of recommendations."""
+def build_recommendations(base_url, robots, llms, schema, meta, content, ai_discovery=None, signals=None) -> list:
+    """Build a prioritized list of recommendations.
+
+    Args:
+        base_url: URL base del sito.
+        robots: RobotsResult.
+        llms: LlmsTxtResult.
+        schema: SchemaResult.
+        meta: MetaResult.
+        content: ContentResult.
+        ai_discovery: AiDiscoveryResult (opzionale).
+        signals: SignalsResult (opzionale, per raccomandazioni machine-readable #263).
+    """
     recommendations = []
 
     if not robots.citation_bots_ok:
         recommendations.append("Update robots.txt to include all AI bots (GPTBot, ClaudeBot, PerplexityBot)")
     if not llms.found:
         recommendations.append(f"Create /llms.txt for AI indexing: geo llms --base-url {base_url}")
+    elif llms.found:
+        # #247: llms.txt Policy Intelligence — raccomandazioni sulla qualità del contenuto
+        if llms.sections_count == 0:
+            recommendations.append(
+                "Add H2 sections to llms.txt to organize content by topic (e.g. ## Features, ## Documentation, ## API)"
+            )
+        if llms.links_count < 3:
+            recommendations.append(
+                f"llms.txt has only {llms.links_count} links. "
+                "Add more markdown links to key pages for better AI indexing coverage."
+            )
     if not schema.has_website:
         recommendations.append("Add WebSite JSON-LD schema to homepage")
     if not schema.has_faq:
@@ -507,6 +554,13 @@ def build_recommendations(base_url, robots, llms, schema, meta, content, ai_disc
     if not content.has_links:
         recommendations.append("Cite authoritative sources with external links (increase AI credibility)")
 
+    # #263: Raccomandazioni Machine-Readable Presence (RSS + sitemap)
+    if signals is not None and not signals.has_rss:
+        recommendations.append(
+            "Add RSS/Atom feed and link it in <head> with "
+            '<link rel="alternate" type="application/rss+xml"> for AI discovery'
+        )
+
     # Raccomandazioni AI discovery (geo-checklist.dev)
     if ai_discovery is not None:
         if not ai_discovery.has_well_known_ai:
@@ -517,6 +571,16 @@ def build_recommendations(base_url, robots, llms, schema, meta, content, ai_disc
             recommendations.append("Create /ai/faq.json with structured FAQ for AI search visibility")
         if not ai_discovery.has_service:
             recommendations.append("Create /ai/service.json to describe service capabilities for AI")
+
+    # #232: Raccomandazione e-commerce se Product schema è incompleto
+    if schema.has_product and hasattr(schema, "ecommerce_signals"):
+        signals_dict = schema.ecommerce_signals
+        missing_fields = [k for k, v in signals_dict.items() if not v and k != "complete"]
+        if missing_fields:
+            recommendations.append(
+                f"Complete Product schema: missing {', '.join(missing_fields)}. "
+                "Rich Product schema improves AI shopping visibility."
+            )
 
     return recommendations
 
@@ -575,7 +639,9 @@ def _build_audit_result(
     band = get_score_band(score)
 
     # Raccomandazioni
-    recommendations = build_recommendations(base_url, robots, llms, schema, meta, content, effective_ai_discovery)
+    recommendations = build_recommendations(
+        base_url, robots, llms, schema, meta, content, effective_ai_discovery, effective_signals
+    )
 
     # Fix #104: esegui plugin registrati in CheckRegistry
     # I risultati non influenzano il punteggio base
@@ -928,10 +994,14 @@ def _audit_llms_from_response(r, r_full=None) -> LlmsTxtResult:
     h2_lines = [line for line in lines if line.startswith("## ")]
     if h2_lines:
         result.has_sections = True
+    # #247: conta sezioni H2 per Policy Intelligence
+    result.sections_count = len(h2_lines)
 
     links = re.findall(r"\[([^\]]+)\]\(([^)]+)\)", content)
     if links:
         result.has_links = True
+    # #247: conta link per Policy Intelligence
+    result.links_count = len(links)
 
     # Check /llms-full.txt — fix #184: now works in the async path too
     if r_full and r_full.status_code == 200 and len(r_full.text.strip()) > 0:

--- a/src/geo_optimizer/core/citability.py
+++ b/src/geo_optimizer/core/citability.py
@@ -1697,6 +1697,382 @@ def detect_nuance_signals(soup, clean_text: str | None = None) -> MethodScore:
     )
 
 
+# ─── 26. Snippet-Ready / Zero-Click (#249) ────────────────────────────────────
+
+# Pattern per definizioni esplicite nei primi 150 char dopo heading
+_SNIPPET_DEF_RE = re.compile(
+    r"\b(?:is|are|refers?\s+to|means?|can\s+be\s+defined\s+as"
+    r"|è|sono|si\s+riferisce\s+a|significa)\b",
+    re.IGNORECASE,
+)
+
+
+def detect_snippet_ready(soup) -> MethodScore:
+    """Detect zero-click / snippet-ready content sections.
+
+    Checks if headings are followed by concise definitions (first 150 chars)
+    or if question headings (ending with '?') have direct answers under 60 words.
+    """
+    headings = soup.find_all(["h2", "h3", "h4"])
+    if not headings:
+        return MethodScore(name="snippet_ready", label="Snippet-Ready Content", max_score=4, impact="+10%")
+
+    snippet_ready_count = 0
+
+    for heading in headings:
+        heading_text = heading.get_text(strip=True)
+        # Trova il primo paragrafo dopo il heading
+        next_p = heading.find_next("p")
+        if not next_p:
+            continue
+        p_text = next_p.get_text(strip=True)
+
+        # Pattern 1: heading con "?" → risposta diretta sotto 60 parole
+        if heading_text.endswith("?"):
+            word_count = len(p_text.split())
+            if 5 <= word_count <= 60:
+                snippet_ready_count += 1
+                continue
+
+        # Pattern 2: definizione esplicita nei primi 150 char dopo heading
+        first_150 = p_text[:150]
+        if _SNIPPET_DEF_RE.search(first_150):
+            snippet_ready_count += 1
+
+    total_headings = len(headings)
+    ratio = snippet_ready_count / total_headings if total_headings > 0 else 0
+
+    # Score proporzionale
+    if ratio >= 0.5:
+        score = 4
+    elif ratio >= 0.3:
+        score = 3
+    elif ratio >= 0.15:
+        score = 2
+    elif snippet_ready_count >= 1:
+        score = 1
+    else:
+        score = 0
+
+    return MethodScore(
+        name="snippet_ready",
+        label="Snippet-Ready Content",
+        detected=snippet_ready_count >= 1,
+        score=min(score, 4),
+        max_score=4,
+        impact="+10%",
+        details={
+            "snippet_ready_sections": snippet_ready_count,
+            "total_headings": total_headings,
+            "ratio": round(ratio, 2),
+        },
+    )
+
+
+# ─── 27. Chunk Quotability (#229) ────────────────────────────────────────────
+
+# Pattern per dati concreti in un paragrafo
+_CONCRETE_DATA_RE = re.compile(
+    r"\b\d+(?:\.\d+)?%"  # percentuali
+    r"|\$\d+"  # valute $
+    r"|€\d+"  # valute €
+    r"|\b\d{4}\b"  # anni
+    r"|\b\d+(?:\.\d+)?\s*(?:x|times|volte)\b"  # moltiplicatori
+    r"|\b\d+(?:\.\d+)?\s*(?:million|billion|miliardi|milioni)\b",  # grandi numeri
+    re.IGNORECASE,
+)
+
+
+def detect_chunk_quotability(soup) -> MethodScore:
+    """Detect quotable content chunks: self-contained paragraphs with concrete data.
+
+    For each paragraph of 50-150 words, checks if it contains concrete data
+    (numbers, percentages, dates) making it independently quotable by AI.
+    """
+    paragraphs = soup.find_all("p")
+    if not paragraphs:
+        return MethodScore(name="chunk_quotability", label="Chunk Quotability", max_score=4, impact="+10%")
+
+    candidate_count = 0
+    quotable_count = 0
+
+    for p in paragraphs:
+        text = p.get_text(strip=True)
+        word_count = len(text.split())
+        # Solo paragrafi nella fascia 50-150 parole
+        if word_count < 50 or word_count > 150:
+            continue
+        candidate_count += 1
+        # Verifica dato concreto
+        if _CONCRETE_DATA_RE.search(text):
+            quotable_count += 1
+
+    ratio = quotable_count / candidate_count if candidate_count > 0 else 0
+
+    # Score proporzionale alla % di paragrafi quotabili
+    if ratio >= 0.5:
+        score = 4
+    elif ratio >= 0.3:
+        score = 3
+    elif ratio >= 0.15:
+        score = 2
+    elif quotable_count >= 1:
+        score = 1
+    else:
+        score = 0
+
+    return MethodScore(
+        name="chunk_quotability",
+        label="Chunk Quotability",
+        detected=quotable_count >= 1,
+        score=min(score, 4),
+        max_score=4,
+        impact="+10%",
+        details={
+            "candidate_paragraphs": candidate_count,
+            "quotable_paragraphs": quotable_count,
+            "ratio": round(ratio, 2),
+        },
+    )
+
+
+# ─── 28. Blog Structure (#230) ───────────────────────────────────────────────
+
+
+def detect_blog_structure(soup) -> MethodScore:
+    """Detect blog structure signals in Article/BlogPosting schema.
+
+    Checks: datePublished/dateModified, author bio, categories/tags.
+    Only scores if Article or BlogPosting schema is present (non-blog pages get 0).
+    """
+    # Cerca schema Article o BlogPosting nel JSON-LD
+    article_schema = None
+    for script in soup.find_all("script", type="application/ld+json"):
+        try:
+            data = json.loads(script.string or "")
+            items = data if isinstance(data, list) else [data]
+            for item in items:
+                if isinstance(item, dict):
+                    schema_type = item.get("@type", "")
+                    types = schema_type if isinstance(schema_type, list) else [schema_type]
+                    if any(t in ("Article", "BlogPosting", "NewsArticle") for t in types):
+                        article_schema = item
+                        break
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if article_schema:
+            break
+
+    # Se non c'è schema Article/BlogPosting, score 0 senza penalizzare
+    if not article_schema:
+        return MethodScore(
+            name="blog_structure",
+            label="Blog Structure",
+            detected=False,
+            score=0,
+            max_score=4,
+            impact="+8%",
+            details={"has_article_schema": False},
+        )
+
+    score = 0
+    has_dates = bool(article_schema.get("datePublished") or article_schema.get("dateModified"))
+    has_author = bool(article_schema.get("author"))
+    # Cerca categorie/tag nei meta o nello schema
+    has_categories = bool(
+        article_schema.get("articleSection")
+        or article_schema.get("keywords")
+        or soup.find("meta", attrs={"property": "article:tag"})
+    )
+    # Cerca author bio nel DOM
+    author_bio = soup.find_all(
+        ["div", "section", "aside"],
+        class_=re.compile(r"author|bio|about-author|byline", re.I),
+    )
+    has_author_bio = bool(author_bio)
+
+    if has_dates:
+        score += 1
+    if has_author:
+        score += 1
+    if has_author_bio:
+        score += 1
+    if has_categories:
+        score += 1
+
+    return MethodScore(
+        name="blog_structure",
+        label="Blog Structure",
+        detected=score >= 2,
+        score=min(score, 4),
+        max_score=4,
+        impact="+8%",
+        details={
+            "has_article_schema": True,
+            "has_dates": has_dates,
+            "has_author": has_author,
+            "has_author_bio": has_author_bio,
+            "has_categories": has_categories,
+        },
+    )
+
+
+# ─── 29. AI Shopping Readiness (#277) ────────────────────────────────────────
+
+
+def detect_shopping_readiness(soup) -> MethodScore:
+    """Detect AI shopping readiness from Product schema.
+
+    Checks: Product schema with price + availability, AggregateRating, review count.
+    Only scores if Product schema is present (non-ecommerce pages get 0).
+    """
+    product_schema = None
+    for script in soup.find_all("script", type="application/ld+json"):
+        try:
+            data = json.loads(script.string or "")
+            items = data if isinstance(data, list) else [data]
+            for item in items:
+                if isinstance(item, dict):
+                    schema_type = item.get("@type", "")
+                    types = schema_type if isinstance(schema_type, list) else [schema_type]
+                    if "Product" in types:
+                        product_schema = item
+                        break
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if product_schema:
+            break
+
+    if not product_schema:
+        return MethodScore(
+            name="shopping_readiness",
+            label="AI Shopping Readiness",
+            detected=False,
+            score=0,
+            max_score=3,
+            impact="+8%",
+            details={"has_product_schema": False},
+        )
+
+    score = 0
+    # Verifica price + availability nell'offerta
+    offers = product_schema.get("offers") or product_schema.get("offer", {})
+    if isinstance(offers, list):
+        offers = offers[0] if offers else {}
+    has_price = bool(offers.get("price") or offers.get("lowPrice"))
+    has_availability = bool(offers.get("availability"))
+
+    if has_price and has_availability:
+        score += 1
+
+    # AggregateRating
+    has_rating = bool(product_schema.get("aggregateRating"))
+    if has_rating:
+        score += 1
+
+    # Review count
+    rating_data = product_schema.get("aggregateRating", {})
+    has_review_count = bool(rating_data.get("reviewCount") or rating_data.get("ratingCount"))
+    if has_review_count:
+        score += 1
+
+    return MethodScore(
+        name="shopping_readiness",
+        label="AI Shopping Readiness",
+        detected=score >= 1,
+        score=min(score, 3),
+        max_score=3,
+        impact="+8%",
+        details={
+            "has_product_schema": True,
+            "has_price": has_price,
+            "has_availability": has_availability,
+            "has_rating": has_rating,
+            "has_review_count": has_review_count,
+        },
+    )
+
+
+# ─── 30. ChatGPT Shopping Feed (#275) ────────────────────────────────────────
+
+
+def detect_chatgpt_shopping(soup) -> MethodScore:
+    """Detect ChatGPT Shopping integration signals from Product schema.
+
+    Checks required fields for ChatGPT Shopping: name, price, image, availability, brand.
+    Cannot verify chatgpt.com/merchants registration, but verifies field completeness.
+    """
+    product_schema = None
+    for script in soup.find_all("script", type="application/ld+json"):
+        try:
+            data = json.loads(script.string or "")
+            items = data if isinstance(data, list) else [data]
+            for item in items:
+                if isinstance(item, dict):
+                    schema_type = item.get("@type", "")
+                    types = schema_type if isinstance(schema_type, list) else [schema_type]
+                    if "Product" in types:
+                        product_schema = item
+                        break
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if product_schema:
+            break
+
+    if not product_schema:
+        return MethodScore(
+            name="chatgpt_shopping",
+            label="ChatGPT Shopping Feed",
+            detected=False,
+            score=0,
+            max_score=3,
+            impact="+8%",
+            details={"has_product_schema": False},
+        )
+
+    # Campi richiesti per ChatGPT Shopping
+    has_name = bool(product_schema.get("name"))
+    has_image = bool(product_schema.get("image"))
+    has_brand = bool(product_schema.get("brand"))
+
+    offers = product_schema.get("offers") or product_schema.get("offer", {})
+    if isinstance(offers, list):
+        offers = offers[0] if offers else {}
+    has_price = bool(offers.get("price") or offers.get("lowPrice"))
+    has_availability = bool(offers.get("availability"))
+
+    # Conta campi presenti su 5 richiesti
+    fields_present = sum([has_name, has_image, has_brand, has_price, has_availability])
+
+    if fields_present >= 5:
+        score = 3
+    elif fields_present >= 3:
+        score = 2
+    elif fields_present >= 1:
+        score = 1
+    else:
+        score = 0
+
+    return MethodScore(
+        name="chatgpt_shopping",
+        label="ChatGPT Shopping Feed",
+        detected=fields_present >= 3,
+        score=min(score, 3),
+        max_score=3,
+        impact="+8%",
+        details={
+            "has_product_schema": True,
+            "has_name": has_name,
+            "has_image": has_image,
+            "has_brand": has_brand,
+            "has_price": has_price,
+            "has_availability": has_availability,
+            "fields_present": fields_present,
+            "fields_required": 5,
+        },
+    )
+
+
 # ─── Orchestrator ─────────────────────────────────────────────────────────────
 
 # Suggerimenti di miglioramento per ogni metodo non rilevato
@@ -1727,6 +2103,12 @@ _IMPROVEMENT_SUGGESTIONS = {
     "no_content_decay": "Update old year references and add recent dateModified (-10%)",
     "boilerplate_ratio": "Ensure main content is >60% of page text; use <main> or <article> tags (+8%)",
     "nuance_signals": "Add nuance: 'however', 'limitations include', 'on the other hand' (+5%)",
+    # Quality Signals Batch 3+4
+    "snippet_ready": "Add snippet-ready definitions after headings: 'X is...', 'X refers to...' (+10%)",
+    "chunk_quotability": "Write self-contained paragraphs (50-150 words) with concrete data for AI quoting (+10%)",
+    "blog_structure": "Add Article/BlogPosting schema with datePublished, author, and categories (+8%)",
+    "shopping_readiness": "Add Product schema with price, availability, and AggregateRating (+8%)",
+    "chatgpt_shopping": "Complete Product schema with name, price, image, availability, brand for ChatGPT Shopping (+8%)",
 }
 
 # Ordine per impatto decrescente (escluso penalità)
@@ -1753,6 +2135,11 @@ _METHOD_ORDER = [
     "format_mix",
     "unique_words",
     "nuance_signals",
+    "snippet_ready",
+    "chunk_quotability",
+    "blog_structure",
+    "shopping_readiness",
+    "chatgpt_shopping",
     "keyword_stuffing",
     "no_negative_signals",
     "no_content_decay",
@@ -1813,6 +2200,12 @@ def audit_citability(soup, base_url: str, soup_clean=None) -> CitabilityResult:
         detect_content_decay(soup, clean_text=clean_text),
         detect_boilerplate_ratio(soup),
         detect_nuance_signals(soup, clean_text=clean_text),
+        # Quality Signals Batch 3+4 (bonus — cappati a 100 dal totale)
+        detect_snippet_ready(soup),
+        detect_chunk_quotability(soup),
+        detect_blog_structure(soup),
+        detect_shopping_readiness(soup),
+        detect_chatgpt_shopping(soup),
     ]
 
     # Somma score (max possibile = 100)

--- a/src/geo_optimizer/models/results.py
+++ b/src/geo_optimizer/models/results.py
@@ -56,6 +56,9 @@ class LlmsTxtResult:
     has_links: bool = False
     word_count: int = 0
     has_full: bool = False  # /llms-full.txt present
+    # #247: llms.txt Policy Intelligence — analisi contenuto
+    sections_count: int = 0
+    links_count: int = 0
 
 
 # ─── Schema JSON-LD ──────────────────────────────────────────────────────────
@@ -80,6 +83,8 @@ class SchemaResult:
     # Schema richness (Growth Marshal Feb 2026): schema con 5+ attributi rilevanti
     schema_richness_score: int = 0
     avg_attributes_per_schema: float = 0.0
+    # #232: E-commerce GEO Profile — analisi ricchezza Product schema
+    ecommerce_signals: dict = field(default_factory=dict)
 
 
 # ─── Meta tags ───────────────────────────────────────────────────────────────

--- a/tests/test_citability.py
+++ b/tests/test_citability.py
@@ -13,7 +13,10 @@ from geo_optimizer.core.citability import (
     audit_citability,
     detect_attribution,
     detect_authoritative_tone,
+    detect_blog_structure,
     detect_boilerplate_ratio,
+    detect_chatgpt_shopping,
+    detect_chunk_quotability,
     detect_citability_density,
     detect_cite_sources,
     detect_comparison_content,
@@ -31,6 +34,8 @@ from geo_optimizer.core.citability import (
     detect_nuance_signals,
     detect_quotations,
     detect_readability,
+    detect_shopping_readiness,
+    detect_snippet_ready,
     detect_statistics,
     detect_technical_terms,
     detect_unique_words,
@@ -852,6 +857,214 @@ class TestNuanceSignals:
 
 
 # ============================================================================
+# TEST: Snippet-Ready Content (#249)
+# ============================================================================
+
+
+class TestSnippetReady:
+    def test_definizione_dopo_heading(self):
+        html = """
+        <html><body>
+            <h2>What is GEO?</h2>
+            <p>GEO is the practice of optimizing content for AI search engines.</p>
+            <h2>Key Benefits</h2>
+            <p>SEO refers to traditional search optimization techniques.</p>
+            <h3>Details</h3>
+            <p>Some additional context here without definition.</p>
+        </body></html>
+        """
+        result = detect_snippet_ready(_soup(html))
+        assert result.detected is True
+        assert result.details["snippet_ready_sections"] >= 2
+        assert result.score > 0
+
+    def test_domanda_con_risposta_breve(self):
+        html = """
+        <html><body>
+            <h2>How does it work?</h2>
+            <p>It works by analyzing structured data and content signals.</p>
+        </body></html>
+        """
+        result = detect_snippet_ready(_soup(html))
+        assert result.detected is True
+        assert result.details["snippet_ready_sections"] >= 1
+
+    def test_nessun_heading(self):
+        html = "<html><body><p>Solo testo.</p></body></html>"
+        result = detect_snippet_ready(_soup(html))
+        assert result.detected is False
+        assert result.score == 0
+
+
+# ============================================================================
+# TEST: Chunk Quotability (#229)
+# ============================================================================
+
+
+class TestChunkQuotability:
+    def test_paragrafi_quotabili(self):
+        # Paragrafo di ~60 parole con dato concreto
+        words = " ".join(["word"] * 55)
+        html = f"""
+        <html><body>
+            <p>In 2024 the market grew by 35% reaching $82 billion.
+            {words} This represents a significant shift.</p>
+            <p>{words} The growth rate was 25% year over year with data backing it up.</p>
+        </body></html>
+        """
+        result = detect_chunk_quotability(_soup(html))
+        assert result.detected is True
+        assert result.details["quotable_paragraphs"] >= 1
+
+    def test_paragrafi_troppo_corti(self):
+        html = """
+        <html><body>
+            <p>Short text.</p>
+            <p>Another short one.</p>
+        </body></html>
+        """
+        result = detect_chunk_quotability(_soup(html))
+        assert result.detected is False
+        assert result.details["candidate_paragraphs"] == 0
+
+
+# ============================================================================
+# TEST: Blog Structure (#230)
+# ============================================================================
+
+
+class TestBlogStructure:
+    def test_blog_completo(self):
+        html = """
+        <html><body>
+            <script type="application/ld+json">
+            {
+                "@type": "BlogPosting",
+                "datePublished": "2025-01-15",
+                "dateModified": "2025-03-01",
+                "author": {"@type": "Person", "name": "Juan"},
+                "articleSection": "SEO",
+                "keywords": ["GEO", "AI"]
+            }
+            </script>
+            <div class="author-bio">Juan — 15 years WordPress developer</div>
+            <p>Contenuto del blog.</p>
+        </body></html>
+        """
+        result = detect_blog_structure(_soup(html))
+        assert result.detected is True
+        assert result.details["has_article_schema"] is True
+        assert result.details["has_dates"] is True
+        assert result.details["has_author"] is True
+        assert result.score >= 3
+
+    def test_nessun_schema_article(self):
+        html = """
+        <html><body>
+            <script type="application/ld+json">
+            {"@type": "WebSite", "name": "Example"}
+            </script>
+            <p>Non è un blog.</p>
+        </body></html>
+        """
+        result = detect_blog_structure(_soup(html))
+        assert result.detected is False
+        assert result.score == 0
+        assert result.details["has_article_schema"] is False
+
+
+# ============================================================================
+# TEST: AI Shopping Readiness (#277)
+# ============================================================================
+
+
+class TestShoppingReadiness:
+    def test_product_completo(self):
+        html = """
+        <html><body>
+            <script type="application/ld+json">
+            {
+                "@type": "Product",
+                "name": "GEO Optimizer Pro",
+                "offers": {
+                    "price": "99.00",
+                    "availability": "https://schema.org/InStock"
+                },
+                "aggregateRating": {
+                    "ratingValue": "4.8",
+                    "reviewCount": "150"
+                }
+            }
+            </script>
+        </body></html>
+        """
+        result = detect_shopping_readiness(_soup(html))
+        assert result.detected is True
+        assert result.score == 3
+        assert result.details["has_price"] is True
+        assert result.details["has_availability"] is True
+        assert result.details["has_review_count"] is True
+
+    def test_nessun_product_schema(self):
+        html = "<html><body><p>Nessun prodotto.</p></body></html>"
+        result = detect_shopping_readiness(_soup(html))
+        assert result.detected is False
+        assert result.score == 0
+        assert result.details["has_product_schema"] is False
+
+
+# ============================================================================
+# TEST: ChatGPT Shopping Feed (#275)
+# ============================================================================
+
+
+class TestChatgptShopping:
+    def test_product_completo_chatgpt(self):
+        html = """
+        <html><body>
+            <script type="application/ld+json">
+            {
+                "@type": "Product",
+                "name": "GEO Optimizer Pro",
+                "image": "https://example.com/img.jpg",
+                "brand": {"@type": "Brand", "name": "Auriti Labs"},
+                "offers": {
+                    "price": "99.00",
+                    "availability": "https://schema.org/InStock"
+                }
+            }
+            </script>
+        </body></html>
+        """
+        result = detect_chatgpt_shopping(_soup(html))
+        assert result.detected is True
+        assert result.score == 3
+        assert result.details["fields_present"] == 5
+
+    def test_product_parziale(self):
+        html = """
+        <html><body>
+            <script type="application/ld+json">
+            {
+                "@type": "Product",
+                "name": "GEO Optimizer",
+                "offers": {"price": "49.00"}
+            }
+            </script>
+        </body></html>
+        """
+        result = detect_chatgpt_shopping(_soup(html))
+        assert result.detected is False
+        assert result.details["fields_present"] == 2
+
+    def test_nessun_product(self):
+        html = "<html><body><p>No product.</p></body></html>"
+        result = detect_chatgpt_shopping(_soup(html))
+        assert result.detected is False
+        assert result.score == 0
+
+
+# ============================================================================
 # TEST: Somma pesi = 100 + bonus
 # ============================================================================
 
@@ -861,9 +1074,9 @@ class TestWeightSum:
         """Verifica che i 18 metodi base sommano 100, i 7 bonus aggiungono 31."""
         html = "<html><body><p>Test content.</p></body></html>"
         result = audit_citability(_soup(html), "https://example.com")
-        # 18 metodi base = 100, 7 bonus = 31, totale max_score = 131
+        # 18 metodi base = 100, 7 bonus batch2 = 31, 5 bonus batch3+4 = 18, totale = 149
         total_max = sum(m.max_score for m in result.methods)
-        assert total_max == 131, f"Somma max_score = {total_max}, atteso 131 (100 base + 31 bonus)"
+        assert total_max == 149, f"Somma max_score = {total_max}, atteso 149 (100 base + 31 batch2 + 18 batch3+4)"
         # Ma il total_score è sempre cappato a 100
         assert result.total_score <= 100
 
@@ -913,7 +1126,7 @@ class TestAuditCitability:
 
         assert result.total_score > 0
         assert result.grade in ("low", "medium", "high", "excellent")
-        assert len(result.methods) == 25
+        assert len(result.methods) == 30
 
         # Verifica che ogni metodo abbia un nome
         names = {m.name for m in result.methods}
@@ -937,11 +1150,17 @@ class TestAuditCitability:
         assert "no_content_decay" in names
         assert "boilerplate_ratio" in names
         assert "nuance_signals" in names
+        # Quality Signals Batch 3+4
+        assert "snippet_ready" in names
+        assert "chunk_quotability" in names
+        assert "blog_structure" in names
+        assert "shopping_readiness" in names
+        assert "chatgpt_shopping" in names
 
     def test_pagina_vuota(self):
         result = audit_citability(_soup("<html><body></body></html>"), "https://example.com")
         assert result.total_score >= 0
-        assert len(result.methods) == 25
+        assert len(result.methods) == 30
 
     def test_top_improvements_generate(self):
         result = audit_citability(_soup("<html><body><p>Testo semplice.</p></body></html>"), "https://example.com")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1377,7 +1377,7 @@ class TestBuildRecommendations:
         recs = build_recommendations(
             "https://example.com",
             RobotsResult(citation_bots_ok=True),
-            LlmsTxtResult(found=True),
+            LlmsTxtResult(found=True, has_sections=True, sections_count=3, has_links=True, links_count=5),
             SchemaResult(has_website=True, has_faq=True),
             MetaResult(has_description=True),
             ContentResult(has_numbers=True, has_links=True),

--- a/tests/test_ricerca_2025_2026.py
+++ b/tests/test_ricerca_2025_2026.py
@@ -284,17 +284,17 @@ class TestOverOptimization:
 
 class TestPesiCitability:
     def test_max_score_totale_100(self):
-        """I 18 metodi base sommano 100, i 7 bonus (Batch 2) aggiungono 31 = 131."""
+        """I 18 metodi base sommano 100, i 7 bonus batch2 aggiungono 31, i 5 bonus batch3+4 aggiungono 18 = 149."""
         html = "<html><body><p>Test content.</p></body></html>"
         result = audit_citability(_soup(html), "https://example.com")
         total_max = sum(m.max_score for m in result.methods)
-        assert total_max == 131, f"Max totale citability: {total_max}, atteso 131 (100 base + 31 bonus)"
+        assert total_max == 149, f"Max totale citability: {total_max}, atteso 149 (100 base + 31 batch2 + 18 batch3+4)"
 
     def test_metodi_sono_25(self):
-        """Devono esserci 25 metodi (18 base + 7 Quality Signals Batch 2)."""
+        """Devono esserci 30 metodi (18 base + 7 Batch 2 + 5 Batch 3+4)."""
         html = "<html><body><p>Test.</p></body></html>"
         result = audit_citability(_soup(html), "https://example.com")
-        assert len(result.methods) == 25
+        assert len(result.methods) == 30
 
     def test_nomi_nuovi_metodi_presenti(self):
         """I nuovi metodi answer_first e passage_density devono essere presenti."""


### PR DESCRIPTION
## Cosa fa questa PR

Implementa gli ultimi 8 check della roadmap v3.15.0 (Batch 3+4).

### Citability — 5 nuovi check bonus

| Check | Issue | max_score | Impact |
|-------|-------|-----------|--------|
| `snippet_ready` | #249 | 4 | +10% |
| `chunk_quotability` | #229 | 4 | +10% |
| `blog_structure` | #230 | 4 | +8% |
| `shopping_readiness` | #277 | 3 | +8% |
| `chatgpt_shopping` | #275 | 3 | +8% |

Tutti bonus — il totale citability resta cappato a 100.

### Audit infra — 3 miglioramenti

- **Machine-Readable Presence** (#263): raccomandazione RSS feed in `build_recommendations()`
- **llms.txt Policy Intelligence** (#247): analisi contenuto con `sections_count` e `links_count` + raccomandazioni qualità
- **E-commerce GEO Profile** (#232): `ecommerce_signals` dict in `SchemaResult` + raccomandazione Product incompleto

### Test
- 760 passati, 0 falliti
- Lint: ruff check + format puliti

Closes #229, Closes #230, Closes #232, Closes #247, Closes #249, Closes #263, Closes #275, Closes #277