### PR TITLE
Release v4.10.3: scoring penalties, robots freshness signals, and CLI hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ Format: [Keep a Changelog](https://keepachangelog.com/) · [SemVer](https://semv
 
 ---
 
+## [4.10.3] — 2026-05-10
+
+### Added
+- **Negative-Signal Penalty Framework** — GEO score now decreases when negative signals are detected: `X-Robots-Tag` headers restricting AI bots, `noai` / `noimageai` meta directives, and excessively high `Crawl-delay` values.
+- **Crawl-Delay Parsing** — `robots.txt` parser now recognizes the `Crawl-delay` directive per RFC 9309-style user-agent blocks.
+- **Freshness-Aware URL Ordering** — `llms.txt` generator uses sitemap `changefreq` and crawl-delay context to prioritize fresher pages.
+- **X-Robots-Tag Detection** — audit pipeline inspects HTTP response headers for bot-specific disallow or noindex rules.
+- **noai / noimageai Detection** — scans `<meta>` tags for AI-exclusion directives and records them as explicit negative signals.
+- **Schema Completeness** — validates required schema properties (`@context`, `@type`, `url`) and surfaces missing fields in audit results.
+- **Brand Sentiment Wiring** — recommendation priority now factors in brand-entity sentiment scores.
+- **Priority-Aware Batch Processing** — when URL lists exceed the batch limit, selection is prioritized by freshness, brand weight, and score impact instead of FIFO.
+- **SARIF & JUnit Enrichment** — SARIF output includes `signals` properties per rule; JUnit reports expose `ai_discovery` custom properties.
+- **CLI Input Validation** — `--threshold` enforces `[0, 100]` range; `--retention-days` rejects non-positive integers.
+- **i18n Guardrail** — `--lang` emits a warning when used before the full i18n subsystem is active.
+
+### Changed
+- **Config Centralization** — magic numbers, timeouts, score weights, and bot display strings moved to named constants in `models/config.py`.
+- **Type Annotations** — added across `core/` modules; fixed module-level logger names; added `__all__` to subpackages.
+
+### Fixed
+- `brand_entity` max-score calculation now correctly reflects the adjusted ceiling after penalties are applied.
+- SARIF serialization edge case where `brand_entity` max-score was emitted as a string instead of a float.
+
+### Tests
+- Expanded edge-case coverage for `soup=None` in schema validators and `FileCache` eviction logic.
+- Full suite validated across supported Python versions through CI.
+
+### Notes
+- No breaking CLI changes.
+- Existing audits may return slightly lower scores if previously ignored negative signals are now present — this is intentional and improves accuracy.
+
+---
 
 ## [4.10.1] — 2026-05-05
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "geo-optimizer-skill"
-version = "4.10.2"
+version = "4.10.3"
 description = "Generative Engine Optimization toolkit — make websites visible to AI search engines"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary

This release significantly deepens the GEO audit engine and hardens the CLI layer. Key themes:
- **Scoring**: a penalty framework for negative GEO signals (e.g., high Crawl-delay, blocking directives) now reduces the final score rather than only logging.
- **Robots / Crawl freshness**: robots.txt Crawl-delay is parsed, evaluated, and surfaced as both an audit signal and a freshness input for llms.txt URL ordering.
- **Audit depth**: detection of X-Robots-Tag HTTP headers, noai / noimageai meta directives, schema completeness checks, and brand-sentiment wiring in recommendations.
- **Reporting**: SARIF and JUnit outputs now include signals and ai_discovery fields; batch processing warns on truncation and selects URLs by priority.
- **CLI / Quality**: input range validation on --threshold and --retention-days, warning on premature --lang usage, plus type annotations and config centralization.

## Detailed Changes

### 1. Scoring — Negative-Signal Penalty Framework
**Commit:** 2bf6ba9

- Introduces a dedicated penalty path in core/audit.py (and models) that subtracts weighted demerits from the GEO score when negative signals are detected.
- Penalties currently trigger on:
  - X-Robots-Tag headers that restrict AI bots.
  - <meta name="robots" content="noai"> / noimageai directives.
  - Excessively high Crawl-delay values.
- Fixes the brand_entity max-score calculation so it correctly reflects the adjusted ceiling after penalties are applied.

### 2. Robots — Crawl-Delay Parsing & Freshness Signals
**Commits:** bd2daed, cdd700f, 68f8bcb

- utils/robots_parser.py now parses the non-standard but widely used Crawl-delay directive per RFC 9309-style user-agent blocks.
- core/audit.py evaluates Crawl-delay:
  - Values above a configurable threshold generate a high-priority recommendation.
  - The delay is fed into the GEO score penalty system.
- core/llms_generator.py leverages changefreq from sitemaps (and Crawl-delay context) to reorder URLs in llms.txt so fresher / more frequently updated pages appear earlier.

### 3. Audit — Header, Meta, and Schema Depth
**Commits:** 5697480, 68f8bcb, b26eb60

- **X-Robots-Tag detection**: checks HTTP response headers for bot-specific Disallow or noindex rules that override robots.txt.
- **noai / noimageai detection**: scans <meta> tags for AI-exclusion directives and records them as explicit negative signals.
- **Schema completeness**: validates that injected or existing schema graphs contain required properties (e.g., @context, @type, url) and surfaces missing fields in the audit result.
- **Brand sentiment wiring**: recommendation priority now factors in brand-entity sentiment scores, elevating fixes that protect brand visibility in AI citations.

### 4. Batch Processing — Priority & Truncation
**Commit:** 28c9bc6

- When the URL list exceeds the batch limit, the selector now picks by priority ( freshness + brand weight + score impact ) instead of simple FIFO.
- Emits a clear CLI warning when truncation occurs, including the count of dropped URLs and their domain distribution.

### 5. CI / Reporting — SARIF & JUnit Enrichment
**Commit:** b26eb60

- SARIF output includes a new signals property under properties for each rule, encoding the negative/positive signals that contributed to the result.
- JUnit XML reports expose ai_discovery as a custom property on test cases, improving downstream dashboard ingestion.
- Fixes an edge case where brand_entity max-score was serialized as a string instead of a float in SARIF.

### 6. CLI — Input Validation & i18n Guardrails
**Commits:** e76842d, 4b68fe2

- --threshold now rejects values outside [0, 100] with a clear error message.
- --retention-days rejects non-positive integers.
- --lang emits a warning when used before the full i18n subsystem is active, preventing false expectations about localized output.

### 7. Code Quality & Maintainability
**Commits:** a341724, e446750, cbcc503

- Centralizes magic numbers (timeouts, score weights, default retention) and bot display strings into models/config.py as named constants.
- Adds type annotations across core/ modules, fixes module-level logger names, and adds __all__ to subpackages for cleaner imports.
- Expands test coverage:
  - soup=None edge cases in schema validators.
  - FileCache eviction logic under memory pressure.

## Test Plan

- [x] python -m pytest tests/ -v — full suite passes.
- [x] flake8 src/geo_optimizer/ scripts/ --max-line-length=120 — clean.
- [x] Manual CLI checks:
  - geo audit --url https://example.com with a site returning X-Robots-Tag: noai → score reduced and recommendation surfaced.
  - geo llms --base-url https://example.com with mixed changefreq values → freshness-based ordering confirmed.
  - geo audit --threshold 105 → immediate validation error.
- [x] SARIF / JUnit round-trip validation via tests/test_reporters.py.

## Migration & Operational Notes

- **No breaking CLI changes** — all new flags are additive or validations are tightened only on invalid input.
- **Score drift**: existing audits may return slightly lower scores if the target site carries previously ignored negative signals (this is intentional and improves accuracy).
- **Config constants**: downstream forks that previously patched magic numbers inline will need to update patches to point to models/config.py.

## Commits since v4.10.2

| Commit | Scope | Description |
|---|---|---|
| a341724 | config | centralize magic numbers and bot display strings |
| e446750 | core | add type annotations, fix module logger, __all__ |
| e76842d | cli | enforce input range validation |
| cbcc503 | test | edge case coverage for soup=None and FileCache |
| 2bf6ba9 | scoring | add negative-signal penalty framework |
| 5697480 | audit | detect X-Robots-Tag, noai, schema completeness |
| 28c9bc6 | batch | priority-aware URL selection and truncation warning |
| b26eb60 | ci | add signals / ai_discovery to SARIF/JUnit; fix brand_entity max-score |
| 68f8bcb | audit | prioritize recommendations, high Crawl-delay, brand sentiment |
| bd2daed | robots | parse Crawl-delay directive |
| cdd700f | llms | parse changefreq for freshness-aware ordering |
| 4b68fe2 | cli | emit warning when --lang is used before i18n is active |