### PR TITLE
fix(web): emit 301 instead of 307 for trailing-slash redirects

### DIFF
--- a/src/geo_optimizer/web/app.py
+++ b/src/geo_optimizer/web/app.py
@@ -22,6 +22,7 @@ import secrets
 import time
 from datetime import datetime, timezone
 from pathlib import Path
+from urllib.parse import urlsplit
 
 from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.middleware.cors import CORSMiddleware
@@ -100,6 +101,37 @@ class BodySizeLimitMiddleware(BaseHTTPMiddleware):
         return await call_next(request)
 
 
+# ─── Middleware: Permanent trailing-slash redirects (SEO) ─────────────────────
+class PermanentRedirectMiddleware(BaseHTTPMiddleware):
+    """Converts StaticFiles trailing-slash redirects from 307 to 301.
+
+    StaticFiles(html=True) issues a 307 Temporary Redirect when a request
+    path is missing the trailing slash (e.g. /research -> /research/). For
+    SEO these must be 301 Permanent so Google consolidates link equity onto
+    the canonical (trailing-slash) URL instead of treating it as temporary.
+
+    Only rewrites GET/HEAD redirects that point to the same path plus a
+    trailing slash, leaving API and other redirects untouched.
+    """
+
+    async def dispatch(self, request: Request, call_next):
+        response = await call_next(request)
+        if (
+            request.method in ("GET", "HEAD")
+            and response.status_code == 307
+            and "location" in response.headers
+        ):
+            # Only promote to 301 when the redirect target is exactly the
+            # request path plus a trailing slash. Location may be absolute
+            # (ProxyHeaders rewrites it to https://host/path/), so compare
+            # the parsed path, not the raw header. This leaves any other
+            # 307 (API, future redirects) as a temporary redirect.
+            location_path = urlsplit(response.headers["location"]).path
+            if location_path == request.url.path + "/":
+                response.status_code = 301
+        return response
+
+
 # ─── Middleware: Security Headers ─────────────────────────────────────────────
 class SecurityHeadersMiddleware(BaseHTTPMiddleware):
     """Adds HTTP security headers to all responses.
@@ -141,6 +173,7 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
 
 app.add_middleware(BodySizeLimitMiddleware)
 app.add_middleware(SecurityHeadersMiddleware)
+app.add_middleware(PermanentRedirectMiddleware)
 # ProxyHeadersMiddleware propagates X-Forwarded-Proto to Starlette scope,
 # so StaticFiles trailing-slash redirects use https:// not http://
 app.add_middleware(ProxyHeadersMiddleware, trusted_hosts=["127.0.0.1", "::1"])

--- a/src/geo_optimizer/web/app.py
+++ b/src/geo_optimizer/web/app.py
@@ -116,11 +116,7 @@ class PermanentRedirectMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: Request, call_next):
         response = await call_next(request)
-        if (
-            request.method in ("GET", "HEAD")
-            and response.status_code == 307
-            and "location" in response.headers
-        ):
+        if request.method in ("GET", "HEAD") and response.status_code == 307 and "location" in response.headers:
             # Only promote to 301 when the redirect target is exactly the
             # request path plus a trailing slash. Location may be absolute
             # (ProxyHeaders rewrites it to https://host/path/), so compare

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -147,6 +147,26 @@ def test_homepage_contiene_form_audit(client):
     assert b"GEO Optimizer" in response.content
 
 
+# ─── Test: trailing-slash redirects are 301 (SEO) ────────────────────────────
+
+
+@requires_frontend_build
+def test_trailing_slash_redirect_is_permanent(client):
+    """GET /research must 301 (not 307) to /research/ for SEO link equity."""
+    from urllib.parse import urlsplit
+
+    response = client.get("/research", follow_redirects=False)
+    assert response.status_code == 301
+    assert urlsplit(response.headers["location"]).path == "/research/"
+
+
+@requires_frontend_build
+def test_non_redirect_response_unaffected(client):
+    """A normal 200 page must not be touched by the redirect middleware."""
+    response = client.get("/research/", follow_redirects=False)
+    assert response.status_code == 200
+
+
 # ─── Test: GET /health ────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Problem

`StaticFiles(html=True)` issues a **307 Temporary Redirect** when a request path lacks its trailing slash (e.g. `/research` → `/research/`). With `trailingSlash: 'always'` on the Astro frontend, every non-slash internal/external link to a page hits this redirect.

For SEO this is wrong: 307 is *temporary*, so Google does not consolidate link equity onto the canonical (trailing-slash) URL and may keep both forms in flux. GSC for geoready.dev shows both `/research` and `/research/` as separate rows for this reason.

## Fix

Adds `PermanentRedirectMiddleware` that rewrites **307 → 301** so the canonical trailing-slash URL accrues link equity permanently.

Scope is deliberately narrow — the rewrite fires **only** when:
- method is `GET` or `HEAD`, and
- the response is a `307` with a `Location` header, and
- the `Location` **path** equals exactly `request.url.path + "/"`.

`Location` may be absolute (`ProxyHeadersMiddleware` rewrites it to `https://host/path/`), so the comparison parses the path via `urlsplit` rather than matching the raw header. Any other 307 (API endpoints, future redirects) is left untouched as a temporary redirect.

## Tests

- `test_trailing_slash_redirect_is_permanent` — `GET /research` returns `301` with `Location` path `/research/`.
- `test_non_redirect_response_unaffected` — `GET /research/` returns `200`, untouched by the middleware.
- Full `tests/test_web_app.py` suite: **40 passed**. `ruff` clean on touched files.

## Deploy risk

**Low.**
- Pure additive middleware; no behavior change for `200`/API responses.
- Only affects GET/HEAD trailing-slash redirects where `Location` path equals request path + `/`.
- ⚠️ 301 is hard-cached by browsers. Risk only materializes if a currently-redirecting path later stops redirecting — not the case for the static page set served with `trailingSlash: 'always'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)