### PR TITLE
feat(site): add guides content sprint 1

### DIFF
--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -61,6 +61,24 @@
     <priority>0.7</priority>
   </url>
   <url>
+    <loc>https://geoready.dev/guides/geo-vs-seo/</loc>
+    <lastmod>2026-06-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://geoready.dev/guides/llms-txt-wordpress/</loc>
+    <lastmod>2026-06-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://geoready.dev/guides/ai-visibility-checklist/</loc>
+    <lastmod>2026-06-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://geoready.dev/manifesto/</loc>
     <lastmod>2026-05-26</lastmod>
     <changefreq>monthly</changefreq>

--- a/frontend/src/pages/guides/ai-visibility-checklist.astro
+++ b/frontend/src/pages/guides/ai-visibility-checklist.astro
@@ -1,0 +1,396 @@
+---
+import Shell from '../../components/Shell.astro';
+
+const title =
+  'AI Visibility Checklist: How to Make Your Website Easier to Find, Cite, and Recommend';
+const description =
+  'A practical checklist covering all the technical and content signals that affect whether AI answer engines can find, parse, and cite your website. Organized by category, with clear pass/fail criteria.';
+const canonical = 'https://geoready.dev/guides/ai-visibility-checklist/';
+const datePublished = '2026-06-05';
+const dateModified = '2026-06-05';
+---
+
+<Shell title={title} description={description} canonical={canonical}>
+  <article class="max-w-3xl mx-auto px-4 sm:px-6 py-10 md:py-16">
+    {/* Header */}
+    <header class="mb-12 md:mb-16">
+      <div class="flex items-center gap-2 text-[10px] font-mono text-text-muted uppercase tracking-wider">
+        <a href="/guides/" class="hover:text-accent-teal">Guides</a>
+        <span class="w-1 h-1 rounded-full bg-text-muted" />
+        <span>Checklist</span>
+      </div>
+
+      <h1 class="mt-3 font-display text-3xl md:text-4xl font-bold text-text-primary leading-tight tracking-tight">
+        AI visibility checklist: how to make your website easier to find, cite, and recommend
+      </h1>
+
+      <p class="mt-4 text-base md:text-lg text-text-secondary leading-relaxed">
+        This checklist covers the signals that determine whether AI answer
+        engines can find your site, parse its content, and cite it in responses.
+        It's organized by category — from crawl-level basics to brand signals —
+        with clear criteria for each item. Work through it top to bottom: the
+        higher categories are foundational; the lower ones have diminishing
+        returns if you skip the basics.
+      </p>
+      <p class="mt-2 text-xs text-text-muted font-mono">
+        Published June 2026 · 14 min read
+      </p>
+    </header>
+
+    <div class="space-y-12 md:space-y-16 [&_h2]:font-display [&_h2]:text-2xl [&_h2]:font-bold [&_h2]:text-text-primary [&_h2]:leading-tight [&_h2]:tracking-tight [&_h3]:font-display [&_h3]:text-lg [&_h3]:font-semibold [&_h3]:text-text-primary [&_p]:text-text-secondary [&_p]:leading-relaxed [&_li]:text-text-secondary [&_li]:leading-relaxed">
+
+      {/* How to use */}
+      <section>
+        <h2>How to use this checklist</h2>
+        <p class="mt-4">
+          Each item has a criterion and what to check. "Pass" means the signal
+          is present and correct. "Fail" means it's missing, broken, or
+          actively working against you. Some items have partial states.
+        </p>
+        <p class="mt-4">
+          You can run through this manually on your own site, or use an
+          automated audit to get a scored report across these categories. The
+          checklist covers the same signals as the GEO Optimizer audit; the
+          audit gives you a numeric score and specific recommendations per page.
+        </p>
+        <p class="mt-4 text-sm text-text-secondary">
+          Shorthand used below: <strong>AI crawler</strong> = agents like GPTBot,
+          OAI-SearchBot, ClaudeBot, PerplexityBot, Google-Extended.
+          <strong>Answer engine</strong> = ChatGPT web search, Perplexity, Gemini,
+          Claude with web access, and similar.
+        </p>
+      </section>
+
+      {/* Category 1: Crawlability */}
+      <section>
+        <h2>1. Crawlability</h2>
+        <p class="mt-3 text-text-secondary text-sm font-mono uppercase tracking-wider">Foundation — fix this first</p>
+
+        <ul class="mt-6 space-y-5">
+          <li class="border-l-2 border-border pl-4">
+            <p class="font-semibold text-text-primary">robots.txt doesn't block AI crawlers you want</p>
+            <p class="mt-1 text-sm">Check: fetch <code class="font-mono">yourdomain.com/robots.txt</code> and look for <code class="font-mono">Disallow: /</code> rules under GPTBot, OAI-SearchBot, ClaudeBot, PerplexityBot, Google-Extended. If they're disallowed, those engines can't retrieve your content.</p>
+            <p class="mt-1 text-sm text-text-muted">Pass: AI crawlers you want are explicitly allowed, or not mentioned (default allow).</p>
+          </li>
+          <li class="border-l-2 border-border pl-4">
+            <p class="font-semibold text-text-primary">Pages return 200 OK</p>
+            <p class="mt-1 text-sm">Crawlers that hit 4xx or 5xx errors on important pages won't index them. Check your key landing pages, guides, and product pages return clean 200s.</p>
+            <p class="mt-1 text-sm text-text-muted">Pass: no important pages returning error status codes.</p>
+          </li>
+          <li class="border-l-2 border-border pl-4">
+            <p class="font-semibold text-text-primary">Redirects are 301, not chains</p>
+            <p class="mt-1 text-sm">Redirect chains (A → B → C) slow down crawlers and dilute link equity. Each extra hop is a failure point. Use 301s directly to the canonical URL.</p>
+            <p class="mt-1 text-sm text-text-muted">Pass: no redirect chains longer than one hop on key pages.</p>
+          </li>
+          <li class="border-l-2 border-border pl-4">
+            <p class="font-semibold text-text-primary">Response time under 3 seconds</p>
+            <p class="mt-1 text-sm">Slow pages get deprioritized or timed out during crawl. Measure TTFB (time to first byte), not just browser load time.</p>
+            <p class="mt-1 text-sm text-text-muted">Pass: TTFB under ~500ms; full page under ~3s for crawlers.</p>
+          </li>
+          <li class="border-l-2 border-border pl-4">
+            <p class="font-semibold text-text-primary">Sitemap is present and linked from robots.txt</p>
+            <p class="mt-1 text-sm">Add <code class="font-mono">Sitemap: https://yourdomain.com/sitemap.xml</code> to your robots.txt so any crawler can discover all your pages.</p>
+            <p class="mt-1 text-sm text-text-muted">Pass: sitemap exists, is accessible, and is referenced in robots.txt.</p>
+          </li>
+        </ul>
+      </section>
+
+      {/* Category 2: Meta / Signals */}
+      <section>
+        <h2>2. Meta signals</h2>
+        <p class="mt-3 text-text-secondary text-sm font-mono uppercase tracking-wider">Page-level identification</p>
+
+        <ul class="mt-6 space-y-5">
+          <li class="border-l-2 border-border pl-4">
+            <p class="font-semibold text-text-primary">Each page has a unique, descriptive &lt;title&gt;</p>
+            <p class="mt-1 text-sm">Title tags are used by both classic search and AI retrieval systems to categorize pages. Duplicate or generic titles ("Home | Site Name" on every page) confuse retrieval.</p>
+            <p class="mt-1 text-sm text-text-muted">Pass: every important page has a unique title that describes its specific content.</p>
+          </li>
+          <li class="border-l-2 border-border pl-4">
+            <p class="font-semibold text-text-primary">Meta description present and accurate</p>
+            <p class="mt-1 text-sm">Not a direct ranking signal for AI, but descriptions are sometimes used as context by tools that summarize pages. Keep them factual and specific.</p>
+            <p class="mt-1 text-sm text-text-muted">Pass: meta description present on all key pages, accurate, under 160 characters.</p>
+          </li>
+          <li class="border-l-2 border-border pl-4">
+            <p class="font-semibold text-text-primary">Canonical tag present and self-referencing</p>
+            <p class="mt-1 text-sm">Without a canonical, retrieval systems may treat multiple URL variants of the same page as separate content, diluting its signal.</p>
+            <p class="mt-1 text-sm text-text-muted">Pass: <code class="font-mono">&lt;link rel="canonical"&gt;</code> on every page, pointing to the preferred URL.</p>
+          </li>
+          <li class="border-l-2 border-border pl-4">
+            <p class="font-semibold text-text-primary">Open Graph / og: tags present</p>
+            <p class="mt-1 text-sm">OG tags are used when pages are shared and summarized. Some AI summarization tools also read them. At minimum: og:title, og:description, og:image.</p>
+            <p class="mt-1 text-sm text-text-muted">Pass: og:title, og:description, og:image, og:url present on key pages.</p>
+          </li>
+        </ul>
+      </section>
+
+      {/* Category 3: llms.txt */}
+      <section>
+        <h2>3. llms.txt</h2>
+        <p class="mt-3 text-text-secondary text-sm font-mono uppercase tracking-wider">Curated content map for AI tools</p>
+
+        <ul class="mt-6 space-y-5">
+          <li class="border-l-2 border-border pl-4">
+            <p class="font-semibold text-text-primary">llms.txt exists at domain root</p>
+            <p class="mt-1 text-sm">Check: <code class="font-mono">yourdomain.com/llms.txt</code> should return a plain text file, not a 404 or HTML page.</p>
+            <p class="mt-1 text-sm text-text-muted">Pass: file accessible, returns plain text (Content-Type: text/plain).</p>
+          </li>
+          <li class="border-l-2 border-border pl-4">
+            <p class="font-semibold text-text-primary">llms.txt follows the correct format</p>
+            <p class="mt-1 text-sm">The file should use Markdown: H1 for site name, a blockquote for the summary, H2 sections for categories, and link lists with descriptions. See our <a href="/guides/llms-txt-wordpress/" class="text-accent-teal hover:underline">implementation guide</a>.</p>
+            <p class="mt-1 text-sm text-text-muted">Pass: valid Markdown, site description present, at least one section with linked pages.</p>
+          </li>
+          <li class="border-l-2 border-border pl-4">
+            <p class="font-semibold text-text-primary">llms.txt includes most important pages</p>
+            <p class="mt-1 text-sm">A file that only lists low-priority pages (or auto-generates every post) is worse than a curated short list. Include homepage, key product/service pages, and your best content.</p>
+            <p class="mt-1 text-sm text-text-muted">Pass: core pages present; no more than ~30-50 entries (quality over quantity).</p>
+          </li>
+        </ul>
+      </section>
+
+      {/* Category 4: Structured data */}
+      <section>
+        <h2>4. Structured data (schema.org)</h2>
+        <p class="mt-3 text-text-secondary text-sm font-mono uppercase tracking-wider">Explicit entity and relationship signals</p>
+
+        <ul class="mt-6 space-y-5">
+          <li class="border-l-2 border-border pl-4">
+            <p class="font-semibold text-text-primary">Organization or Person schema present</p>
+            <p class="mt-1 text-sm">Every site should declare its identity. An <code class="font-mono">Organization</code> schema with name, URL, logo, and description helps AI systems build entity associations.</p>
+            <p class="mt-1 text-sm text-text-muted">Pass: valid JSON-LD <code class="font-mono">Organization</code> (or <code class="font-mono">Person</code> for personal sites) on homepage.</p>
+          </li>
+          <li class="border-l-2 border-border pl-4">
+            <p class="font-semibold text-text-primary">WebSite schema with search action</p>
+            <p class="mt-1 text-sm">Helps engines understand the site as a whole. Include a <code class="font-mono">SearchAction</code> if you have on-site search.</p>
+            <p class="mt-1 text-sm text-text-muted">Pass: <code class="font-mono">WebSite</code> schema present, name and URL match the canonical domain.</p>
+          </li>
+          <li class="border-l-2 border-border pl-4">
+            <p class="font-semibold text-text-primary">Article schema on blog/guide pages</p>
+            <p class="mt-1 text-sm">Marks content as authored, dated, and categorized. Include <code class="font-mono">headline</code>, <code class="font-mono">author</code>, <code class="font-mono">datePublished</code>, <code class="font-mono">dateModified</code>.</p>
+            <p class="mt-1 text-sm text-text-muted">Pass: valid Article schema on all editorial content pages.</p>
+          </li>
+          <li class="border-l-2 border-border pl-4">
+            <p class="font-semibold text-text-primary">FAQPage schema where applicable</p>
+            <p class="mt-1 text-sm">FAQ sections marked with <code class="font-mono">FAQPage</code> schema give AI systems clean question-answer pairs to pull from.</p>
+            <p class="mt-1 text-sm text-text-muted">Pass: FAQPage schema present on pages with Q&A sections; questions and answers accurate and specific.</p>
+          </li>
+          <li class="border-l-2 border-border pl-4">
+            <p class="font-semibold text-text-primary">BreadcrumbList schema on sub-pages</p>
+            <p class="mt-1 text-sm">Helps engines understand site structure and page context.</p>
+            <p class="mt-1 text-sm text-text-muted">Pass: breadcrumb schema present on all pages more than one level deep.</p>
+          </li>
+          <li class="border-l-2 border-border pl-4">
+            <p class="font-semibold text-text-primary">No schema validation errors</p>
+            <p class="mt-1 text-sm">Malformed JSON-LD (unclosed brackets, wrong types) can be silently ignored. Validate with Google's Rich Results Test or schema.org validator.</p>
+            <p class="mt-1 text-sm text-text-muted">Pass: no errors in validator; warnings are acceptable if the meaning is clear.</p>
+          </li>
+        </ul>
+      </section>
+
+      {/* Category 5: Content signals */}
+      <section>
+        <h2>5. Content signals</h2>
+        <p class="mt-3 text-text-secondary text-sm font-mono uppercase tracking-wider">Quotability and clarity</p>
+
+        <ul class="mt-6 space-y-5">
+          <li class="border-l-2 border-border pl-4">
+            <p class="font-semibold text-text-primary">Content is in server-rendered HTML</p>
+            <p class="mt-1 text-sm">View the raw HTML source (not the rendered DOM). Your key paragraphs, headings, and facts must appear there. If they only appear after JavaScript runs, assume a basic crawler won't see them.</p>
+            <p class="mt-1 text-sm text-text-muted">Pass: all important content present in raw HTML source.</p>
+          </li>
+          <li class="border-l-2 border-border pl-4">
+            <p class="font-semibold text-text-primary">Pages lead with a direct answer or summary</p>
+            <p class="mt-1 text-sm">AI retrieval favors pages where the first paragraph states the answer clearly. Burying the key point under marketing prose reduces quotability.</p>
+            <p class="mt-1 text-sm text-text-muted">Pass: first paragraph of each key page states its main point directly.</p>
+          </li>
+          <li class="border-l-2 border-border pl-4">
+            <p class="font-semibold text-text-primary">Headings match real questions or intents</p>
+            <p class="mt-1 text-sm">H2/H3 headings that match how people phrase queries help retrieval systems identify which section answers which question.</p>
+            <p class="mt-1 text-sm text-text-muted">Pass: headings are descriptive and query-shaped; not generic ("Introduction", "Section 3").</p>
+          </li>
+          <li class="border-l-2 border-border pl-4">
+            <p class="font-semibold text-text-primary">Facts are specific and verifiable</p>
+            <p class="mt-1 text-sm">Vague claims ("industry-leading performance") aren't quotable. Numbers, dates, and concrete statements are. A model can cite "response time under 200ms"; it can't cite "blazing fast".</p>
+            <p class="mt-1 text-sm text-text-muted">Pass: key claims are specific, dated where relevant, and don't require context to interpret.</p>
+          </li>
+          <li class="border-l-2 border-border pl-4">
+            <p class="font-semibold text-text-primary">One idea per paragraph</p>
+            <p class="mt-1 text-sm">Dense paragraphs that mix multiple ideas are harder to lift cleanly. Short, focused paragraphs make it easy for a model to pull a clean passage.</p>
+            <p class="mt-1 text-sm text-text-muted">Pass: most paragraphs cover one point; rarely more than 5-6 sentences.</p>
+          </li>
+          <li class="border-l-2 border-border pl-4">
+            <p class="font-semibold text-text-primary">Processes are written as numbered steps</p>
+            <p class="mt-1 text-sm">Numbered steps are one of the easiest formats for AI to quote and reproduce. If you're explaining how to do something, use an ordered list.</p>
+            <p class="mt-1 text-sm text-text-muted">Pass: all how-to content uses numbered steps, not prose-only descriptions.</p>
+          </li>
+        </ul>
+      </section>
+
+      {/* Category 6: AI discovery */}
+      <section>
+        <h2>6. AI discovery signals</h2>
+        <p class="mt-3 text-text-secondary text-sm font-mono uppercase tracking-wider">Findability beyond direct crawl</p>
+
+        <ul class="mt-6 space-y-5">
+          <li class="border-l-2 border-border pl-4">
+            <p class="font-semibold text-text-primary">XML sitemap is complete and up to date</p>
+            <p class="mt-1 text-sm">A sitemap tells crawlers what URLs exist. An outdated sitemap with broken or missing URLs undermines discoverability.</p>
+            <p class="mt-1 text-sm text-text-muted">Pass: sitemap includes all important pages; lastmod dates are accurate; no 404s in the sitemap.</p>
+          </li>
+          <li class="border-l-2 border-border pl-4">
+            <p class="font-semibold text-text-primary">Internal linking connects key pages</p>
+            <p class="mt-1 text-sm">Orphan pages (reachable only via sitemap, not through in-site links) are less likely to be indexed and less likely to accumulate authority.</p>
+            <p class="mt-1 text-sm text-text-muted">Pass: every important page linked from at least two other pages; no key pages require sitemap to reach.</p>
+          </li>
+          <li class="border-l-2 border-border pl-4">
+            <p class="font-semibold text-text-primary">No noindex on pages you want cited</p>
+            <p class="mt-1 text-sm">A <code class="font-mono">noindex</code> meta tag or X-Robots-Tag header tells crawlers to exclude the page from their index. Verify it isn't set accidentally on content you want visible.</p>
+            <p class="mt-1 text-sm text-text-muted">Pass: no noindex on pages you want indexed and cited.</p>
+          </li>
+        </ul>
+      </section>
+
+      {/* Category 7: Brand / entity */}
+      <section>
+        <h2>7. Brand and entity signals</h2>
+        <p class="mt-3 text-text-secondary text-sm font-mono uppercase tracking-wider">Who you are, consistently stated</p>
+
+        <ul class="mt-6 space-y-5">
+          <li class="border-l-2 border-border pl-4">
+            <p class="font-semibold text-text-primary">Brand name used consistently across all pages</p>
+            <p class="mt-1 text-sm">Inconsistent naming (sometimes "Acme", sometimes "Acme Inc.", sometimes "acme.com") fragments entity associations. AI systems use consistent references to build confidence in who you are.</p>
+            <p class="mt-1 text-sm text-text-muted">Pass: brand name spelled identically across title tags, schema, footer, and copy.</p>
+          </li>
+          <li class="border-l-2 border-border pl-4">
+            <p class="font-semibold text-text-primary">About page describes the entity clearly</p>
+            <p class="mt-1 text-sm">A clear, factual About page (who you are, what you do, where you're based, when founded) gives models anchor points for entity recognition.</p>
+            <p class="mt-1 text-sm text-text-muted">Pass: About page exists, factual, describes the organization concisely.</p>
+          </li>
+          <li class="border-l-2 border-border pl-4">
+            <p class="font-semibold text-text-primary">Social profiles and external mentions are consistent</p>
+            <p class="mt-1 text-sm">LinkedIn, GitHub, Crunchbase, press mentions — all should use the same brand name and description. Cross-web consistency strengthens entity association.</p>
+            <p class="mt-1 text-sm text-text-muted">Pass: major external profiles exist and match on-site branding.</p>
+          </li>
+          <li class="border-l-2 border-border pl-4">
+            <p class="font-semibold text-text-primary">Wikidata or Wikipedia entry (if applicable)</p>
+            <p class="mt-1 text-sm">Not achievable for most sites, but the strongest entity signal if you qualify. Models are trained on Wikipedia and Wikidata; being there creates a canonical entity record.</p>
+            <p class="mt-1 text-sm text-text-muted">Pass: entry exists, accurate, linked from your site. Skip if not notable enough — a bad entry is worse than none.</p>
+          </li>
+        </ul>
+      </section>
+
+      {/* Priority order */}
+      <section>
+        <h2>Priority order for a first pass</h2>
+        <p class="mt-4">
+          If you're auditing a site for the first time and want to know where to
+          start:
+        </p>
+        <ol class="mt-4 space-y-3 list-decimal pl-5">
+          <li>Fix crawlability issues first — robots.txt blocks, redirect chains, slow responses.</li>
+          <li>Add or fix canonical tags and meta titles on all key pages.</li>
+          <li>Create an <code class="font-mono">llms.txt</code> — low effort, explicitly surfaces your priorities.</li>
+          <li>Add Organization and Article schema to your homepage and content pages.</li>
+          <li>Rewrite your most important page introductions to lead with direct answers.</li>
+          <li>Fix internal linking so no important page is an orphan.</li>
+          <li>Work on brand/entity consistency across the web — this is slower but compounds.</li>
+        </ol>
+        <p class="mt-4">
+          The <a href="/guides/geo-vs-seo/" class="text-accent-teal hover:underline">GEO vs SEO guide</a> explains
+          why these priorities differ from a classic SEO checklist.
+        </p>
+      </section>
+
+      {/* Limits */}
+      <section>
+        <h2>Limits of this checklist</h2>
+        <p class="mt-4">
+          This checklist covers signals that are in your control. It doesn't
+          cover:
+        </p>
+        <ul class="mt-4 space-y-2 list-disc pl-5">
+          <li><strong>Training data inclusion</strong> — you can't directly control whether your site was included in a model's training corpus, only whether future crawls can access it.</li>
+          <li><strong>Citation frequency</strong> — even a perfect score doesn't guarantee citations. Models have their own retrieval and selection logic, and it changes between versions.</li>
+          <li><strong>Query intent matching</strong> — if your content doesn't actually answer the queries people are asking, technical optimization won't manufacture relevance.</li>
+          <li><strong>Domain authority</strong> — established, heavily-cited domains have an advantage that a checklist won't close overnight.</li>
+        </ul>
+        <p class="mt-4">
+          Use this checklist to remove friction and make your site's signals
+          accurate. Don't use it expecting guaranteed citation outcomes — no
+          checklist can promise that.
+        </p>
+      </section>
+
+      {/* CTA */}
+      <section class="rounded-2xl border border-border bg-bg-surface p-6 md:p-8">
+        <h2>Get a scored audit across all these categories</h2>
+        <p class="mt-3">
+          Instead of working through this manually, run the free audit: it
+          checks your site across these eight categories and gives specific,
+          actionable recommendations. No account required.
+        </p>
+        <div class="mt-6 flex flex-col sm:flex-row gap-3">
+          <a
+            href="/#audit-form"
+            class="inline-flex items-center justify-center rounded-full bg-accent-teal px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-accent-teal-dark"
+          >
+            Run a free AI visibility audit
+          </a>
+          <a
+            href="https://app.geoready.dev/signup"
+            class="inline-flex items-center justify-center rounded-full border border-border px-6 py-3 text-sm font-medium text-text-primary transition-colors hover:border-accent-teal"
+          >
+            Create a GeoReady account
+          </a>
+        </div>
+        <p class="mt-4 text-xs text-text-muted">
+          A GeoReady account lets you save reports, monitor domains over time, and track whether your changes improve your score. See <a href="/pricing/" class="text-accent-teal hover:underline">pricing</a>.
+        </p>
+      </section>
+
+      {/* Further reading */}
+      <section>
+        <h2>Further reading</h2>
+        <ul class="mt-4 space-y-2 list-disc pl-5">
+          <li><a href="/guides/appear-in-chatgpt-perplexity/" class="text-accent-teal hover:underline">How to make your website appear in ChatGPT and Perplexity sources</a> — deep dive on the crawlability and content layers.</li>
+          <li><a href="/guides/geo-vs-seo/" class="text-accent-teal hover:underline">GEO vs SEO: what changes when AI becomes the interface</a> — how these signals differ from classic SEO priorities.</li>
+          <li><a href="/guides/llms-txt-wordpress/" class="text-accent-teal hover:underline">llms.txt for WordPress and AI visibility</a> — implementing the llms.txt layer.</li>
+          <li>The research behind these categories: <a href="/research/" class="text-accent-teal hover:underline">GEO Optimizer research foundation</a>.</li>
+          <li>Our philosophy on AI visibility: <a href="/manifesto/" class="text-accent-teal hover:underline">the manifesto</a>.</li>
+        </ul>
+      </section>
+    </div>
+  </article>
+
+  <script type="application/ld+json" set:html={JSON.stringify({
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "headline": title,
+    "description": description,
+    "author": {
+      "@type": "Organization",
+      "name": "Auriti Labs",
+      "url": "https://github.com/Auriti-Labs"
+    },
+    "publisher": {
+      "@type": "Organization",
+      "name": "Auriti Labs",
+      "url": "https://github.com/Auriti-Labs"
+    },
+    "datePublished": datePublished,
+    "dateModified": dateModified,
+    "image": "https://geoready.dev/assets/og-image.png",
+    "mainEntityOfPage": {
+      "@type": "WebPage",
+      "@id": canonical
+    },
+    "about": [
+      "AI search visibility",
+      "Generative Engine Optimization",
+      "AI visibility checklist",
+      "SEO",
+      "llms.txt",
+      "structured data"
+    ]
+  })} />
+</Shell>

--- a/frontend/src/pages/guides/appear-in-chatgpt-perplexity.astro
+++ b/frontend/src/pages/guides/appear-in-chatgpt-perplexity.astro
@@ -203,6 +203,9 @@ const dateModified = '2026-06-04';
       <section>
         <h2>Further reading</h2>
         <ul class="mt-4 space-y-2 list-disc pl-5">
+          <li><a href="/guides/geo-vs-seo/" class="text-accent-teal hover:underline">GEO vs SEO: what changes when AI engines become the interface</a> — how GEO differs from classic SEO and where to focus effort.</li>
+          <li><a href="/guides/llms-txt-wordpress/" class="text-accent-teal hover:underline">llms.txt for WordPress and AI visibility</a> — how to create and implement llms.txt on any site.</li>
+          <li><a href="/guides/ai-visibility-checklist/" class="text-accent-teal hover:underline">AI Visibility Checklist</a> — all signals in one place with pass/fail criteria.</li>
           <li>The signals above are grounded in our <a href="/research/" class="text-accent-teal hover:underline">research foundation</a>.</li>
           <li>Why we think AI visibility should be auditable and open — the <a href="/manifesto/" class="text-accent-teal hover:underline">GEO Optimizer manifesto</a>.</li>
           <li>More walkthroughs in the <a href="/guides/" class="text-accent-teal hover:underline">guides hub</a>.</li>

--- a/frontend/src/pages/guides/geo-vs-seo.astro
+++ b/frontend/src/pages/guides/geo-vs-seo.astro
@@ -1,0 +1,275 @@
+---
+import Shell from '../../components/Shell.astro';
+
+const title = 'GEO vs SEO: What Changes When AI Engines Become the Interface';
+const description =
+  'SEO and GEO share some foundations but diverge in what they optimize for. This guide explains the differences, what stays the same, and where you need to change your approach when AI engines become the answer interface.';
+const canonical = 'https://geoready.dev/guides/geo-vs-seo/';
+const datePublished = '2026-06-05';
+const dateModified = '2026-06-05';
+---
+
+<Shell title={title} description={description} canonical={canonical}>
+  <article class="max-w-3xl mx-auto px-4 sm:px-6 py-10 md:py-16">
+    {/* Header */}
+    <header class="mb-12 md:mb-16">
+      <div class="flex items-center gap-2 text-[10px] font-mono text-text-muted uppercase tracking-wider">
+        <a href="/guides/" class="hover:text-accent-teal">Guides</a>
+        <span class="w-1 h-1 rounded-full bg-text-muted" />
+        <span>GEO</span>
+      </div>
+
+      <h1 class="mt-3 font-display text-3xl md:text-4xl font-bold text-text-primary leading-tight tracking-tight">
+        GEO vs SEO: what changes when AI engines become the interface
+      </h1>
+
+      <p class="mt-4 text-base md:text-lg text-text-secondary leading-relaxed">
+        Search engine optimization is about ranking links. Generative engine
+        optimization is about being cited, summarized, or recommended by an AI
+        answer. They share technical foundations but diverge in what matters
+        most. This guide maps the overlap, the differences, and the practical
+        changes your workflow actually needs.
+      </p>
+      <p class="mt-2 text-xs text-text-muted font-mono">
+        Published June 2026 · 10 min read
+      </p>
+    </header>
+
+    <div class="space-y-12 md:space-y-16 [&_h2]:font-display [&_h2]:text-2xl [&_h2]:font-bold [&_h2]:text-text-primary [&_h2]:leading-tight [&_h2]:tracking-tight [&_h3]:font-display [&_h3]:text-lg [&_h3]:font-semibold [&_h3]:text-text-primary [&_p]:text-text-secondary [&_p]:leading-relaxed [&_li]:text-text-secondary [&_li]:leading-relaxed">
+
+      {/* The core difference */}
+      <section>
+        <h2>The core difference: ranking vs. retrieval</h2>
+        <p class="mt-4">
+          Classic SEO optimizes for a ranked list of links. A human user sees
+          that list and clicks. Generative engines don't show ten blue links —
+          they synthesize a single answer and cite a few sources inline. The
+          human never sees a rank; they see a summary.
+        </p>
+        <p class="mt-4">
+          That changes the success metric. In SEO you want position 1. In GEO
+          you want to be one of the sources a model trusts enough to pull from
+          and attribute. There's no rank 1 in a paragraph.
+        </p>
+        <p class="mt-4">
+          This isn't a complete replacement. Classic search is still the
+          dominant interface for most queries, and ranking well in Google
+          correlates with being in training and retrieval sets. But the
+          optimization target has shifted for a meaningful share of queries,
+          especially informational and comparison ones.
+        </p>
+      </section>
+
+      {/* What stays the same */}
+      <section>
+        <h2>What stays the same</h2>
+        <p class="mt-4">
+          Most of the technical fundamentals carry over:
+        </p>
+        <ul class="mt-4 space-y-2 list-disc pl-5">
+          <li><strong>Crawlability</strong> — if a bot can't fetch your page, neither engine can use it. Clean robots.txt, fast responses, correct status codes.</li>
+          <li><strong>Indexable HTML</strong> — content must be in the server-rendered markup, not behind JavaScript that a basic crawler won't execute.</li>
+          <li><strong>Canonical URLs</strong> — duplicate content confuses both Google and retrieval systems. Pick a canonical, redirect correctly, use trailing slashes consistently.</li>
+          <li><strong>Page authority</strong> — links pointing to your domain are still a proxy for trust. More authoritative domains get pulled more often by RAG systems.</li>
+          <li><strong>Structured data</strong> — JSON-LD helps both rich results and entity disambiguation by AI systems.</li>
+        </ul>
+        <p class="mt-4">
+          If your SEO fundamentals are weak, GEO won't save you. Fix the
+          foundation first.
+        </p>
+      </section>
+
+      {/* What changes */}
+      <section>
+        <h2>What changes</h2>
+
+        <h3 class="mt-6">1. Quotability over keyword density</h3>
+        <p class="mt-3">
+          SEO copywriting obsesses over keyword frequency and placement. GEO
+          cares about whether a passage can be lifted cleanly. A model looking
+          for a definition doesn't want a paragraph that mentions the keyword
+          twelve times; it wants one clear sentence that states what the term
+          means, followed by context.
+        </p>
+        <p class="mt-3">
+          The shift: write for direct extraction. Lead with the answer. State
+          facts in a form that makes sense out of context.
+        </p>
+
+        <h3 class="mt-6">2. Entity clarity over anchor text</h3>
+        <p class="mt-3">
+          SEO builds link equity through anchor text. GEO needs clear entity
+          associations. Who is your brand? What does it do? What category does
+          it live in? Models build entity graphs from structured data,
+          consistent references across the web, and the way you describe
+          yourself on your own site.
+        </p>
+        <p class="mt-3">
+          Mark up your <code class="text-sm font-mono">Organization</code> and
+          <code class="text-sm font-mono">WebSite</code> schema. Be consistent
+          with your brand name, product names, and category language across
+          every page. A Wikipedia article or Wikidata entity helps; not everyone
+          can get that, but it's the clearest signal.
+        </p>
+
+        <h3 class="mt-6">3. Source trust over CTR signals</h3>
+        <p class="mt-3">
+          Google has click-through rate as a behavioral signal. Generative
+          engines don't — they assess source quality through a different lens:
+          content accuracy, domain authority, freshness, and whether the content
+          matches what the model already knows from training. There's no A/B
+          testing your title tag for citation rate the way you would for CTR.
+        </p>
+
+        <h3 class="mt-6">4. llms.txt as explicit context</h3>
+        <p class="mt-3">
+          <code class="text-sm font-mono">llms.txt</code> is an emerging standard
+          with no SEO analogue. It's a plain-text file at your domain root that
+          says: "here are my important pages, here's what this site is about."
+          It's not a ranking signal; it's a hint for LLM tools that read it
+          directly. Read our{' '}
+          <a href="/guides/llms-txt-wordpress/" class="text-accent-teal hover:underline">llms.txt implementation guide</a>
+          {' '}for details.
+        </p>
+
+        <h3 class="mt-6">5. AI-specific crawler permission</h3>
+        <p class="mt-3">
+          SEO robots.txt blocks Googlebot and Bingbot. GEO requires deliberate
+          decisions about AI crawlers: <code class="text-sm font-mono">GPTBot</code>,
+          <code class="text-sm font-mono">OAI-SearchBot</code>,
+          <code class="text-sm font-mono">ClaudeBot</code>,
+          <code class="text-sm font-mono">PerplexityBot</code>,
+          <code class="text-sm font-mono">Google-Extended</code>. Each engine
+          behaves differently. Blocking them all to protect your content from
+          training also blocks the retrieval that drives citations.
+        </p>
+      </section>
+
+      {/* Practical priority matrix */}
+      <section>
+        <h2>Practical priority: what to do first</h2>
+        <p class="mt-4">
+          If you're already doing solid SEO and want to add GEO, here's where
+          the marginal effort goes:
+        </p>
+        <ul class="mt-4 space-y-3 list-decimal pl-5">
+          <li>
+            <strong>Audit your robots.txt</strong> for unintentional AI crawler blocks.
+            If you're blocking <code class="text-sm font-mono">GPTBot</code> or
+            <code class="text-sm font-mono">PerplexityBot</code>, decide deliberately.
+          </li>
+          <li>
+            <strong>Run a baseline audit</strong> to see how your site scores on
+            crawlability, llms.txt, schema, and content signals.
+          </li>
+          <li>
+            <strong>Rewrite your key pages</strong> to lead with direct answers.
+            Check your most important landing pages: does the first paragraph
+            state what you do and for whom, in one clear sentence?
+          </li>
+          <li>
+            <strong>Add or fix entity schema</strong> — <code class="text-sm font-mono">Organization</code>,
+            <code class="text-sm font-mono">WebSite</code>, <code class="text-sm font-mono">BreadcrumbList</code>.
+          </li>
+          <li>
+            <strong>Create an llms.txt</strong> pointing to your most important content.
+            Low effort, makes your key URLs explicit.
+          </li>
+          <li>
+            <strong>Monitor over time.</strong> AI visibility changes as models
+            update. A snapshot tells you where you are; tracking tells you whether
+            changes worked.
+          </li>
+        </ul>
+      </section>
+
+      {/* What GEO can't do */}
+      <section>
+        <h2>What GEO can't do</h2>
+        <p class="mt-4">
+          Be honest with yourself about the limits:
+        </p>
+        <ul class="mt-4 space-y-2 list-disc pl-5">
+          <li>No one can guarantee a specific model will cite you. Citation behavior is probabilistic and changes as models are retrained.</li>
+          <li>You can't directly control what training data includes your content.</li>
+          <li>GEO doesn't replace SEO for transactional queries — people still use classic search to buy things, compare prices, and find local services.</li>
+          <li>Brand authority built over years of SEO carries over. A two-week sprint won't substitute for it.</li>
+        </ul>
+        <p class="mt-4">
+          GEO removes friction. It doesn't manufacture authority from nothing.
+        </p>
+      </section>
+
+      {/* CTA */}
+      <section class="rounded-2xl border border-border bg-bg-surface p-6 md:p-8">
+        <h2>See how your site scores on GEO signals</h2>
+        <p class="mt-3">
+          The free audit checks your site across eight GEO categories:
+          crawlability, llms.txt, schema, content signals, AI discovery, and
+          more. No account needed.
+        </p>
+        <div class="mt-6 flex flex-col sm:flex-row gap-3">
+          <a
+            href="/#audit-form"
+            class="inline-flex items-center justify-center rounded-full bg-accent-teal px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-accent-teal-dark"
+          >
+            Run a free AI visibility audit
+          </a>
+          <a
+            href="https://app.geoready.dev/signup"
+            class="inline-flex items-center justify-center rounded-full border border-border px-6 py-3 text-sm font-medium text-text-primary transition-colors hover:border-accent-teal"
+          >
+            Create a GeoReady account
+          </a>
+        </div>
+        <p class="mt-4 text-xs text-text-muted">
+          A GeoReady account lets you save reports, track changes over time, and
+          unlock the full audit. See <a href="/pricing/" class="text-accent-teal hover:underline">pricing</a>.
+        </p>
+      </section>
+
+      {/* Further reading */}
+      <section>
+        <h2>Further reading</h2>
+        <ul class="mt-4 space-y-2 list-disc pl-5">
+          <li><a href="/guides/appear-in-chatgpt-perplexity/" class="text-accent-teal hover:underline">How to make your website appear in ChatGPT and Perplexity sources</a> — the technical and content checklist.</li>
+          <li><a href="/guides/llms-txt-wordpress/" class="text-accent-teal hover:underline">llms.txt for WordPress and AI visibility</a> — practical implementation guide.</li>
+          <li><a href="/guides/ai-visibility-checklist/" class="text-accent-teal hover:underline">AI Visibility Checklist</a> — all the signals in one place.</li>
+          <li>The signals behind these guides: our <a href="/research/" class="text-accent-teal hover:underline">research foundation</a>.</li>
+          <li>Why we think AI visibility should be auditable — the <a href="/manifesto/" class="text-accent-teal hover:underline">GEO Optimizer manifesto</a>.</li>
+        </ul>
+      </section>
+    </div>
+  </article>
+
+  <script type="application/ld+json" set:html={JSON.stringify({
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "headline": title,
+    "description": description,
+    "author": {
+      "@type": "Organization",
+      "name": "Auriti Labs",
+      "url": "https://github.com/Auriti-Labs"
+    },
+    "publisher": {
+      "@type": "Organization",
+      "name": "Auriti Labs",
+      "url": "https://github.com/Auriti-Labs"
+    },
+    "datePublished": datePublished,
+    "dateModified": dateModified,
+    "image": "https://geoready.dev/assets/og-image.png",
+    "mainEntityOfPage": {
+      "@type": "WebPage",
+      "@id": canonical
+    },
+    "about": [
+      "Generative Engine Optimization",
+      "SEO",
+      "AI search visibility",
+      "GEO vs SEO",
+      "AI citations"
+    ]
+  })} />
+</Shell>

--- a/frontend/src/pages/guides/index.astro
+++ b/frontend/src/pages/guides/index.astro
@@ -10,6 +10,27 @@ const guides = [
       'A practical checklist for becoming citable by AI answer engines — crawlability, llms.txt, structured data, and the content patterns models tend to quote.',
     readingTime: '12 min read',
   },
+  {
+    href: '/guides/geo-vs-seo/',
+    title: 'GEO vs SEO: what changes when AI engines become the interface',
+    description:
+      'SEO and GEO share technical foundations but diverge in what they optimize for. A guide to the overlap, the differences, and where to focus effort when AI answer engines matter.',
+    readingTime: '10 min read',
+  },
+  {
+    href: '/guides/llms-txt-wordpress/',
+    title: 'llms.txt for WordPress and AI visibility: a practical guide',
+    description:
+      'What llms.txt is, what it actually does, and how to implement it on WordPress — manually or with a plugin. Includes format reference and what to include.',
+    readingTime: '9 min read',
+  },
+  {
+    href: '/guides/ai-visibility-checklist/',
+    title: 'AI visibility checklist: how to make your website easier to find, cite, and recommend',
+    description:
+      'All the technical and content signals that affect AI answer engine visibility, organized by category with clear pass/fail criteria. Crawlability, schema, llms.txt, brand signals, and more.',
+    readingTime: '14 min read',
+  },
 ];
 ---
 

