### PR TITLE
fix: avoid perfect coherence score without analysis

### DIFF
--- a/src/geo_optimizer/core/site_coherence.py
+++ b/src/geo_optimizer/core/site_coherence.py
@@ -36,7 +36,7 @@ def run_site_coherence(
     """
     entries = fetch_sitemap(sitemap_url)
     if not entries:
-        return SemanticCoherenceResult(checked=True)
+        return SemanticCoherenceResult(checked=True, pages_analyzed=0, coherence_score=0)
 
     urls = _dedupe_urls(entries, max_pages)
     extracts = _fetch_and_extract(urls)
@@ -51,7 +51,7 @@ async def run_site_coherence_async(
     """Async variant with parallel page fetching."""
     entries = await asyncio.to_thread(fetch_sitemap, sitemap_url)
     if not entries:
-        return SemanticCoherenceResult(checked=True)
+        return SemanticCoherenceResult(checked=True, pages_analyzed=0, coherence_score=0)
 
     urls = _dedupe_urls(entries, max_pages)
 

--- a/tests/test_coherence.py
+++ b/tests/test_coherence.py
@@ -133,6 +133,7 @@ class TestSiteCoherenceOrchestrator:
         # Assert
         assert result.checked is True
         assert result.pages_analyzed == 0
+        assert result.coherence_score == 0
 
     def test_run_site_coherence_with_realistic_sitemap(self):
         # Arrange


### PR DESCRIPTION
## Summary

This PR prevents the site coherence analysis from returning a perfect `coherence_score=100` when no sitemap entries are available and no pages are actually analyzed.

## Problem

Previously, `run_site_coherence()` and `run_site_coherence_async()` returned `SemanticCoherenceResult(checked=True)` for empty sitemap results.

Because `SemanticCoherenceResult` defaults to `coherence_score=100`, an empty or non-analyzable sitemap could appear as a perfect semantic coherence result.

## Change

When the sitemap contains no entries, the result now explicitly returns:

- `checked=True`
- `pages_analyzed=0`
- `coherence_score=0`

This avoids presenting an unverified result as perfect.

## Validation

Executed successfully:

```bash
pytest tests/test_coherence.py -v
pytest tests/test_coherence.py --cov=geo_optimizer.core.site_coherence --cov-report=term-missing
pytest tests/ -v --tb=short
ruff check src/geo_optimizer/core/site_coherence.py tests/test_coherence.py
ruff format src/geo_optimizer/core/site_coherence.py tests/test_coherence.py --check
mypy src/geo_optimizer/
git diff --check
```

## Test Results

- **pytest test_coherence.py**: 19 passed ✅
- **coverage site_coherence.py**: 98% ✅
- **pytest full suite**: 1449 passed ✅
- **mypy**: Success ✅
- **ruff check/format**: passed ✅
- **git diff --check**: clean ✅
