### PR TITLE
fix(scoring): realign Google AI per-platform lens

### DIFF
--- a/src/geo_optimizer/core/audit.py
+++ b/src/geo_optimizer/core/audit.py
@@ -592,6 +592,7 @@ def _build_audit_result(
             citability=citability,
             signals=effective_signals,
             ai_discovery=effective_ai_discovery,
+            js_rendering=effective_js,
         )
 
     return result

--- a/src/geo_optimizer/core/audit_platform.py
+++ b/src/geo_optimizer/core/audit_platform.py
@@ -16,6 +16,7 @@ from geo_optimizer.models.results import (
     AiDiscoveryResult,
     CitabilityResult,
     ContentResult,
+    JsRenderingResult,
     LlmsTxtResult,
     MetaResult,
     PlatformCitationResult,
@@ -35,6 +36,7 @@ def audit_platform_citation(
     citability: CitabilityResult,
     signals: SignalsResult | None = None,
     ai_discovery: AiDiscoveryResult | None = None,
+    js_rendering: JsRenderingResult | None = None,
 ) -> PlatformCitationResult:
     """Compute per-platform citation readiness scores.
 
@@ -45,7 +47,7 @@ def audit_platform_citation(
         platforms=[
             _score_chatgpt(robots, llms, content, citability, schema),
             _score_perplexity(robots, llms, content, citability, signals),
-            _score_google_ai(robots, schema, meta, content, citability, ai_discovery),
+            _score_google_ai(robots, schema, meta, content, citability, signals, js_rendering),
         ],
     )
 
@@ -168,8 +170,13 @@ def _score_perplexity(robots, llms, content, citability, signals) -> PlatformSco
     return PlatformScore(platform="perplexity", score=min(score, 100), strengths=strengths, recommendations=recs)
 
 
-def _score_google_ai(robots, schema, meta, content, citability, ai_discovery) -> PlatformScore:
-    """Google AI Overviews favors: schema, domain authority, traditional SEO."""
+def _score_google_ai(robots, schema, meta, content, citability, signals=None, js_rendering=None) -> PlatformScore:
+    """Google AI Overviews favors: indexable HTML, structured data, traditional SEO, freshness.
+
+    Per Google's AI optimization guide, machine-readable AI files (llms.txt,
+    .well-known/ai.txt) are NOT used by Google AI. We score crawlable/SSR content,
+    schema, meta, freshness, and image quality instead.
+    """
     score = 0
     strengths: list[str] = []
     recs: list[str] = []
@@ -215,12 +222,27 @@ def _score_google_ai(robots, schema, meta, content, citability, ai_discovery) ->
         score += 10
         strengths.append("Quality content structure")
 
-    # AI discovery endpoints
-    if ai_discovery and ai_discovery.has_well_known_ai:
-        score += 10
-        strengths.append("AI discovery endpoints present")
+    # Freshness (Google values recently-updated content)
+    if signals and signals.has_freshness:
+        score += 4
+        strengths.append("Content freshness signals present")
     else:
-        recs.append("Add /.well-known/ai.txt for AI discovery")
+        recs.append("Add dateModified / lastmod freshness signals")
+
+    # SSR-safe content (Google AI needs crawlable HTML, not JS-only)
+    if js_rendering and js_rendering.checked and not js_rendering.js_dependent:
+        score += 3
+        strengths.append("Content available without JS (SSR-safe)")
+    elif js_rendering and js_rendering.checked and js_rendering.js_dependent:
+        recs.append("Serve content server-side; Google AI may not execute your JS")
+
+    # Image alt quality (Google surfaces images in AI results)
+    img_alt = next((m for m in citability.methods if m.name == "image_alt_quality"), None)
+    if img_alt and img_alt.detected:
+        score += 3
+        strengths.append("Descriptive image alt text")
+    elif img_alt and not img_alt.detected:
+        recs.append("Add descriptive alt text to images")
 
     # sameAs links (domain authority proxy)
     if schema.has_sameas:

--- a/tests/test_platform_citation.py
+++ b/tests/test_platform_citation.py
@@ -4,14 +4,22 @@ from __future__ import annotations
 
 from geo_optimizer.core.audit_platform import audit_platform_citation
 from geo_optimizer.models.results import (
+    AiDiscoveryResult,
     CitabilityResult,
     ContentResult,
+    JsRenderingResult,
     LlmsTxtResult,
     MetaResult,
+    MethodScore,
     RobotsResult,
     SchemaResult,
     SignalsResult,
 )
+
+
+def _google_ai(result):
+    """Extract the google_ai PlatformScore from a result."""
+    return next(p for p in result.platforms if p.platform == "google_ai")
 
 
 def _defaults(**overrides):
@@ -83,6 +91,103 @@ class TestPlatformCitation:
         result = audit_platform_citation(**_defaults())
         for p in result.platforms:
             assert len(p.recommendations) > 0
+
+    def test_backward_compat_without_js_rendering_kwarg(self):
+        # Calling without js_rendering must not raise (default None).
+        result = audit_platform_citation(**_defaults())
+        assert _google_ai(result) is not None
+
+
+class TestGoogleAiRealign:
+    """Google AI lens aligned to Google's AI optimization guide (#realign)."""
+
+    def test_well_known_ai_does_not_affect_google_ai_score(self):
+        # Google does NOT use .well-known/ai.txt — toggling it must not move the score.
+        with_ai = audit_platform_citation(
+            **_defaults(), ai_discovery=AiDiscoveryResult(has_well_known_ai=True)
+        )
+        without_ai = audit_platform_citation(
+            **_defaults(), ai_discovery=AiDiscoveryResult(has_well_known_ai=False)
+        )
+        assert _google_ai(with_ai).score == _google_ai(without_ai).score
+
+    def test_no_ai_txt_recommendation_for_google_ai(self):
+        result = audit_platform_citation(
+            **_defaults(), ai_discovery=AiDiscoveryResult(has_well_known_ai=False)
+        )
+        recs = " ".join(_google_ai(result).recommendations).lower()
+        assert "ai.txt" not in recs
+        assert ".well-known" not in recs
+
+    def test_freshness_boosts_google_ai_by_4(self):
+        fresh = audit_platform_citation(**_defaults(signals=SignalsResult(has_freshness=True)))
+        stale = audit_platform_citation(**_defaults(signals=SignalsResult(has_freshness=False)))
+        assert _google_ai(fresh).score - _google_ai(stale).score == 4
+
+    def test_ssr_safe_content_boosts_google_ai_by_3(self):
+        ssr = audit_platform_citation(
+            **_defaults(), js_rendering=JsRenderingResult(checked=True, js_dependent=False)
+        )
+        js_only = audit_platform_citation(
+            **_defaults(), js_rendering=JsRenderingResult(checked=True, js_dependent=True)
+        )
+        assert _google_ai(ssr).score - _google_ai(js_only).score == 3
+
+    def test_js_dependent_content_gets_ssr_recommendation(self):
+        result = audit_platform_citation(
+            **_defaults(), js_rendering=JsRenderingResult(checked=True, js_dependent=True)
+        )
+        recs = " ".join(_google_ai(result).recommendations).lower()
+        assert "server-side" in recs or "server side" in recs
+
+    def test_image_alt_quality_boosts_google_ai_by_3(self):
+        good = CitabilityResult(
+            total_score=10,
+            methods=[MethodScore(name="image_alt_quality", label="Image alt", detected=True, score=5, max_score=5)],
+        )
+        bad = CitabilityResult(
+            total_score=10,
+            methods=[MethodScore(name="image_alt_quality", label="Image alt", detected=False, score=0, max_score=5)],
+        )
+        r_good = audit_platform_citation(**_defaults(citability=good))
+        r_bad = audit_platform_citation(**_defaults(citability=bad))
+        assert _google_ai(r_good).score - _google_ai(r_bad).score == 3
+
+    def test_missing_image_alt_recommendation(self):
+        bad = CitabilityResult(
+            total_score=10,
+            methods=[MethodScore(name="image_alt_quality", label="Image alt", detected=False, score=0, max_score=5)],
+        )
+        result = audit_platform_citation(**_defaults(citability=bad))
+        recs = " ".join(_google_ai(result).recommendations).lower()
+        assert "alt text" in recs
+
+    def test_google_ai_score_capped_at_100(self):
+        result = audit_platform_citation(
+            robots=RobotsResult(bots_allowed=["Google-Extended"]),
+            llms=LlmsTxtResult(),
+            schema=SchemaResult(any_schema_found=True, schema_richness_score=6, has_sameas=True),
+            meta=MetaResult(
+                has_title=True, has_description=True, has_canonical=True, has_og_title=True, has_og_description=True
+            ),
+            content=ContentResult(has_h1=True, word_count=600),
+            citability=CitabilityResult(
+                total_score=90,
+                methods=[MethodScore(name="image_alt_quality", label="Image alt", detected=True, score=5, max_score=5)],
+            ),
+            signals=SignalsResult(has_freshness=True),
+            js_rendering=JsRenderingResult(checked=True, js_dependent=False),
+        )
+        assert _google_ai(result).score <= 100
+
+    def test_chatgpt_perplexity_unchanged_by_realign(self):
+        # llms.txt remains valid outside Google — other lenses still reward it.
+        llms_with = LlmsTxtResult(found=True, has_links=True)
+        result = audit_platform_citation(**_defaults(llms=llms_with))
+        chatgpt = next(p for p in result.platforms if p.platform == "chatgpt")
+        perp = next(p for p in result.platforms if p.platform == "perplexity")
+        assert any("llms.txt" in s.lower() for s in chatgpt.strengths)
+        assert any("llms.txt" in s.lower() for s in perp.strengths)
 
     def test_strengths_present_for_optimized_site(self):
         result = audit_platform_citation(


### PR DESCRIPTION
## Summary

Realigns the per-platform **Google AI** citation lens (`_score_google_ai`) to Google's official [AI optimization guide](https://developers.google.com/search/docs/fundamentals/ai-optimization-guide). The guide explicitly states that machine-readable AI files (`.well-known/ai.txt`, `llms.txt`) are **not** used by Google AI (AI Overviews / AI Mode). The previous lens both rewarded and recommended `.well-known/ai.txt`, contradicting Google.

## Changes

### `.well-known/ai.txt` no longer a Google AI factor
Removed from `_score_google_ai`:
- the `+10` reward gated on `ai_discovery.has_well_known_ai`
- the recommendation `"Add /.well-known/ai.txt for AI discovery"`

### 10pt redistribution to Google-confirmed signals
The freed 10 points go to signals Google's guide actually endorses:

| Signal | Points | Gate |
|---|---|---|
| Content freshness | **+4** | `signals.has_freshness` |
| SSR-safe / no-JS-only content | **+3** | `js_rendering.checked and not js_rendering.js_dependent` |
| Descriptive image alt quality | **+3** | `citability.methods` entry `name=="image_alt_quality"` with `.detected` |

Each adds an aligned recommendation when the signal is absent (freshness / server-side rendering / alt text), replacing the removed ai.txt rec.

`audit_platform_citation` gains a `js_rendering: JsRenderingResult | None = None` param (default `None`, backward-compatible) passed through from the audit call site.

## Compatibility

- **Core 100pt score unchanged** — no SCORING weight touched.
- **`score_breakdown` unchanged.**
- **ChatGPT and Perplexity lenses unchanged** — `_score_chatgpt` / `_score_perplexity` bodies untouched; `llms.txt` remains a valid signal for them.
- **Gate / alert / monitoring / historical score interpretation unaffected** — only `platform_citation.google_ai` changes.
- Calling `audit_platform_citation` without `js_rendering` still works.

## Test plan

- [x] `pytest tests/test_platform_citation.py -v` → **18 passed** (incl. new `TestGoogleAiRealign`: well_known no-op, no ai.txt rec, freshness ±4, SSR ±3 + rec, image-alt ±3 + rec, cap ≤100, chatgpt/perplexity invariants, backward-compat without kwarg)
- [x] `pytest tests/ -q` → **1541 passed** (zero regressions)

## Release note

- **No version bump** in this PR.
- **No PyPI publish** in this PR.
- Version bump (→ 4.11.2), changelog, tag and release are **deferred to a separate explicit approval**.