--- a/frontend/src/pages/guides/llms-txt-wordpress.astro
+++ b/frontend/src/pages/guides/llms-txt-wordpress.astro
@@ -1,0 +1,310 @@
+---
+import Shell from '../../components/Shell.astro';
+
+const title = 'llms.txt for WordPress and AI Visibility: A Practical Guide';
+const description =
+  'llms.txt is a plain-text file that helps AI tools understand your site. This guide explains what it is, what it actually does, and how to implement it on WordPress — manually or with a plugin.';
+const canonical = 'https://geoready.dev/guides/llms-txt-wordpress/';
+const datePublished = '2026-06-05';
+const dateModified = '2026-06-05';
+---
+
+<Shell title={title} description={description} canonical={canonical}>
+  <article class="max-w-3xl mx-auto px-4 sm:px-6 py-10 md:py-16">
+    {/* Header */}
+    <header class="mb-12 md:mb-16">
+      <div class="flex items-center gap-2 text-[10px] font-mono text-text-muted uppercase tracking-wider">
+        <a href="/guides/" class="hover:text-accent-teal">Guides</a>
+        <span class="w-1 h-1 rounded-full bg-text-muted" />
+        <span>llms.txt</span>
+      </div>
+
+      <h1 class="mt-3 font-display text-3xl md:text-4xl font-bold text-text-primary leading-tight tracking-tight">
+        llms.txt for WordPress and AI visibility: a practical guide
+      </h1>
+
+      <p class="mt-4 text-base md:text-lg text-text-secondary leading-relaxed">
+        <code class="text-sm font-mono">llms.txt</code> is a plain-text file at
+        your domain root that tells AI tools which of your pages matter and what
+        your site is about. It's an emerging convention, not a standard, and
+        it's not supported by every engine — but it's low-effort, low-risk, and
+        makes your key content explicit. This guide covers what it actually does,
+        how to create one on WordPress, and where it fits in your broader AI
+        visibility strategy.
+      </p>
+      <p class="mt-2 text-xs text-text-muted font-mono">
+        Published June 2026 · 9 min read
+      </p>
+    </header>
+
+    <div class="space-y-12 md:space-y-16 [&_h2]:font-display [&_h2]:text-2xl [&_h2]:font-bold [&_h2]:text-text-primary [&_h2]:leading-tight [&_h2]:tracking-tight [&_h3]:font-display [&_h3]:text-lg [&_h3]:font-semibold [&_h3]:text-text-primary [&_p]:text-text-secondary [&_p]:leading-relaxed [&_li]:text-text-secondary [&_li]:leading-relaxed">
+
+      {/* What is llms.txt */}
+      <section>
+        <h2>What is llms.txt?</h2>
+        <p class="mt-4">
+          <code class="text-sm font-mono">llms.txt</code> is a convention
+          proposed by Jeremy Howard in late 2024. The idea: place a plain-text
+          file at <code class="text-sm font-mono">yourdomain.com/llms.txt</code> that
+          lists your site's important URLs along with short descriptions, giving
+          AI tools a curated map of your content.
+        </p>
+        <p class="mt-4">
+          The analogy is <code class="text-sm font-mono">robots.txt</code> for
+          classic crawlers, or <code class="text-sm font-mono">humans.txt</code>
+          for people — a discoverable convention rather than a formal standard.
+          Unlike <code class="text-sm font-mono">robots.txt</code>, it's purely
+          informational: it doesn't block or allow anything.
+        </p>
+        <p class="mt-4">
+          There's also an extended form: <code class="text-sm font-mono">llms-full.txt</code>,
+          which contains the full text of your content for tools that want to
+          ingest it directly. This guide focuses on the standard
+          <code class="text-sm font-mono">llms.txt</code> index file.
+        </p>
+      </section>
+
+      {/* What it actually does */}
+      <section>
+        <h2>What it actually does — and doesn't</h2>
+        <p class="mt-4">
+          Be realistic about the scope:
+        </p>
+        <ul class="mt-4 space-y-2 list-disc pl-5">
+          <li><strong>It helps LLM-powered tools</strong> that explicitly read it — Claude's Projects feature, some RAG pipelines, research assistants, and tools built on the llms.txt spec.</li>
+          <li><strong>It's not a ranking signal</strong> for ChatGPT, Perplexity, or Gemini web search. Those engines use their own crawlers and retrieval systems; they don't consult your llms.txt when answering queries.</li>
+          <li><strong>It makes your priorities explicit</strong> — even if a tool doesn't read it, writing it forces you to decide which pages are your most important.</li>
+          <li><strong>It's low risk.</strong> A bad llms.txt won't hurt your SEO or block any crawler. The worst case is that tools ignore it.</li>
+        </ul>
+        <p class="mt-4">
+          In short: it's worth doing because the upside is real (better context
+          for tools that do read it) and the cost is an hour of work.
+        </p>
+      </section>
+
+      {/* The format */}
+      <section>
+        <h2>The llms.txt format</h2>
+        <p class="mt-4">
+          The file uses Markdown. The basic structure:
+        </p>
+        <pre class="mt-4 rounded-xl bg-bg-surface border border-border p-4 overflow-x-auto text-sm font-mono text-text-secondary leading-relaxed">{`# Your Site Name
+
+> One paragraph describing what this site is, who it's for, and what it covers.
+
+## Core pages
+
+- [Page title](https://yourdomain.com/page/): short description of what this page covers.
+- [Another page](https://yourdomain.com/other/): short description.
+
+## Documentation / Guides
+
+- [Guide title](https://yourdomain.com/guides/guide-name/): what this guide covers.
+
+## Optional: what to ignore
+
+- [/login](https://yourdomain.com/login/): authentication page, not useful content.`}</pre>
+        <p class="mt-4">
+          Rules of thumb:
+        </p>
+        <ul class="mt-4 space-y-2 list-disc pl-5">
+          <li>Use H1 for your site name, H2 for categories of pages.</li>
+          <li>The blockquote (<code class="text-sm font-mono">&gt;</code>) under the H1 is the site summary — make it clear and factual.</li>
+          <li>Keep descriptions to one sentence. They're context, not marketing copy.</li>
+          <li>Include your most important pages. Don't try to list everything.</li>
+          <li>Optionally link to an <code class="text-sm font-mono">llms-full.txt</code> at the bottom if you have one.</li>
+        </ul>
+      </section>
+
+      {/* WordPress implementation */}
+      <section>
+        <h2>Implementing on WordPress</h2>
+
+        <h3 class="mt-6">Option 1: manual file upload (simplest)</h3>
+        <p class="mt-3">
+          Create a plain text file named <code class="text-sm font-mono">llms.txt</code>,
+          write your content using the format above, and upload it to the root
+          of your web server (same directory as <code class="text-sm font-mono">wp-config.php</code>
+          and <code class="text-sm font-mono">robots.txt</code>). That's it.
+        </p>
+        <p class="mt-3">
+          To verify: visit <code class="text-sm font-mono">yourdomain.com/llms.txt</code>
+          in a browser. You should see plain text. If WordPress tries to serve
+          a 404 page instead, check that the file is in the true root directory,
+          not in <code class="text-sm font-mono">wp-content</code>.
+        </p>
+
+        <h3 class="mt-6">Option 2: serve via functions.php or a plugin</h3>
+        <p class="mt-3">
+          If you're on a managed host where FTP access to the root is restricted,
+          you can serve the file via WordPress itself. Add this to your theme's
+          <code class="text-sm font-mono">functions.php</code> or a site-specific plugin:
+        </p>
+        <pre class="mt-3 rounded-xl bg-bg-surface border border-border p-4 overflow-x-auto text-sm font-mono text-text-secondary leading-relaxed">{`add_action( 'init', function () {
+    add_rewrite_rule( '^llms\\.txt$', 'index.php?llms_txt=1', 'top' );
+} );
+
+add_filter( 'query_vars', function ( $vars ) {
+    $vars[] = 'llms_txt';
+    return $vars;
+} );
+
+add_action( 'template_redirect', function () {
+    if ( ! get_query_var( 'llms_txt' ) ) {
+        return;
+    }
+    header( 'Content-Type: text/plain; charset=UTF-8' );
+    echo "# Your Site Name\n\n";
+    echo "> One sentence describing your site.\n\n";
+    echo "## Core pages\n\n";
+    echo "- [Home](https://yourdomain.com/): description.\n";
+    // add more pages here
+    exit;
+} );`}</pre>
+        <p class="mt-3">
+          After adding this, go to <strong>Settings → Permalinks</strong> in
+          WordPress and click Save (this flushes rewrite rules without changing
+          anything). Then visit <code class="text-sm font-mono">yourdomain.com/llms.txt</code>
+          to verify.
+        </p>
+
+        <h3 class="mt-6">Option 3: dedicated plugins</h3>
+        <p class="mt-3">
+          Several WordPress plugins now generate llms.txt automatically by
+          reading your pages, posts, and custom post types. Search the WordPress
+          plugin directory for "llms.txt" to see current options. Verify what the
+          plugin outputs before relying on it — auto-generated files often include
+          too many low-priority pages.
+        </p>
+      </section>
+
+      {/* What to include */}
+      <section>
+        <h2>What to include — and what to skip</h2>
+
+        <h3 class="mt-6">Include</h3>
+        <ul class="mt-3 space-y-2 list-disc pl-5">
+          <li>Your homepage — with a description of what your site is and who it's for.</li>
+          <li>Core product or service pages — what you offer, concretely.</li>
+          <li>High-value content: guides, documentation, research, long-form articles.</li>
+          <li>About and contact pages — helps with entity associations.</li>
+          <li>Your most important landing pages.</li>
+        </ul>
+
+        <h3 class="mt-6">Skip</h3>
+        <ul class="mt-3 space-y-2 list-disc pl-5">
+          <li>Login, register, checkout, account, cart pages.</li>
+          <li>Pagination pages (<code class="text-sm font-mono">/page/2/</code>, etc.).</li>
+          <li>Tag and category archive pages unless they have real editorial content.</li>
+          <li>Any URL with query parameters or session state.</li>
+          <li>Pages you'd noindex in SEO.</li>
+        </ul>
+      </section>
+
+      {/* Maintenance */}
+      <section>
+        <h2>Keeping it up to date</h2>
+        <p class="mt-4">
+          If you upload a static file, update it when you publish major new
+          content. It doesn't need to be real-time — treating it like your
+          sitemap (update it when something meaningful changes) is fine.
+        </p>
+        <p class="mt-4">
+          If you generate it dynamically via a plugin or
+          <code class="text-sm font-mono">functions.php</code>, consider
+          pinning the most important pages explicitly rather than auto-generating
+          from all content. Auto-generation tends to produce noisy files that
+          dilute the signal.
+        </p>
+      </section>
+
+      {/* Where llms.txt fits */}
+      <section>
+        <h2>Where llms.txt fits in your AI visibility stack</h2>
+        <p class="mt-4">
+          Think of it as one layer in a broader strategy:
+        </p>
+        <ul class="mt-4 space-y-2 list-disc pl-5">
+          <li><strong>Crawlability</strong> — the foundation. AI crawlers need to reach your pages at all. See our <a href="/guides/appear-in-chatgpt-perplexity/" class="text-accent-teal hover:underline">ChatGPT/Perplexity guide</a> for the full checklist.</li>
+          <li><strong>Structured data (schema.org)</strong> — helps engines understand entities and relationships. Works for both classic SEO rich results and AI.</li>
+          <li><strong>llms.txt</strong> — a curated map for LLM tools. Complements, doesn't replace, structured data.</li>
+          <li><strong>Content quality</strong> — the most important layer. A perfect llms.txt pointing to thin content won't get you cited.</li>
+          <li><strong>Monitoring</strong> — track whether your changes move your AI visibility score over time.</li>
+        </ul>
+        <p class="mt-4">
+          See the full stack in the <a href="/guides/ai-visibility-checklist/" class="text-accent-teal hover:underline">AI visibility checklist</a>
+          and the <a href="/guides/geo-vs-seo/" class="text-accent-teal hover:underline">GEO vs SEO comparison</a>.
+        </p>
+      </section>
+
+      {/* CTA */}
+      <section class="rounded-2xl border border-border bg-bg-surface p-6 md:p-8">
+        <h2>Check your site's llms.txt and structured data</h2>
+        <p class="mt-3">
+          The free audit checks whether your llms.txt exists and is valid,
+          alongside seven other AI visibility categories. No account required.
+        </p>
+        <div class="mt-6 flex flex-col sm:flex-row gap-3">
+          <a
+            href="/#audit-form"
+            class="inline-flex items-center justify-center rounded-full bg-accent-teal px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-accent-teal-dark"
+          >
+            Run a free AI visibility audit
+          </a>
+          <a
+            href="https://app.geoready.dev/signup"
+            class="inline-flex items-center justify-center rounded-full border border-border px-6 py-3 text-sm font-medium text-text-primary transition-colors hover:border-accent-teal"
+          >
+            Create a GeoReady account
+          </a>
+        </div>
+        <p class="mt-4 text-xs text-text-muted">
+          A GeoReady account unlocks the full report and lets you track changes over time. See <a href="/pricing/" class="text-accent-teal hover:underline">pricing</a>.
+        </p>
+      </section>
+
+      {/* Further reading */}
+      <section>
+        <h2>Further reading</h2>
+        <ul class="mt-4 space-y-2 list-disc pl-5">
+          <li><a href="/guides/appear-in-chatgpt-perplexity/" class="text-accent-teal hover:underline">How to make your website appear in ChatGPT and Perplexity sources</a> — full technical checklist.</li>
+          <li><a href="/guides/geo-vs-seo/" class="text-accent-teal hover:underline">GEO vs SEO: what changes when AI becomes the interface</a>.</li>
+          <li><a href="/guides/ai-visibility-checklist/" class="text-accent-teal hover:underline">AI Visibility Checklist</a> — all signals in one place.</li>
+          <li>The research behind these guides: <a href="/research/" class="text-accent-teal hover:underline">GEO Optimizer research foundation</a>.</li>
+          <li>Our take on why AI visibility should be auditable: <a href="/manifesto/" class="text-accent-teal hover:underline">the manifesto</a>.</li>
+        </ul>
+      </section>
+    </div>
+  </article>
+
+  <script type="application/ld+json" set:html={JSON.stringify({
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "headline": title,
+    "description": description,
+    "author": {
+      "@type": "Organization",
+      "name": "Auriti Labs",
+      "url": "https://github.com/Auriti-Labs"
+    },
+    "publisher": {
+      "@type": "Organization",
+      "name": "Auriti Labs",
+      "url": "https://github.com/Auriti-Labs"
+    },
+    "datePublished": datePublished,
+    "dateModified": dateModified,
+    "image": "https://geoready.dev/assets/og-image.png",
+    "mainEntityOfPage": {
+      "@type": "WebPage",
+      "@id": canonical
+    },
+    "about": [
+      "llms.txt",
+      "AI visibility",
+      "WordPress",
+      "Generative Engine Optimization",
+      "AI search"
+    ]
+  })} />
+</Shell>


### PR DESCRIPTION
## Problem solved

geoready.dev had one guide in `/guides/`. The hub was live but thin — no content depth, no internal linking, no keyword surface for GEO vs SEO, llms.txt, or AI visibility checklist queries.

## Guides added (3)

| URL | Title | Read time |
|-----|-------|-----------|
| `/guides/geo-vs-seo/` | GEO vs SEO: What Changes When AI Engines Become the Interface | 10 min |
| `/guides/llms-txt-wordpress/` | llms.txt for WordPress and AI Visibility: A Practical Guide | 9 min |
| `/guides/ai-visibility-checklist/` | AI Visibility Checklist: How to Make Your Website Easier to Find, Cite, and Recommend | 14 min |

## Sitemap update

Three new `<url>` entries added to `frontend/public/sitemap.xml`:
- `https://geoready.dev/guides/geo-vs-seo/`
- `https://geoready.dev/guides/llms-txt-wordpress/`
- `https://geoready.dev/guides/ai-visibility-checklist/`
All with `lastmod: 2026-06-05`, `changefreq: monthly`, `priority: 0.7`.

## /guides/ index update

`frontend/src/pages/guides/index.astro` now lists all 4 guides with title, description, and reading time.

## Internal link mesh

All 4 guides cross-link each other in their "Further reading" sections. Links present:
- → `/guides/appear-in-chatgpt-perplexity/`
- → `/guides/geo-vs-seo/`
- → `/guides/llms-txt-wordpress/`
- → `/guides/ai-visibility-checklist/`
- → `/research/`
- → `/manifesto/`
- → `/pricing/`
- → `/#audit-form`
- → `https://app.geoready.dev/signup`

## CTA strategy

Every guide has two CTAs:
- **Primary:** "Run a free AI visibility audit" → `/#audit-form` (teal button)
- **Secondary:** "Create a GeoReady account" → `https://app.geoready.dev/signup` (outline button)

The two CTAs are described as distinct actions. Signup is not described as the free anonymous audit.

## Build result

`npm run build` — green, 20 pages, 0 errors, 0 warnings.
All 3 new routes generated: `/guides/geo-vs-seo/index.html`, `/guides/llms-txt-wordpress/index.html`, `/guides/ai-visibility-checklist/index.html`.

## Branch base

Branch is based on `origin/main` at `9894ebe` (feat(site): add guides hub with first AI visibility pillar, PR #495). Exactly 1 commit ahead: `bce53c5`.

## Deploy risk

None from this PR. Static Astro pages, no backend changes, no API changes, no schema migrations, no dependency changes.

## Residual risks

- No visual/browser QA performed (dev server not started). Build output is correct HTML; layout untested in browser.
- Schema.org Article JSON-LD not validated against Google Rich Results Test — structure follows existing guide pattern, no known issues.
- `app.geoready.dev/signup` link hardcoded in CTAs — if signup URL changes, all 4 guides need updating.