### PR TITLE
feat(site): add SVG illustrations to guides

### DIFF
--- a/frontend/src/components/guide-visuals/A1HeroAIDiscovery.astro
+++ b/frontend/src/components/guide-visuals/A1HeroAIDiscovery.astro
@@ -1,0 +1,97 @@
+---
+---
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 220" width="100%" height="auto" role="img" aria-labelledby="a1-hero-title">
+  <title id="a1-hero-title">How AI answer engines discover and cite a website: end-to-end flow from website through signal pillars to AI engines and citation output</title>
+
+  <!-- Section label -->
+  <text x="390" y="22" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#475569" text-anchor="middle">How AI answer engines discover and cite a website</text>
+
+  <!-- ── 1. Your Website box ── -->
+  <rect x="18" y="44" width="112" height="132" rx="8" fill="#F7F5F0" stroke="#E2E0DA" stroke-width="1.5"/>
+  <!-- Circle icon with W -->
+  <circle cx="74" cy="84" r="20" fill="#FFFFFF" stroke="#E2E0DA" stroke-width="1.5"/>
+  <text x="74" y="89" font-family="system-ui, -apple-system, sans-serif" font-size="15" font-weight="600" fill="#0F172A" text-anchor="middle">W</text>
+  <!-- Label -->
+  <text x="74" y="116" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="600" fill="#0F172A" text-anchor="middle">Your</text>
+  <text x="74" y="131" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="600" fill="#0F172A" text-anchor="middle">Website</text>
+  <text x="74" y="166" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#94A3B8" text-anchor="middle">Any domain</text>
+
+  <!-- ── Arrow 1 ── -->
+  <line x1="132" y1="110" x2="162" y2="110" stroke="#94A3B8" stroke-width="1.5" stroke-linecap="round"/>
+  <polyline points="157,104 163,110 157,116" fill="none" stroke="#94A3B8" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <!-- ── 2. Signal pillars box ── -->
+  <rect x="166" y="44" width="148" height="132" rx="8" fill="#F7F5F0" stroke="#E2E0DA" stroke-width="1.5"/>
+  <text x="240" y="65" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="600" fill="#475569" text-anchor="middle">Signals</text>
+
+  <!-- Signal pill: Crawlable -->
+  <rect x="182" y="73" width="116" height="22" rx="5" fill="#FFFFFF" stroke="#E2E0DA" stroke-width="1.5"/>
+  <circle cx="196" cy="84" r="4" fill="#0D9488"/>
+  <text x="206" y="88" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#0F172A">Crawlable</text>
+
+  <!-- Signal pill: Structured Data -->
+  <rect x="182" y="100" width="116" height="22" rx="5" fill="#FFFFFF" stroke="#E2E0DA" stroke-width="1.5"/>
+  <circle cx="196" cy="111" r="4" fill="#0D9488"/>
+  <text x="206" y="115" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#0F172A">Structured Data</text>
+
+  <!-- Signal pill: llms.txt -->
+  <rect x="182" y="127" width="116" height="22" rx="5" fill="#FFFFFF" stroke="#E2E0DA" stroke-width="1.5"/>
+  <circle cx="196" cy="138" r="4" fill="#6366F1"/>
+  <text x="206" y="142" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#0F172A">llms.txt</text>
+
+  <!-- Signal pill: Clear Content -->
+  <rect x="182" y="154" width="116" height="22" rx="5" fill="#FFFFFF" stroke="#E2E0DA" stroke-width="1.5"/>
+  <circle cx="196" cy="165" r="4" fill="#0D9488"/>
+  <text x="206" y="169" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#0F172A">Clear Content</text>
+
+  <!-- ── Arrow 2 ── -->
+  <line x1="316" y1="110" x2="346" y2="110" stroke="#94A3B8" stroke-width="1.5" stroke-linecap="round"/>
+  <polyline points="341,104 347,110 341,116" fill="none" stroke="#94A3B8" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <!-- ── 3. Engine nodes 2x2 grid ── -->
+  <!-- ChatGPT -->
+  <rect x="350" y="50" width="106" height="44" rx="7" fill="#0D9488"/>
+  <text x="403" y="72" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#FFFFFF" text-anchor="middle">ChatGPT</text>
+  <text x="403" y="86" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#FFFFFF" text-anchor="middle" opacity="0.8">OpenAI</text>
+
+  <!-- Perplexity -->
+  <rect x="464" y="50" width="106" height="44" rx="7" fill="#0D9488"/>
+  <text x="517" y="72" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#FFFFFF" text-anchor="middle">Perplexity</text>
+  <text x="517" y="86" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#FFFFFF" text-anchor="middle" opacity="0.8">AI Search</text>
+
+  <!-- Claude -->
+  <rect x="350" y="126" width="106" height="44" rx="7" fill="#0D9488"/>
+  <text x="403" y="148" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#FFFFFF" text-anchor="middle">Claude</text>
+  <text x="403" y="162" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#FFFFFF" text-anchor="middle" opacity="0.8">Anthropic</text>
+
+  <!-- Gemini -->
+  <rect x="464" y="126" width="106" height="44" rx="7" fill="#0D9488"/>
+  <text x="517" y="148" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#FFFFFF" text-anchor="middle">Gemini</text>
+  <text x="517" y="162" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#FFFFFF" text-anchor="middle" opacity="0.8">Google</text>
+
+  <!-- Connector lines inside engine grid (vertical and horizontal midlines) -->
+  <line x1="456" y1="72" x2="464" y2="72" stroke="#0F766E" stroke-width="1" stroke-dasharray="3,2"/>
+  <line x1="456" y1="148" x2="464" y2="148" stroke="#0F766E" stroke-width="1" stroke-dasharray="3,2"/>
+  <line x1="403" y1="94" x2="403" y2="126" stroke="#0F766E" stroke-width="1" stroke-dasharray="3,2"/>
+  <line x1="517" y1="94" x2="517" y2="126" stroke="#0F766E" stroke-width="1" stroke-dasharray="3,2"/>
+
+  <!-- ── Arrow 3 ── -->
+  <line x1="572" y1="110" x2="602" y2="110" stroke="#94A3B8" stroke-width="1.5" stroke-linecap="round"/>
+  <polyline points="597,104 603,110 597,116" fill="none" stroke="#94A3B8" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <!-- ── 4. Citation output box ── -->
+  <rect x="606" y="62" width="152" height="96" rx="8" fill="#059669"/>
+  <!-- Checkmark icon -->
+  <circle cx="640" cy="96" r="14" fill="#FFFFFF" fill-opacity="0.2"/>
+  <polyline points="633,96 638,102 648,88" fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- Label -->
+  <text x="682" y="91" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="700" fill="#FFFFFF">Citation</text>
+  <text x="682" y="108" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#FFFFFF" opacity="0.9">Your site appears</text>
+  <text x="682" y="122" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#FFFFFF" opacity="0.9">in AI answers</text>
+
+  <!-- Bottom caption row -->
+  <text x="74" y="198" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#94A3B8" text-anchor="middle">Source</text>
+  <text x="240" y="198" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#94A3B8" text-anchor="middle">Optimization signals</text>
+  <text x="462" y="198" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#94A3B8" text-anchor="middle">AI answer engines</text>
+  <text x="682" y="198" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#94A3B8" text-anchor="middle">Outcome</text>
+</svg>

--- a/frontend/src/components/guide-visuals/A2TechFoundations.astro
+++ b/frontend/src/components/guide-visuals/A2TechFoundations.astro
@@ -1,0 +1,73 @@
+---
+---
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 160" width="100%" height="auto" role="img" aria-labelledby="a2-tech-title">
+  <title id="a2-tech-title">Technical foundations for AI citability</title>
+
+  <!-- Background -->
+  <rect width="680" height="160" fill="#F7F5F0"/>
+
+  <!-- Title -->
+  <text x="340" y="22" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="600" fill="#0F172A" text-anchor="middle">Technical foundations for AI citability</text>
+
+  <!-- Block 1: robots.txt -->
+  <rect x="12" y="36" width="100" height="84" rx="8" ry="8" fill="#FFFFFF" stroke="#E2E0DA" stroke-width="1.5"/>
+  <!-- Icon: file with lines -->
+  <rect x="42" y="46" width="18" height="22" rx="2" ry="2" fill="none" stroke="#0D9488" stroke-width="1.5"/>
+  <path d="M45 54h12M45 59h9M45 64h10" stroke="#0D9488" stroke-width="1.5" stroke-linecap="round"/>
+  <text x="62" y="83" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="600" fill="#0F172A" text-anchor="middle">robots.txt</text>
+  <text x="62" y="96" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#475569" text-anchor="middle">crawl access</text>
+  <text x="62" y="109" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#475569" text-anchor="middle">control</text>
+
+  <!-- Block 2: Canonical URL -->
+  <rect x="122" y="36" width="100" height="84" rx="8" ry="8" fill="#FFFFFF" stroke="#E2E0DA" stroke-width="1.5"/>
+  <!-- Icon: link chain -->
+  <path d="M158 57 a6 6 0 0 1 8.5 0l3 3 a6 6 0 0 1 0 8.5l-3 3 a6 6 0 0 1-8.5 0" fill="none" stroke="#0D9488" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M169 57 a6 6 0 0 0-8.5 0l-3 3 a6 6 0 0 0 0 8.5l3 3 a6 6 0 0 0 8.5 0" fill="none" stroke="#0D9488" stroke-width="1.5" stroke-linecap="round"/>
+  <text x="172" y="83" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="600" fill="#0F172A" text-anchor="middle">Canonical URL</text>
+  <text x="172" y="96" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#475569" text-anchor="middle">no duplicate</text>
+  <text x="172" y="109" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#475569" text-anchor="middle">content signals</text>
+
+  <!-- Block 3: Structured Data -->
+  <rect x="232" y="36" width="100" height="84" rx="8" ry="8" fill="#FFFFFF" stroke="#E2E0DA" stroke-width="1.5"/>
+  <!-- Icon: curly braces -->
+  <path d="M268 48 q-8 0-8 8 v2 q0 6-6 6 q6 0 6 6 v2 q0 8 8 8" fill="none" stroke="#0D9488" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M278 48 q8 0 8 8 v2 q0 6 6 6 q-6 0-6 6 v2 q0 8-8 8" fill="none" stroke="#0D9488" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="282" y="83" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="600" fill="#0F172A" text-anchor="middle">Structured Data</text>
+  <text x="282" y="96" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#475569" text-anchor="middle">schema.org</text>
+  <text x="282" y="109" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#475569" text-anchor="middle">markup</text>
+
+  <!-- Block 4: llms.txt -->
+  <rect x="342" y="36" width="100" height="84" rx="8" ry="8" fill="#FFFFFF" stroke="#E2E0DA" stroke-width="1.5"/>
+  <!-- Icon: robot/AI head -->
+  <rect x="374" y="46" width="16" height="14" rx="3" ry="3" fill="none" stroke="#6366F1" stroke-width="1.5"/>
+  <circle cx="378" cy="53" r="2" fill="#6366F1"/>
+  <circle cx="386" cy="53" r="2" fill="#6366F1"/>
+  <path d="M378 58 q4 3 8 0" fill="none" stroke="#6366F1" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="382" y1="46" x2="382" y2="43" stroke="#6366F1" stroke-width="1.5" stroke-linecap="round"/>
+  <circle cx="382" cy="42" r="1.5" fill="#6366F1"/>
+  <path d="M374 60 l-4 4 M390 60 l4 4" stroke="#6366F1" stroke-width="1.5" stroke-linecap="round"/>
+  <text x="392" y="83" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="600" fill="#0F172A" text-anchor="middle">llms.txt</text>
+  <text x="392" y="96" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#475569" text-anchor="middle">AI engine</text>
+  <text x="392" y="109" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#475569" text-anchor="middle">instructions</text>
+
+  <!-- Block 5: Clean HTML -->
+  <rect x="452" y="36" width="100" height="84" rx="8" ry="8" fill="#FFFFFF" stroke="#E2E0DA" stroke-width="1.5"/>
+  <!-- Icon: angle brackets -->
+  <path d="M484 55 l-8 10 l8 10" fill="none" stroke="#0D9488" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M520 55 l8 10 l-8 10" fill="none" stroke="#0D9488" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <line x1="508" y1="52" x2="496" y2="78" stroke="#0D9488" stroke-width="1.5" stroke-linecap="round"/>
+  <text x="502" y="83" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="600" fill="#0F172A" text-anchor="middle">Clean HTML</text>
+  <text x="502" y="96" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#475569" text-anchor="middle">semantic</text>
+  <text x="502" y="109" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#475569" text-anchor="middle">markup</text>
+
+  <!-- Block 6: Fast Response -->
+  <rect x="562" y="36" width="106" height="84" rx="8" ry="8" fill="#FFFFFF" stroke="#E2E0DA" stroke-width="1.5"/>
+  <!-- Icon: lightning bolt / speedometer -->
+  <path d="M622 46 l-6 12 h5 l-5 14 l10-16 h-5 z" fill="#D97706" stroke="#D97706" stroke-width="0.5" stroke-linejoin="round"/>
+  <text x="615" y="83" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="600" fill="#0F172A" text-anchor="middle">Fast Response</text>
+  <text x="615" y="96" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#475569" text-anchor="middle">TTFB &lt; 200ms</text>
+  <text x="615" y="109" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#475569" text-anchor="middle">target</text>
+
+  <!-- Subtext -->
+  <text x="340" y="147" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#94A3B8" text-anchor="middle">All six must be present before AI engines can reliably retrieve and cite a page</text>
+</svg>

--- a/frontend/src/components/guide-visuals/A3FailureModes.astro
+++ b/frontend/src/components/guide-visuals/A3FailureModes.astro
@@ -1,0 +1,81 @@
+---
+---
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 180" width="100%" height="auto" role="img" aria-labelledby="a3-fail-title">
+  <title id="a3-fail-title">Common reasons a website fails to get cited by AI engines</title>
+
+  <!-- Background -->
+  <rect width="680" height="180" fill="#F7F5F0"/>
+
+  <!-- Section title -->
+  <text x="340" y="24" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#0F172A">Common reasons a website fails to get cited by AI engines</text>
+
+  <!-- Card 1: Blocked Crawlers -->
+  <rect x="16" y="40" width="120" height="124" rx="8" fill="#FFF7ED" stroke="#D97706" stroke-width="1.5"/>
+  <!-- Warning icon -->
+  <polygon points="76,58 68,72 84,72" fill="none" stroke="#D97706" stroke-width="1.5" stroke-linejoin="round"/>
+  <line x1="76" y1="63" x2="76" y2="68" stroke="#D97706" stroke-width="1.5" stroke-linecap="round"/>
+  <circle cx="76" cy="70.5" r="0.8" fill="#D97706"/>
+  <!-- Label -->
+  <text x="76" y="92" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="700" fill="#0F172A">Blocked</text>
+  <text x="76" y="107" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="700" fill="#0F172A">Crawlers</text>
+  <!-- Description -->
+  <text x="76" y="126" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#475569">robots.txt or</text>
+  <text x="76" y="139" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#475569">noindex tags</text>
+  <text x="76" y="152" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#475569">block AI bots</text>
+
+  <!-- Card 2: JS-only Content -->
+  <rect x="148" y="40" width="120" height="124" rx="8" fill="#FFF7ED" stroke="#D97706" stroke-width="1.5"/>
+  <!-- Warning icon -->
+  <polygon points="208,58 200,72 216,72" fill="none" stroke="#D97706" stroke-width="1.5" stroke-linejoin="round"/>
+  <line x1="208" y1="63" x2="208" y2="68" stroke="#D97706" stroke-width="1.5" stroke-linecap="round"/>
+  <circle cx="208" cy="70.5" r="0.8" fill="#D97706"/>
+  <!-- Label -->
+  <text x="208" y="92" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="700" fill="#0F172A">JS-only</text>
+  <text x="208" y="107" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="700" fill="#0F172A">Content</text>
+  <!-- Description -->
+  <text x="208" y="126" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#475569">Text rendered</text>
+  <text x="208" y="139" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#475569">only via JS is</text>
+  <text x="208" y="152" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#475569">invisible to AI</text>
+
+  <!-- Card 3: Thin Copy -->
+  <rect x="280" y="40" width="120" height="124" rx="8" fill="#FFF7ED" stroke="#D97706" stroke-width="1.5"/>
+  <!-- Warning icon -->
+  <polygon points="340,58 332,72 348,72" fill="none" stroke="#D97706" stroke-width="1.5" stroke-linejoin="round"/>
+  <line x1="340" y1="63" x2="340" y2="68" stroke="#D97706" stroke-width="1.5" stroke-linecap="round"/>
+  <circle cx="340" cy="70.5" r="0.8" fill="#D97706"/>
+  <!-- Label -->
+  <text x="340" y="92" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="700" fill="#0F172A">Thin</text>
+  <text x="340" y="107" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="700" fill="#0F172A">Copy</text>
+  <!-- Description -->
+  <text x="340" y="126" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#475569">Too little text</text>
+  <text x="340" y="139" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#475569">for AI to extract</text>
+  <text x="340" y="152" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#475569">a clear answer</text>
+
+  <!-- Card 4: Vague Claims -->
+  <rect x="412" y="40" width="120" height="124" rx="8" fill="#FFF7ED" stroke="#D97706" stroke-width="1.5"/>
+  <!-- Warning icon -->
+  <polygon points="472,58 464,72 480,72" fill="none" stroke="#D97706" stroke-width="1.5" stroke-linejoin="round"/>
+  <line x1="472" y1="63" x2="472" y2="68" stroke="#D97706" stroke-width="1.5" stroke-linecap="round"/>
+  <circle cx="472" cy="70.5" r="0.8" fill="#D97706"/>
+  <!-- Label -->
+  <text x="472" y="92" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="700" fill="#0F172A">Vague</text>
+  <text x="472" y="107" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="700" fill="#0F172A">Claims</text>
+  <!-- Description -->
+  <text x="472" y="126" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#475569">Generic phrases</text>
+  <text x="472" y="139" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#475569">lack the facts</text>
+  <text x="472" y="152" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#475569">AI wants to cite</text>
+
+  <!-- Card 5: No Schema -->
+  <rect x="544" y="40" width="120" height="124" rx="8" fill="#FFF7ED" stroke="#D97706" stroke-width="1.5"/>
+  <!-- Warning icon -->
+  <polygon points="604,58 596,72 612,72" fill="none" stroke="#D97706" stroke-width="1.5" stroke-linejoin="round"/>
+  <line x1="604" y1="63" x2="604" y2="68" stroke="#D97706" stroke-width="1.5" stroke-linecap="round"/>
+  <circle cx="604" cy="70.5" r="0.8" fill="#D97706"/>
+  <!-- Label -->
+  <text x="604" y="92" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="700" fill="#0F172A">No</text>
+  <text x="604" y="107" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="700" fill="#0F172A">Schema</text>
+  <!-- Description -->
+  <text x="604" y="126" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#475569">Missing structured</text>
+  <text x="604" y="139" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#475569">data reduces AI</text>
+  <text x="604" y="152" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#475569">confidence</text>
+</svg>

--- a/frontend/src/components/guide-visuals/B1HeroSEOvsGEO.astro
+++ b/frontend/src/components/guide-visuals/B1HeroSEOvsGEO.astro
@@ -1,0 +1,123 @@
+---
+---
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 220" width="100%" height="auto" role="img" aria-labelledby="b1-hero-title">
+  <title id="b1-hero-title">SEO vs GEO: Traditional search returns a ranked list of links; AI answer engines synthesize a direct answer with inline citations</title>
+
+  <!-- LEFT column background -->
+  <rect x="0" y="0" width="370" height="220" fill="#F7F5F0" rx="0"/>
+
+  <!-- RIGHT column background -->
+  <rect x="410" y="0" width="370" height="220" fill="#F0FBFA" rx="0"/>
+
+  <!-- Center divider line -->
+  <line x1="390" y1="16" x2="390" y2="204" stroke="#E2E0DA" stroke-width="1.5"/>
+
+  <!-- "vs" label -->
+  <rect x="374" y="98" width="32" height="22" fill="#FFFFFF" rx="4"/>
+  <text x="390" y="114" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="700" fill="#94A3B8">vs</text>
+
+  <!-- ============ LEFT COLUMN ============ -->
+
+  <!-- Column header -->
+  <text x="185" y="26" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="700" fill="#0F172A">SEO — Traditional Search</text>
+
+  <!-- Search box -->
+  <rect x="108" y="36" width="154" height="26" rx="5" fill="#FFFFFF" stroke="#E2E0DA" stroke-width="1.5"/>
+  <!-- Search icon circle -->
+  <circle cx="123" cy="49" r="6" fill="none" stroke="#94A3B8" stroke-width="1.5"/>
+  <line x1="127.2" y1="53.2" x2="131" y2="57" stroke="#94A3B8" stroke-width="1.5" stroke-linecap="round"/>
+  <!-- Query text lines -->
+  <rect x="134" y="45" width="52" height="4" rx="2" fill="#CBD5E1"/>
+  <rect x="134" y="52" width="36" height="3" rx="1.5" fill="#E2E0DA"/>
+
+  <!-- Arrow down -->
+  <line x1="185" y1="64" x2="185" y2="76" stroke="#94A3B8" stroke-width="1.5" stroke-linecap="round"/>
+  <polyline points="181,73 185,78 189,73" fill="none" stroke="#94A3B8" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <!-- Ranked list box -->
+  <rect x="84" y="80" width="202" height="104" rx="6" fill="#FFFFFF" stroke="#E2E0DA" stroke-width="1.5"/>
+
+  <!-- List items -->
+  <!-- Item 1 -->
+  <text x="98" y="98" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#94A3B8">1</text>
+  <rect x="110" y="90" width="88" height="4" rx="2" fill="#CBD5E1"/>
+  <rect x="110" y="97" width="64" height="3" rx="1.5" fill="#E2E0DA"/>
+
+  <!-- Item 2 -->
+  <text x="98" y="118" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#94A3B8">2</text>
+  <rect x="110" y="110" width="96" height="4" rx="2" fill="#CBD5E1"/>
+  <rect x="110" y="117" width="72" height="3" rx="1.5" fill="#E2E0DA"/>
+
+  <!-- Item 3 — highlighted -->
+  <rect x="88" y="125" width="192" height="22" rx="4" fill="#FEF9C3" stroke="#D97706" stroke-width="1.5"/>
+  <text x="98" y="139" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="700" fill="#D97706">3</text>
+  <rect x="110" y="130" width="100" height="4" rx="2" fill="#FDE68A"/>
+  <rect x="110" y="137" width="76" height="3" rx="1.5" fill="#FDE68A"/>
+  <!-- "click" arrow label -->
+  <line x1="254" y1="136" x2="266" y2="136" stroke="#D97706" stroke-width="1.5" stroke-linecap="round"/>
+  <polyline points="262,132 267,136 262,140" fill="none" stroke="#D97706" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="270" y="140" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#D97706" font-weight="600">click</text>
+
+  <!-- Item 4 -->
+  <text x="98" y="162" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#94A3B8">4</text>
+  <rect x="110" y="154" width="80" height="4" rx="2" fill="#E2E0DA"/>
+  <rect x="110" y="161" width="58" height="3" rx="1.5" fill="#E2E0DA"/>
+
+  <!-- Item 5 -->
+  <text x="98" y="178" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E2E0DA">5</text>
+  <rect x="110" y="170" width="72" height="4" rx="2" fill="#E2E0DA"/>
+  <rect x="110" y="177" width="50" height="3" rx="1.5" fill="#EEE"/>
+
+  <!-- ============ RIGHT COLUMN ============ -->
+
+  <!-- Column header -->
+  <text x="595" y="26" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="700" fill="#0F172A">GEO — AI Answer Engines</text>
+
+  <!-- AI box -->
+  <rect x="518" y="36" width="154" height="26" rx="5" fill="#FFFFFF" stroke="#0D9488" stroke-width="1.5"/>
+  <!-- AI icon -->
+  <circle cx="533" cy="49" r="7" fill="#0D9488"/>
+  <text x="533" y="53" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="9" font-weight="700" fill="#FFFFFF">AI</text>
+  <!-- Query text lines -->
+  <rect x="546" y="45" width="52" height="4" rx="2" fill="#99F6E4"/>
+  <rect x="546" y="52" width="36" height="3" rx="1.5" fill="#CCFBF1"/>
+
+  <!-- Arrow down -->
+  <line x1="595" y1="64" x2="595" y2="76" stroke="#0D9488" stroke-width="1.5" stroke-linecap="round"/>
+  <polyline points="591,73 595,78 599,73" fill="none" stroke="#0D9488" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <!-- Answer block -->
+  <rect x="494" y="80" width="202" height="104" rx="6" fill="#FFFFFF" stroke="#0D9488" stroke-width="1.5"/>
+
+  <!-- Paragraph header hint -->
+  <rect x="506" y="92" width="60" height="5" rx="2.5" fill="#0D9488" opacity="0.25"/>
+
+  <!-- Squiggly text lines (represented as slightly wavy rects) -->
+  <!-- Line 1 -->
+  <rect x="506" y="103" width="178" height="4" rx="2" fill="#CBD5E1"/>
+  <!-- Line 2 -->
+  <rect x="506" y="112" width="162" height="4" rx="2" fill="#CBD5E1"/>
+  <!-- Line 3 -->
+  <rect x="506" y="121" width="174" height="4" rx="2" fill="#CBD5E1"/>
+  <!-- Line 4 — shorter, ends with citations -->
+  <rect x="506" y="130" width="110" height="4" rx="2" fill="#CBD5E1"/>
+
+  <!-- Citation badge [1] -->
+  <rect x="622" y="125" width="22" height="14" rx="3" fill="#0D9488"/>
+  <text x="633" y="135.5" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="700" fill="#FFFFFF">[1]</text>
+
+  <!-- Citation badge [2] -->
+  <rect x="649" y="125" width="22" height="14" rx="3" fill="#0F766E"/>
+  <text x="660" y="135.5" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="700" fill="#FFFFFF">[2]</text>
+
+  <!-- Source attribution row -->
+  <rect x="506" y="148" width="1" height="24" rx="0.5" fill="#0D9488" opacity="0.4"/>
+  <rect x="511" y="150" width="58" height="4" rx="2" fill="#99F6E4"/>
+  <rect x="511" y="157" width="42" height="3" rx="1.5" fill="#CCFBF1"/>
+  <rect x="576" y="150" width="52" height="4" rx="2" fill="#99F6E4"/>
+  <rect x="576" y="157" width="38" height="3" rx="1.5" fill="#CCFBF1"/>
+
+  <!-- "cited inline" label -->
+  <text x="595" y="178" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#0D9488" font-weight="600">sources cited inline</text>
+
+</svg>

--- a/frontend/src/components/guide-visuals/B2RankingVsCitation.astro
+++ b/frontend/src/components/guide-visuals/B2RankingVsCitation.astro
@@ -1,0 +1,91 @@
+---
+---
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 160" width="100%" height="auto" role="img" aria-labelledby="b2-rank-title">
+  <title id="b2-rank-title">In traditional search, you rank. In AI answers, you get cited — or you don't.</title>
+
+  <!-- Background -->
+  <rect width="680" height="160" fill="#F7F5F0"/>
+
+  <!-- Header text -->
+  <text x="340" y="22" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#0F172A">In traditional search, you rank. In AI answers, you get cited — or you don't.</text>
+
+  <!-- Divider below header -->
+  <line x1="24" y1="32" x2="656" y2="32" stroke="#E2E0DA" stroke-width="1"/>
+
+  <!-- ── LEFT PANEL: Ranking ── -->
+  <!-- Panel BG -->
+  <rect x="24" y="40" width="296" height="108" rx="6" fill="#FFFFFF" stroke="#E2E0DA" stroke-width="1"/>
+
+  <!-- Column header -->
+  <text x="36" y="58" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="700" fill="#0F172A">Ranking</text>
+  <text x="36" y="72" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#475569">Traditional search results</text>
+
+  <!-- Row 1 — highlighted -->
+  <rect x="36" y="80" width="272" height="14" rx="3" fill="#CCFBF1"/>
+  <text x="44" y="91" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="600" fill="#0F766E">#1</text>
+  <rect x="62" y="83" width="180" height="7" rx="2" fill="#0D9488"/>
+  <rect x="248" y="83" width="48" height="7" rx="2" fill="#99F6E4"/>
+
+  <!-- Row 2 -->
+  <rect x="36" y="97" width="272" height="13" rx="3" fill="#F7F5F0"/>
+  <text x="44" y="107" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#94A3B8">#2</text>
+  <rect x="62" y="100" width="152" height="6" rx="2" fill="#E2E0DA"/>
+  <rect x="220" y="100" width="56" height="6" rx="2" fill="#E2E0DA"/>
+
+  <!-- Row 3 -->
+  <rect x="36" y="113" width="272" height="13" rx="3" fill="#F7F5F0"/>
+  <text x="44" y="123" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#94A3B8">#3</text>
+  <rect x="62" y="116" width="120" height="6" rx="2" fill="#E2E0DA"/>
+  <rect x="188" y="116" width="72" height="6" rx="2" fill="#E2E0DA"/>
+
+  <!-- Row 4 -->
+  <rect x="36" y="129" width="272" height="13" rx="3" fill="#F7F5F0"/>
+  <text x="44" y="139" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#94A3B8">#4</text>
+  <rect x="62" y="132" width="136" height="6" rx="2" fill="#E2E0DA"/>
+  <rect x="204" y="132" width="60" height="6" rx="2" fill="#E2E0DA"/>
+
+  <!-- Row 5 -->
+  <rect x="36" y="141" width="272" height="5" rx="2.5"/>
+  <rect x="36" y="141" width="272" height="5" rx="2.5" fill="#F7F5F0"/>
+  <text x="44" y="140" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#94A3B8">#5</text>
+  <rect x="62" y="143" width="100" height="5" rx="2" fill="#E2E0DA"/>
+
+  <!-- ── RIGHT PANEL: Citation ── -->
+  <!-- Panel BG -->
+  <rect x="360" y="40" width="296" height="108" rx="6" fill="#FFFFFF" stroke="#E2E0DA" stroke-width="1"/>
+
+  <!-- Column header -->
+  <text x="372" y="58" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="700" fill="#0F172A">Citation</text>
+  <text x="372" y="72" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#475569">AI-generated answer</text>
+
+  <!-- Body paragraph lines -->
+  <rect x="372" y="81" width="100" height="6" rx="2" fill="#E2E0DA"/>
+  <rect x="478" y="81" width="60" height="6" rx="2" fill="#E2E0DA"/>
+  <rect x="544" y="81" width="40" height="6" rx="2" fill="#E2E0DA"/>
+
+  <rect x="372" y="92" width="72" height="6" rx="2" fill="#E2E0DA"/>
+  <!-- [source] tag inline -->
+  <rect x="450" y="90" width="42" height="9" rx="3" fill="#CCFBF1" stroke="#0D9488" stroke-width="1"/>
+  <text x="471" y="98" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="9" font-weight="600" fill="#0F766E">[source]</text>
+  <rect x="498" y="92" width="78" height="6" rx="2" fill="#E2E0DA"/>
+
+  <rect x="372" y="103" width="118" height="6" rx="2" fill="#E2E0DA"/>
+  <rect x="496" y="103" width="80" height="6" rx="2" fill="#E2E0DA"/>
+
+  <rect x="372" y="114" width="84" height="6" rx="2" fill="#E2E0DA"/>
+  <!-- second [source] tag inline -->
+  <rect x="462" y="112" width="42" height="9" rx="3" fill="#CCFBF1" stroke="#0D9488" stroke-width="1"/>
+  <text x="483" y="120" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="9" font-weight="600" fill="#0F766E">[source]</text>
+  <rect x="510" y="114" width="66" height="6" rx="2" fill="#E2E0DA"/>
+
+  <!-- Footnote divider -->
+  <line x1="372" y1="128" x2="644" y2="128" stroke="#E2E0DA" stroke-width="1" stroke-dasharray="3,2"/>
+
+  <!-- Footnote source URLs -->
+  <text x="372" y="139" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#0D9488">1. yoursite.com/guide/topic</text>
+  <text x="372" y="150" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#94A3B8">2. competitor.com/article</text>
+
+  <!-- Center divider arrow -->
+  <line x1="328" y1="94" x2="352" y2="94" stroke="#94A3B8" stroke-width="1.5" stroke-linecap="round"/>
+  <polyline points="346,89 352,94 346,99" fill="none" stroke="#94A3B8" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/src/components/guide-visuals/B3StaysSameChanges.astro
+++ b/frontend/src/components/guide-visuals/B3StaysSameChanges.astro
@@ -1,0 +1,78 @@
+---
+---
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 180" width="100%" height="auto" role="img" aria-labelledby="b3-split-title">
+  <title id="b3-split-title">SEO and GEO overlap: what stays the same versus what changes with GEO</title>
+
+  <!-- Left column background -->
+  <rect x="0" y="0" width="338" height="180" fill="#F7F5F0" />
+
+  <!-- Right column background -->
+  <rect x="342" y="0" width="338" height="180" fill="#F5F3FF" />
+
+  <!-- Center divider -->
+  <line x1="340" y1="0" x2="340" y2="180" stroke="#E2E0DA" stroke-width="1.5" />
+
+  <!-- Left header -->
+  <text x="24" y="30" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="700" fill="#0F172A">Stays the same (SEO ∩ GEO)</text>
+
+  <!-- Left items -->
+  <!-- Item 1: Crawlability -->
+  <g transform="translate(24, 52)">
+    <circle cx="8" cy="8" r="8" fill="none" stroke="#0D9488" stroke-width="1.5" />
+    <polyline points="4.5,8 7,10.5 11.5,5.5" fill="none" stroke="#0D9488" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+    <text x="24" y="12" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#0F172A">Crawlability</text>
+  </g>
+
+  <!-- Item 2: HTML content -->
+  <g transform="translate(24, 82)">
+    <circle cx="8" cy="8" r="8" fill="none" stroke="#0D9488" stroke-width="1.5" />
+    <polyline points="4.5,8 7,10.5 11.5,5.5" fill="none" stroke="#0D9488" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+    <text x="24" y="12" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#0F172A">HTML content</text>
+  </g>
+
+  <!-- Item 3: Canonical URLs -->
+  <g transform="translate(24, 112)">
+    <circle cx="8" cy="8" r="8" fill="none" stroke="#0D9488" stroke-width="1.5" />
+    <polyline points="4.5,8 7,10.5 11.5,5.5" fill="none" stroke="#0D9488" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+    <text x="24" y="12" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#0F172A">Canonical URLs</text>
+  </g>
+
+  <!-- Item 4: Domain authority -->
+  <g transform="translate(24, 142)">
+    <circle cx="8" cy="8" r="8" fill="none" stroke="#0D9488" stroke-width="1.5" />
+    <polyline points="4.5,8 7,10.5 11.5,5.5" fill="none" stroke="#0D9488" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+    <text x="24" y="12" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#0F172A">Domain authority</text>
+  </g>
+
+  <!-- Right header -->
+  <text x="362" y="30" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="700" fill="#0F172A">Changes with GEO</text>
+
+  <!-- Right items -->
+  <!-- Item 1: Quotability over keyword density -->
+  <g transform="translate(362, 52)">
+    <line x1="0" y1="8" x2="13" y2="8" stroke="#6366F1" stroke-width="1.5" stroke-linecap="round" />
+    <polyline points="8,4 13,8 8,12" fill="none" stroke="#6366F1" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+    <text x="22" y="12" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#0F172A">Quotability over keyword density</text>
+  </g>
+
+  <!-- Item 2: Entity clarity -->
+  <g transform="translate(362, 82)">
+    <line x1="0" y1="8" x2="13" y2="8" stroke="#6366F1" stroke-width="1.5" stroke-linecap="round" />
+    <polyline points="8,4 13,8 8,12" fill="none" stroke="#6366F1" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+    <text x="22" y="12" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#0F172A">Entity clarity</text>
+  </g>
+
+  <!-- Item 3: Source trustworthiness -->
+  <g transform="translate(362, 112)">
+    <line x1="0" y1="8" x2="13" y2="8" stroke="#6366F1" stroke-width="1.5" stroke-linecap="round" />
+    <polyline points="8,4 13,8 8,12" fill="none" stroke="#6366F1" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+    <text x="22" y="12" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#0F172A">Source trustworthiness</text>
+  </g>
+
+  <!-- Item 4: llms.txt signal -->
+  <g transform="translate(362, 142)">
+    <line x1="0" y1="8" x2="13" y2="8" stroke="#6366F1" stroke-width="1.5" stroke-linecap="round" />
+    <polyline points="8,4 13,8 8,12" fill="none" stroke="#6366F1" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+    <text x="22" y="12" font-family="system-ui, -apple-system, sans-serif" font-size="12" fill="#0F172A">llms.txt signal</text>
+  </g>
+</svg>

--- a/frontend/src/components/guide-visuals/C1HeroLlmsTxt.astro
+++ b/frontend/src/components/guide-visuals/C1HeroLlmsTxt.astro
@@ -1,0 +1,71 @@
+---
+---
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 200" width="100%" role="img" aria-labelledby="c1-hero-title">
+  <title id="c1-hero-title">Where llms.txt fits in the AI discovery stack</title>
+
+  <!-- Title -->
+  <text x="390" y="22" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="600" fill="#0F172A">Where llms.txt fits in the AI discovery stack</text>
+  <text x="390" y="40" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#475569">llms.txt is one signal layer — it complements, not replaces, the others</text>
+
+  <!-- Box 1: WordPress Site -->
+  <rect x="20" y="60" width="110" height="100" rx="8" ry="8" fill="#F7F5F0" stroke="#E2E0DA" stroke-width="1.5"/>
+  <text x="75" y="104" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#0F172A">WordPress</text>
+  <text x="75" y="120" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#0F172A">Site</text>
+
+  <!-- Arrow 1 -->
+  <line x1="130" y1="110" x2="160" y2="110" stroke="#94A3B8" stroke-width="1.5" stroke-linecap="round"/>
+  <polyline points="155,104 162,110 155,116" fill="none" stroke="#94A3B8" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <!-- Box 2: Signal Layer (stacked rows) -->
+  <rect x="163" y="60" width="150" height="100" rx="8" ry="8" fill="#FFFFFF" stroke="#E2E0DA" stroke-width="1.5"/>
+  <!-- Header label -->
+  <text x="238" y="76" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="600" fill="#475569" letter-spacing="0.5">SIGNAL LAYER</text>
+  <!-- Divider under header -->
+  <line x1="163" y1="82" x2="313" y2="82" stroke="#E2E0DA" stroke-width="1"/>
+  <!-- Row 1: robots.txt -->
+  <rect x="163" y="82" width="150" height="19" fill="#FFFFFF"/>
+  <text x="238" y="95" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#475569">robots.txt</text>
+  <line x1="163" y1="101" x2="313" y2="101" stroke="#E2E0DA" stroke-width="1"/>
+  <!-- Row 2: sitemap.xml -->
+  <rect x="163" y="101" width="150" height="19" fill="#FFFFFF"/>
+  <text x="238" y="114" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#475569">sitemap.xml</text>
+  <line x1="163" y1="120" x2="313" y2="120" stroke="#E2E0DA" stroke-width="1"/>
+  <!-- Row 3: schema.org -->
+  <rect x="163" y="120" width="150" height="19" fill="#FFFFFF"/>
+  <text x="238" y="133" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#475569">schema.org</text>
+  <line x1="163" y1="139" x2="313" y2="139" stroke="#E2E0DA" stroke-width="1"/>
+  <!-- Row 4: llms.txt — highlighted -->
+  <rect x="164" y="140" width="148" height="19" rx="0" ry="0" fill="#0D9488"/>
+  <rect x="164" y="140" width="148" height="18" rx="0" ry="0" fill="#0D9488"/>
+  <!-- Rounded bottom corners only -->
+  <rect x="164" y="148" width="148" height="11" fill="#0D9488"/>
+  <rect x="164" y="140" width="148" height="19" fill="#0D9488"/>
+  <!-- Re-clip to match parent rounded rect bottom -->
+  <rect x="163" y="139" width="150" height="22" rx="0" fill="#0D9488"/>
+  <rect x="163" y="152" width="150" height="9" rx="8" fill="#0D9488"/>
+  <text x="238" y="153" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="700" fill="#FFFFFF">llms.txt</text>
+
+  <!-- Arrow 2 -->
+  <line x1="313" y1="110" x2="343" y2="110" stroke="#94A3B8" stroke-width="1.5" stroke-linecap="round"/>
+  <polyline points="338,104 345,110 338,116" fill="none" stroke="#94A3B8" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <!-- Box 3: AI Retrieval Layer -->
+  <rect x="346" y="60" width="150" height="100" rx="8" ry="8" fill="#0F172A" stroke="#0F172A" stroke-width="1.5"/>
+  <text x="421" y="97" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="600" fill="#94A3B8" letter-spacing="0.5">AI RETRIEVAL</text>
+  <text x="421" y="112" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#FFFFFF">AI Engines</text>
+  <text x="421" y="128" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#FFFFFF">&amp; Tools</text>
+
+  <!-- Arrow 3 -->
+  <line x1="496" y1="110" x2="526" y2="110" stroke="#94A3B8" stroke-width="1.5" stroke-linecap="round"/>
+  <polyline points="521,104 528,110 521,116" fill="none" stroke="#94A3B8" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <!-- Box 4: Answer / Citation -->
+  <rect x="529" y="60" width="140" height="100" rx="8" ry="8" fill="#059669" stroke="#059669" stroke-width="1.5"/>
+  <text x="599" y="97" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="600" fill="#D1FAE5" letter-spacing="0.5">OUTPUT</text>
+  <text x="599" y="114" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#FFFFFF">Answer /</text>
+  <text x="599" y="130" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#FFFFFF">Citation</text>
+
+  <!-- llms.txt callout arrow pointing to highlighted row -->
+  <line x1="238" y1="162" x2="238" y2="178" stroke="#0D9488" stroke-width="1.5" stroke-linecap="round" stroke-dasharray="3,2"/>
+  <text x="238" y="191" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="600" fill="#0D9488">you are here</text>
+</svg>

--- a/frontend/src/components/guide-visuals/C2LlmsTxtStructure.astro
+++ b/frontend/src/components/guide-visuals/C2LlmsTxtStructure.astro
@@ -1,0 +1,106 @@
+---
+---
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 240" width="100%" height="auto" role="img" aria-labelledby="c2-struct-title">
+  <title id="c2-struct-title">Recommended llms.txt structure with annotated sections</title>
+
+  <!-- Background -->
+  <rect width="680" height="240" fill="#F7F5F0"/>
+
+  <!-- Title -->
+  <text x="24" y="28" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="600" fill="#0F172A">Recommended llms.txt structure</text>
+
+  <!-- Code block background -->
+  <rect x="24" y="44" width="400" height="180" rx="8" fill="#1E293B"/>
+
+  <!-- Line highlight rows (alternating subtle) -->
+  <rect x="24" y="56" width="400" height="20" fill="#263548"/>
+  <rect x="24" y="96" width="400" height="20" fill="#263548"/>
+  <rect x="24" y="136" width="400" height="20" fill="#263548"/>
+  <rect x="24" y="176" width="400" height="20" fill="#263548"/>
+
+  <!-- Line numbers column -->
+  <rect x="24" y="44" width="32" height="180" rx="8" fill="#1A2744"/>
+  <rect x="44" y="44" width="12" height="180" fill="#1A2744"/>
+
+  <!-- Line numbers -->
+  <text x="36" y="70" font-family="ui-monospace, 'Cascadia Code', 'Fira Code', monospace" font-size="11" fill="#475569" text-anchor="middle">1</text>
+  <text x="36" y="90" font-family="ui-monospace, 'Cascadia Code', 'Fira Code', monospace" font-size="11" fill="#475569" text-anchor="middle">2</text>
+  <text x="36" y="110" font-family="ui-monospace, 'Cascadia Code', 'Fira Code', monospace" font-size="11" fill="#475569" text-anchor="middle">3</text>
+  <text x="36" y="130" font-family="ui-monospace, 'Cascadia Code', 'Fira Code', monospace" font-size="11" fill="#475569" text-anchor="middle">4</text>
+  <text x="36" y="150" font-family="ui-monospace, 'Cascadia Code', 'Fira Code', monospace" font-size="11" fill="#475569" text-anchor="middle">5</text>
+  <text x="36" y="170" font-family="ui-monospace, 'Cascadia Code', 'Fira Code', monospace" font-size="11" fill="#475569" text-anchor="middle">6</text>
+  <text x="36" y="190" font-family="ui-monospace, 'Cascadia Code', 'Fira Code', monospace" font-size="11" fill="#475569" text-anchor="middle">7</text>
+  <text x="36" y="210" font-family="ui-monospace, 'Cascadia Code', 'Fira Code', monospace" font-size="11" fill="#475569" text-anchor="middle">8</text>
+
+  <!-- Code content -->
+  <!-- Row 1: # Site Name -->
+  <text x="68" y="70" font-family="ui-monospace, 'Cascadia Code', 'Fira Code', monospace" font-size="12" fill="#38BDF8"># </text>
+  <text x="83" y="70" font-family="ui-monospace, 'Cascadia Code', 'Fira Code', monospace" font-size="12" fill="#F1F5F9">Site Name</text>
+
+  <!-- Row 2: > description -->
+  <text x="68" y="90" font-family="ui-monospace, 'Cascadia Code', 'Fira Code', monospace" font-size="12" fill="#94A3B8">&gt; </text>
+  <text x="83" y="90" font-family="ui-monospace, 'Cascadia Code', 'Fira Code', monospace" font-size="12" fill="#CBD5E1">Site description and purpose</text>
+
+  <!-- Row 3: blank -->
+  <text x="68" y="110" font-family="ui-monospace, 'Cascadia Code', 'Fira Code', monospace" font-size="12" fill="#475569"> </text>
+
+  <!-- Row 4: ## Core Pages -->
+  <text x="68" y="130" font-family="ui-monospace, 'Cascadia Code', 'Fira Code', monospace" font-size="12" fill="#38BDF8">## </text>
+  <text x="92" y="130" font-family="ui-monospace, 'Cascadia Code', 'Fira Code', monospace" font-size="12" fill="#F1F5F9">Core Pages</text>
+
+  <!-- Row 5: - [Home](/) -->
+  <text x="68" y="150" font-family="ui-monospace, 'Cascadia Code', 'Fira Code', monospace" font-size="12" fill="#94A3B8">- </text>
+  <text x="82" y="150" font-family="ui-monospace, 'Cascadia Code', 'Fira Code', monospace" font-size="12" fill="#7DD3FC">[Home](/)</text>
+  <text x="136" y="150" font-family="ui-monospace, 'Cascadia Code', 'Fira Code', monospace" font-size="12" fill="#94A3B8">: Homepage overview</text>
+
+  <!-- Row 6: - [About](/about/) -->
+  <text x="68" y="170" font-family="ui-monospace, 'Cascadia Code', 'Fira Code', monospace" font-size="12" fill="#94A3B8">- </text>
+  <text x="82" y="170" font-family="ui-monospace, 'Cascadia Code', 'Fira Code', monospace" font-size="12" fill="#7DD3FC">[About](/about/)</text>
+  <text x="170" y="170" font-family="ui-monospace, 'Cascadia Code', 'Fira Code', monospace" font-size="12" fill="#94A3B8">: About us</text>
+
+  <!-- Row 7: ## Guides -->
+  <text x="68" y="190" font-family="ui-monospace, 'Cascadia Code', 'Fira Code', monospace" font-size="12" fill="#38BDF8">## </text>
+  <text x="92" y="190" font-family="ui-monospace, 'Cascadia Code', 'Fira Code', monospace" font-size="12" fill="#F1F5F9">Guides</text>
+
+  <!-- Row 8: - [Guide name] -->
+  <text x="68" y="210" font-family="ui-monospace, 'Cascadia Code', 'Fira Code', monospace" font-size="12" fill="#94A3B8">- </text>
+  <text x="82" y="210" font-family="ui-monospace, 'Cascadia Code', 'Fira Code', monospace" font-size="12" fill="#7DD3FC">[Guide name](/guides/...)</text>
+  <text x="244" y="210" font-family="ui-monospace, 'Cascadia Code', 'Fira Code', monospace" font-size="12" fill="#94A3B8">: ...</text>
+
+  <!-- Annotation connector lines -->
+  <!-- H1 annotation: row 1, y=70 -->
+  <line x1="424" y1="70" x2="464" y2="70" stroke="#94A3B8" stroke-width="1" stroke-dasharray="3,2"/>
+  <circle cx="424" cy="70" r="2" fill="#94A3B8"/>
+
+  <!-- Blockquote annotation: row 2, y=90 -->
+  <line x1="424" y1="90" x2="464" y2="90" stroke="#94A3B8" stroke-width="1" stroke-dasharray="3,2"/>
+  <circle cx="424" cy="90" r="2" fill="#94A3B8"/>
+
+  <!-- H2 annotation: row 4, y=130 -->
+  <line x1="424" y1="130" x2="464" y2="130" stroke="#94A3B8" stroke-width="1" stroke-dasharray="3,2"/>
+  <circle cx="424" cy="130" r="2" fill="#94A3B8"/>
+
+  <!-- Link annotation: row 5, y=150 -->
+  <line x1="424" y1="150" x2="464" y2="158" stroke="#94A3B8" stroke-width="1" stroke-dasharray="3,2"/>
+  <circle cx="424" cy="150" r="2" fill="#94A3B8"/>
+
+  <!-- Annotation labels -->
+  <!-- H1 label -->
+  <rect x="466" y="58" width="148" height="22" rx="4" fill="#FFFFFF" stroke="#E2E0DA" stroke-width="1"/>
+  <text x="540" y="73" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#94A3B8" text-anchor="middle">H1: site name (required)</text>
+
+  <!-- Blockquote label -->
+  <rect x="466" y="78" width="148" height="22" rx="4" fill="#FFFFFF" stroke="#E2E0DA" stroke-width="1"/>
+  <text x="540" y="93" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#94A3B8" text-anchor="middle">Blockquote: summary</text>
+
+  <!-- H2 label -->
+  <rect x="466" y="118" width="148" height="22" rx="4" fill="#FFFFFF" stroke="#E2E0DA" stroke-width="1"/>
+  <text x="540" y="133" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#94A3B8" text-anchor="middle">H2: section grouping</text>
+
+  <!-- Link + description label -->
+  <rect x="466" y="146" width="148" height="22" rx="4" fill="#FFFFFF" stroke="#E2E0DA" stroke-width="1"/>
+  <text x="540" y="161" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#94A3B8" text-anchor="middle">Link + description</text>
+
+  <!-- Bottom note -->
+  <text x="24" y="234" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#94A3B8">Sections repeat for each content category. Descriptions are optional but recommended.</text>
+</svg>

--- a/frontend/src/components/guide-visuals/C3WordPressOptions.astro
+++ b/frontend/src/components/guide-visuals/C3WordPressOptions.astro
@@ -1,0 +1,122 @@
+---
+---
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 180" width="100%" height="auto" role="img" aria-labelledby="c3-wp-title">
+  <title id="c3-wp-title">Three ways to add llms.txt to a WordPress site</title>
+
+  <!-- Background -->
+  <rect width="680" height="180" fill="#F7F5F0"/>
+
+  <!-- Title -->
+  <text x="340" y="22" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#0F172A" text-anchor="middle">Three ways to add llms.txt to a WordPress site</text>
+
+  <!-- ── Column 1: Manual Upload ── -->
+  <rect x="16" y="36" width="202" height="128" rx="6" fill="#FFFFFF" stroke="#E2E0DA" stroke-width="1"/>
+
+  <!-- FTP/file icon (teal) -->
+  <g transform="translate(54, 58)" stroke="#0D9488" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none">
+    <!-- file -->
+    <rect x="0" y="0" width="18" height="22" rx="2" fill="#F0FDFA" stroke="#0D9488"/>
+    <polyline points="11,0 11,7 18,7"/>
+    <line x1="4" y1="12" x2="14" y2="12"/>
+    <line x1="4" y1="16" x2="10" y2="16"/>
+  </g>
+
+  <!-- arrow -->
+  <line x1="77" y1="69" x2="95" y2="69" stroke="#0D9488" stroke-width="1.5" stroke-linecap="round"/>
+  <polyline points="92,65 97,69 92,73" fill="none" stroke="#0D9488" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <!-- server icon (teal) -->
+  <g transform="translate(99, 58)" stroke="#0D9488" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none">
+    <rect x="0" y="0" width="22" height="9" rx="2" fill="#F0FDFA" stroke="#0D9488"/>
+    <circle cx="17" cy="4.5" r="1.5" fill="#0D9488"/>
+    <rect x="0" y="13" width="22" height="9" rx="2" fill="#F0FDFA" stroke="#0D9488"/>
+    <circle cx="17" cy="17.5" r="1.5" fill="#0D9488"/>
+  </g>
+
+  <!-- arrow -->
+  <line x1="125" y1="69" x2="142" y2="69" stroke="#0D9488" stroke-width="1.5" stroke-linecap="round"/>
+  <polyline points="139,65 144,69 139,73" fill="none" stroke="#0D9488" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <!-- llms.txt label badge (teal) -->
+  <rect x="147" y="60" width="54" height="18" rx="3" fill="#0D9488"/>
+  <text x="174" y="73" font-family="system-ui, -apple-system, sans-serif" font-size="9" font-weight="600" fill="#FFFFFF" text-anchor="middle">llms.txt</text>
+
+  <!-- Column 1 labels -->
+  <text x="117" y="102" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#0D9488" text-anchor="middle">Manual Upload</text>
+  <text x="117" y="117" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#475569" text-anchor="middle">Upload via FTP/SFTP</text>
+  <text x="117" y="130" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#475569" text-anchor="middle">to your web root.</text>
+  <text x="117" y="145" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#94A3B8" text-anchor="middle">at root (/llms.txt)</text>
+
+  <!-- ── Column 2: functions.php / Plugin ── -->
+  <rect x="238" y="36" width="202" height="128" rx="6" fill="#FFFFFF" stroke="#E2E0DA" stroke-width="1"/>
+
+  <!-- WordPress "W" icon (indigo) -->
+  <g transform="translate(276, 55)">
+    <rect x="0" y="0" width="22" height="22" rx="4" fill="#EEF2FF" stroke="#6366F1" stroke-width="1.5"/>
+    <text x="11" y="16" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="700" fill="#6366F1" text-anchor="middle">W</text>
+  </g>
+
+  <!-- arrow -->
+  <line x1="302" y1="67" x2="319" y2="67" stroke="#6366F1" stroke-width="1.5" stroke-linecap="round"/>
+  <polyline points="316,63 321,67 316,71" fill="none" stroke="#6366F1" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <!-- code block icon (indigo) -->
+  <g transform="translate(323, 55)" stroke="#6366F1" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none">
+    <rect x="0" y="0" width="22" height="22" rx="3" fill="#EEF2FF" stroke="#6366F1"/>
+    <polyline points="6,8 2,11 6,14"/>
+    <polyline points="16,8 20,11 16,14"/>
+    <line x1="10" y1="16" x2="12" y2="6"/>
+  </g>
+
+  <!-- arrow -->
+  <line x1="349" y1="67" x2="366" y2="67" stroke="#6366F1" stroke-width="1.5" stroke-linecap="round"/>
+  <polyline points="363,63 368,67 363,71" fill="none" stroke="#6366F1" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <!-- Dynamic route badge (indigo) -->
+  <rect x="370" y="58" width="54" height="18" rx="3" fill="#6366F1"/>
+  <text x="397" y="71" font-family="system-ui, -apple-system, sans-serif" font-size="8.5" font-weight="600" fill="#FFFFFF" text-anchor="middle">Dynamic</text>
+
+  <!-- Column 2 labels -->
+  <text x="339" y="102" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#6366F1" text-anchor="middle">Plugin / Code</text>
+  <text x="339" y="117" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#475569" text-anchor="middle">functions.php or custom</text>
+  <text x="339" y="130" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#475569" text-anchor="middle">plugin adds a route.</text>
+  <text x="339" y="145" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#94A3B8" text-anchor="middle">Dynamic rewrite rule</text>
+
+  <!-- ── Column 3: Hosting Control Panel ── -->
+  <rect x="460" y="36" width="202" height="128" rx="6" fill="#FFFFFF" stroke="#E2E0DA" stroke-width="1"/>
+
+  <!-- cPanel/grid icon (text-secondary) -->
+  <g transform="translate(498, 55)" stroke="#475569" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none">
+    <rect x="0" y="0" width="22" height="22" rx="3" fill="#F8FAFC" stroke="#475569"/>
+    <line x1="7" y1="0" x2="7" y2="22"/>
+    <line x1="15" y1="0" x2="15" y2="22"/>
+    <line x1="0" y1="7" x2="22" y2="7"/>
+    <line x1="0" y1="15" x2="22" y2="15"/>
+  </g>
+
+  <!-- arrow -->
+  <line x1="524" y1="67" x2="541" y2="67" stroke="#475569" stroke-width="1.5" stroke-linecap="round"/>
+  <polyline points="538,63 543,67 538,71" fill="none" stroke="#475569" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <!-- static hosting icon -->
+  <g transform="translate(545, 55)" stroke="#475569" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none">
+    <rect x="0" y="0" width="22" height="22" rx="3" fill="#F8FAFC" stroke="#475569"/>
+    <rect x="4" y="6" width="14" height="10" rx="1"/>
+    <line x1="7" y1="19" x2="15" y2="19"/>
+    <line x1="11" y1="16" x2="11" y2="19"/>
+  </g>
+
+  <!-- arrow -->
+  <line x1="571" y1="67" x2="588" y2="67" stroke="#475569" stroke-width="1.5" stroke-linecap="round"/>
+  <polyline points="585,63 590,67 585,71" fill="none" stroke="#475569" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <!-- Served badge (muted) -->
+  <rect x="592" y="58" width="54" height="18" rx="3" fill="#E2E0DA"/>
+  <text x="619" y="71" font-family="system-ui, -apple-system, sans-serif" font-size="8.5" font-weight="600" fill="#475569" text-anchor="middle">Served</text>
+
+  <!-- Column 3 labels -->
+  <text x="561" y="102" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#475569" text-anchor="middle">Hosting Panel</text>
+  <text x="561" y="117" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#475569" text-anchor="middle">cPanel or host dashboard</text>
+  <text x="561" y="130" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#475569" text-anchor="middle">manages static files.</text>
+  <text x="561" y="145" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#94A3B8" text-anchor="middle">Served directly by host</text>
+</svg>

--- a/frontend/src/components/guide-visuals/D1HeroChecklist.astro
+++ b/frontend/src/components/guide-visuals/D1HeroChecklist.astro
@@ -1,0 +1,54 @@
+---
+---
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 200" width="100%" height="auto" role="img" aria-labelledby="d1-hero-title">
+  <title id="d1-hero-title">AI visibility checklist — five layers to audit</title>
+
+  <!-- Title -->
+  <text x="390" y="22" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="600" fill="#0F172A">AI visibility checklist — five layers to audit</text>
+
+  <!-- Block 1: Crawlability -->
+  <rect x="16" y="38" width="136" height="64" rx="6" fill="#F7F5F0" stroke="#E2E0DA" stroke-width="1.5"/>
+  <text x="84" y="64" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#0F172A">Crawlability</text>
+  <text x="84" y="82" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#475569">Foundation</text>
+
+  <!-- Block 2: Meta & Signals -->
+  <rect x="168" y="38" width="136" height="64" rx="6" fill="#F7F5F0" stroke="#E2E0DA" stroke-width="1.5"/>
+  <text x="236" y="64" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#0F172A">Meta &amp; Signals</text>
+  <text x="236" y="82" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#475569">Foundation</text>
+
+  <!-- Block 3: llms.txt + Schema (teal/AI layer) -->
+  <rect x="320" y="38" width="140" height="64" rx="6" fill="#0D9488" stroke="none"/>
+  <text x="390" y="62" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#FFFFFF">llms.txt + Schema</text>
+  <text x="390" y="80" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#CCFBF1">AI Layer</text>
+
+  <!-- Block 4: Content Quality -->
+  <rect x="476" y="38" width="136" height="64" rx="6" fill="#F7F5F0" stroke="#E2E0DA" stroke-width="1.5"/>
+  <text x="544" y="64" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#0F172A">Content Quality</text>
+  <text x="544" y="82" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#475569">Foundation</text>
+
+  <!-- Block 5: Brand & Entity -->
+  <rect x="628" y="38" width="136" height="64" rx="6" fill="#F7F5F0" stroke="#E2E0DA" stroke-width="1.5"/>
+  <text x="696" y="64" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#0F172A">Brand &amp; Entity</text>
+  <text x="696" y="82" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#475569">Foundation</text>
+
+  <!-- Check counts below blocks -->
+  <text x="84" y="120" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#94A3B8">5 checks</text>
+  <text x="236" y="120" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#94A3B8">4 checks</text>
+  <text x="390" y="120" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#0D9488" font-weight="500">6 checks</text>
+  <text x="544" y="120" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#94A3B8">6 checks</text>
+  <text x="696" y="120" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#94A3B8">4 checks</text>
+
+  <!-- Arrow line left→right -->
+  <line x1="36" y1="148" x2="726" y2="148" stroke="#CBD5E1" stroke-width="1.5" stroke-linecap="round"/>
+  <!-- Arrowhead -->
+  <polyline points="716,142 726,148 716,154" fill="none" stroke="#CBD5E1" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- Tick marks at each block start -->
+  <line x1="36" y1="144" x2="36" y2="152" stroke="#CBD5E1" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="188" y1="144" x2="188" y2="152" stroke="#CBD5E1" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="340" y1="144" x2="340" y2="152" stroke="#0D9488" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="496" y1="144" x2="496" y2="152" stroke="#CBD5E1" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="648" y1="144" x2="648" y2="152" stroke="#CBD5E1" stroke-width="1.5" stroke-linecap="round"/>
+
+  <!-- Arrow label -->
+  <text x="390" y="175" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#94A3B8">Fix in order — each layer depends on the previous</text>
+</svg>

--- a/frontend/src/components/guide-visuals/D2TechChecklist.astro
+++ b/frontend/src/components/guide-visuals/D2TechChecklist.astro
@@ -1,0 +1,55 @@
+---
+---
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 180" width="100%" height="auto" role="img" aria-labelledby="d2-tech-title">
+  <title id="d2-tech-title">Technical layer — five checks</title>
+
+  <!-- Background -->
+  <rect width="680" height="180" fill="#F7F5F0"/>
+
+  <!-- Section title -->
+  <text x="340" y="22" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#0F172A">Technical layer — five checks</text>
+
+  <!-- Card 1: robots.txt -->
+  <rect x="12" y="36" width="122" height="132" rx="8" fill="#FFFFFF" stroke="#E2E0DA" stroke-width="1.5"/>
+  <!-- Checkmark circle -->
+  <circle cx="73" cy="66" r="13" fill="#0D9488" stroke="none"/>
+  <polyline points="66,66 71,72 81,60" fill="none" stroke="#FFFFFF" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- Card title -->
+  <text x="73" y="95" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="700" fill="#0F172A">robots.txt</text>
+  <!-- Description line 1 -->
+  <text x="73" y="113" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#475569">AI crawlers</text>
+  <!-- Description line 2 -->
+  <text x="73" y="128" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#475569">allowed</text>
+
+  <!-- Card 2: Canonical -->
+  <rect x="144" y="36" width="122" height="132" rx="8" fill="#FFFFFF" stroke="#E2E0DA" stroke-width="1.5"/>
+  <circle cx="205" cy="66" r="13" fill="#0D9488" stroke="none"/>
+  <polyline points="198,66 203,72 213,60" fill="none" stroke="#FFFFFF" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="205" y="95" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="700" fill="#0F172A">Canonical</text>
+  <text x="205" y="113" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#475569">Self-referencing</text>
+  <text x="205" y="128" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#475569">tag present</text>
+
+  <!-- Card 3: Sitemap -->
+  <rect x="276" y="36" width="122" height="132" rx="8" fill="#FFFFFF" stroke="#E2E0DA" stroke-width="1.5"/>
+  <circle cx="337" cy="66" r="13" fill="#0D9488" stroke="none"/>
+  <polyline points="330,66 335,72 345,60" fill="none" stroke="#FFFFFF" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="337" y="95" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="700" fill="#0F172A">Sitemap</text>
+  <text x="337" y="113" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#475569">XML submitted</text>
+  <text x="337" y="128" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#475569">&amp; reachable</text>
+
+  <!-- Card 4: llms.txt -->
+  <rect x="408" y="36" width="122" height="132" rx="8" fill="#FFFFFF" stroke="#E2E0DA" stroke-width="1.5"/>
+  <circle cx="469" cy="66" r="13" fill="#0D9488" stroke="none"/>
+  <polyline points="462,66 467,72 477,60" fill="none" stroke="#FFFFFF" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="469" y="95" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="700" fill="#0F172A">llms.txt</text>
+  <text x="469" y="113" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#475569">AI context file</text>
+  <text x="469" y="128" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#475569">published</text>
+
+  <!-- Card 5: Schema -->
+  <rect x="540" y="36" width="128" height="132" rx="8" fill="#FFFFFF" stroke="#E2E0DA" stroke-width="1.5"/>
+  <circle cx="604" cy="66" r="13" fill="#0D9488" stroke="none"/>
+  <polyline points="597,66 602,72 612,60" fill="none" stroke="#FFFFFF" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="604" y="95" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="700" fill="#0F172A">Schema</text>
+  <text x="604" y="113" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#475569">Structured data</text>
+  <text x="604" y="128" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#475569">validated</text>
+</svg>

--- a/frontend/src/components/guide-visuals/D3ContentChecklist.astro
+++ b/frontend/src/components/guide-visuals/D3ContentChecklist.astro
@@ -1,0 +1,79 @@
+---
+---
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 180" width="100%" height="auto" role="img" aria-labelledby="d3-content-title">
+  <title id="d3-content-title">Content layer — five checks: Direct Answer, Clear Headings, Specific Facts, Numbered Steps, One Idea per Paragraph</title>
+
+  <!-- Background -->
+  <rect width="680" height="180" fill="#F7F5F0"/>
+
+  <!-- Section header -->
+  <text x="340" y="22" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#0F172A">Content layer — five checks</text>
+
+  <!-- Divider below header -->
+  <line x1="24" y1="32" x2="656" y2="32" stroke="#E2E0DA" stroke-width="1"/>
+
+  <!-- ── CARD 1: Direct Answer ── -->
+  <rect x="24" y="44" width="120" height="122" rx="6" fill="#FFFFFF" stroke="#E2E0DA" stroke-width="1"/>
+  <!-- Checkmark circle -->
+  <circle cx="84" cy="72" r="14" fill="#CCFBF1"/>
+  <polyline points="76,72 81,78 93,65" fill="none" stroke="#0D9488" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- Title -->
+  <text x="84" y="98" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="700" fill="#0F172A">Direct</text>
+  <text x="84" y="113" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="700" fill="#0F172A">Answer</text>
+  <!-- Description -->
+  <text x="84" y="132" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#475569">Lead with the</text>
+  <text x="84" y="146" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#475569">answer, not</text>
+  <text x="84" y="160" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#475569">context first</text>
+
+  <!-- ── CARD 2: Clear Headings ── -->
+  <rect x="156" y="44" width="120" height="122" rx="6" fill="#FFFFFF" stroke="#E2E0DA" stroke-width="1"/>
+  <!-- Checkmark circle -->
+  <circle cx="216" cy="72" r="14" fill="#CCFBF1"/>
+  <polyline points="208,72 213,78 225,65" fill="none" stroke="#0D9488" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- Title -->
+  <text x="216" y="98" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="700" fill="#0F172A">Clear</text>
+  <text x="216" y="113" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="700" fill="#0F172A">Headings</text>
+  <!-- Description -->
+  <text x="216" y="132" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#475569">H2/H3 match</text>
+  <text x="216" y="146" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#475569">real questions</text>
+  <text x="216" y="160" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#475569">people ask</text>
+
+  <!-- ── CARD 3: Specific Facts ── -->
+  <rect x="288" y="44" width="120" height="122" rx="6" fill="#FFFFFF" stroke="#E2E0DA" stroke-width="1"/>
+  <!-- Checkmark circle -->
+  <circle cx="348" cy="72" r="14" fill="#CCFBF1"/>
+  <polyline points="340,72 345,78 357,65" fill="none" stroke="#0D9488" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- Title -->
+  <text x="348" y="98" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="700" fill="#0F172A">Specific</text>
+  <text x="348" y="113" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="700" fill="#0F172A">Facts</text>
+  <!-- Description -->
+  <text x="348" y="132" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#475569">Numbers, dates,</text>
+  <text x="348" y="146" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#475569">names the AI</text>
+  <text x="348" y="160" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#475569">can cite</text>
+
+  <!-- ── CARD 4: Numbered Steps ── -->
+  <rect x="420" y="44" width="120" height="122" rx="6" fill="#FFFFFF" stroke="#E2E0DA" stroke-width="1"/>
+  <!-- Checkmark circle -->
+  <circle cx="480" cy="72" r="14" fill="#CCFBF1"/>
+  <polyline points="472,72 477,78 489,65" fill="none" stroke="#0D9488" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- Title -->
+  <text x="480" y="98" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="700" fill="#0F172A">Numbered</text>
+  <text x="480" y="113" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="700" fill="#0F172A">Steps</text>
+  <!-- Description -->
+  <text x="480" y="132" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#475569">Ordered lists</text>
+  <text x="480" y="146" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#475569">signal clear</text>
+  <text x="480" y="160" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#475569">procedure</text>
+
+  <!-- ── CARD 5: One Idea / Para ── -->
+  <rect x="552" y="44" width="104" height="122" rx="6" fill="#FFFFFF" stroke="#E2E0DA" stroke-width="1"/>
+  <!-- Checkmark circle -->
+  <circle cx="604" cy="72" r="14" fill="#CCFBF1"/>
+  <polyline points="596,72 601,78 613,65" fill="none" stroke="#0D9488" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- Title -->
+  <text x="604" y="98" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="700" fill="#0F172A">One Idea</text>
+  <text x="604" y="113" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="700" fill="#0F172A">/ Para</text>
+  <!-- Description -->
+  <text x="604" y="132" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#475569">Short, dense</text>
+  <text x="604" y="146" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#475569">paragraphs</text>
+  <text x="604" y="160" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#475569">easy to extract</text>
+</svg>

--- a/frontend/src/components/guide-visuals/D4MonitorLoop.astro
+++ b/frontend/src/components/guide-visuals/D4MonitorLoop.astro
@@ -1,0 +1,66 @@
+---
+---
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 180" width="100%" height="auto" role="img" aria-labelledby="d4-loop-title">
+  <title id="d4-loop-title">AI visibility is a continuous loop, not a one-time setup</title>
+
+  <!-- Title -->
+  <text x="340" y="22" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600" fill="#0F172A">AI visibility is a continuous loop, not a one-time setup</text>
+
+  <!-- Node positions (center x, center y): evenly spaced across width -->
+  <!-- Audit: 68,100 | Monitor: 178,75 | Fix: 340,62 | Measure: 502,75 | Improve: 612,100 -->
+
+  <!-- Arrows between nodes (drawn before nodes so nodes sit on top) -->
+
+  <!-- Audit → Monitor -->
+  <path d="M 118 97 C 138 87, 155 80, 168 79" fill="none" stroke="#94A3B8" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#d4-arrow)"/>
+
+  <!-- Monitor → Fix -->
+  <path d="M 228 75 C 258 69, 290 65, 310 64" fill="none" stroke="#94A3B8" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#d4-arrow)"/>
+
+  <!-- Fix → Measure -->
+  <path d="M 390 64 C 410 65, 440 69, 472 75" fill="none" stroke="#94A3B8" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#d4-arrow)"/>
+
+  <!-- Measure → Improve -->
+  <path d="M 552 79 C 565 82, 578 88, 590 95" fill="none" stroke="#94A3B8" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#d4-arrow)"/>
+
+  <!-- Return arrow: Improve → Audit (curved below) -->
+  <path d="M 612 122 C 612 155, 500 165, 340 165 C 180 165, 68 155, 68 122" fill="none" stroke="#0D9488" stroke-width="1.5" stroke-dasharray="5 3" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#d4-arrow-teal)"/>
+
+  <!-- Arrow marker (grey) -->
+  <defs>
+    <marker id="d4-arrow" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L7,3 z" fill="#94A3B8"/>
+    </marker>
+    <marker id="d4-arrow-teal" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L7,3 z" fill="#0D9488"/>
+    </marker>
+  </defs>
+
+  <!-- Node 1: Audit (teal filled, start) -->
+  <rect x="20" y="82" width="96" height="36" rx="8" fill="#0D9488"/>
+  <text x="68" y="97" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="700" fill="#FFFFFF">① Audit</text>
+  <text x="68" y="111" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="rgba(255,255,255,0.85)">Full site scan</text>
+
+  <!-- Node 2: Monitor -->
+  <rect x="130" y="57" width="96" height="36" rx="8" fill="#F7F5F0" stroke="#E2E0DA" stroke-width="1.5"/>
+  <text x="178" y="72" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="600" fill="#0F172A">② Monitor</text>
+  <text x="178" y="86" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#475569">Track changes</text>
+
+  <!-- Node 3: Fix -->
+  <rect x="292" y="44" width="96" height="36" rx="8" fill="#F7F5F0" stroke="#E2E0DA" stroke-width="1.5"/>
+  <text x="340" y="59" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="600" fill="#0F172A">③ Fix</text>
+  <text x="340" y="73" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#475569">Apply patches</text>
+
+  <!-- Node 4: Measure -->
+  <rect x="454" y="57" width="96" height="36" rx="8" fill="#F7F5F0" stroke="#E2E0DA" stroke-width="1.5"/>
+  <text x="502" y="72" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="600" fill="#0F172A">④ Measure</text>
+  <text x="502" y="86" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#475569">Check impact</text>
+
+  <!-- Node 5: Improve (green filled, outcome) -->
+  <rect x="564" y="82" width="96" height="36" rx="8" fill="#059669"/>
+  <text x="612" y="97" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="700" fill="#FFFFFF">⑤ Improve</text>
+  <text x="612" y="111" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="rgba(255,255,255,0.85)">Score grows</text>
+
+  <!-- Return label -->
+  <text x="340" y="163" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#0D9488">repeat every 30 days</text>
+</svg>

--- a/frontend/src/pages/guides/ai-visibility-checklist.astro
+++ b/frontend/src/pages/guides/ai-visibility-checklist.astro
@@ -1,5 +1,9 @@
 ---
 import Shell from '../../components/Shell.astro';
+import D1HeroChecklist from '../../components/guide-visuals/D1HeroChecklist.astro';
+import D2TechChecklist from '../../components/guide-visuals/D2TechChecklist.astro';
+import D3ContentChecklist from '../../components/guide-visuals/D3ContentChecklist.astro';
+import D4MonitorLoop from '../../components/guide-visuals/D4MonitorLoop.astro';
 
 const title =
   'AI Visibility Checklist: How to Make Your Website Easier to Find, Cite, and Recommend';
@@ -36,6 +40,11 @@ const dateModified = '2026-06-05';
         Published June 2026 · 14 min read
       </p>
     </header>
+
+    <figure class="my-8 md:my-10 rounded-2xl border border-border bg-bg-surface p-4 md:p-6 overflow-x-auto">
+      <D1HeroChecklist />
+      <figcaption class="mt-3 text-xs text-text-muted text-center font-mono">Five layers of AI visibility signals — work through them in order, since each builds on the previous.</figcaption>
+    </figure>
 
     <div class="space-y-12 md:space-y-16 [&_h2]:font-display [&_h2]:text-2xl [&_h2]:font-bold [&_h2]:text-text-primary [&_h2]:leading-tight [&_h2]:tracking-tight [&_h3]:font-display [&_h3]:text-lg [&_h3]:font-semibold [&_h3]:text-text-primary [&_p]:text-text-secondary [&_p]:leading-relaxed [&_li]:text-text-secondary [&_li]:leading-relaxed">
 
@@ -93,6 +102,10 @@ const dateModified = '2026-06-05';
             <p class="mt-1 text-sm text-text-muted">Pass: sitemap exists, is accessible, and is referenced in robots.txt.</p>
           </li>
         </ul>
+        <figure class="my-8 md:my-10 rounded-2xl border border-border bg-bg-surface p-4 md:p-6 overflow-x-auto">
+          <D2TechChecklist />
+          <figcaption class="mt-3 text-xs text-text-muted text-center font-mono">The technical layer: five checks that determine whether AI engines can reach and index your pages.</figcaption>
+        </figure>
       </section>
 
       {/* Category 2: Meta / Signals */}
@@ -224,6 +237,10 @@ const dateModified = '2026-06-05';
             <p class="mt-1 text-sm text-text-muted">Pass: all how-to content uses numbered steps, not prose-only descriptions.</p>
           </li>
         </ul>
+        <figure class="my-8 md:my-10 rounded-2xl border border-border bg-bg-surface p-4 md:p-6 overflow-x-auto">
+          <D3ContentChecklist />
+          <figcaption class="mt-3 text-xs text-text-muted text-center font-mono">The content layer: five signals that determine whether your pages are quotable by AI answer engines.</figcaption>
+        </figure>
       </section>
 
       {/* Category 6: AI discovery */}
@@ -299,6 +316,10 @@ const dateModified = '2026-06-05';
           The <a href="/guides/geo-vs-seo/" class="text-accent-teal hover:underline">GEO vs SEO guide</a> explains
           why these priorities differ from a classic SEO checklist.
         </p>
+        <figure class="my-8 md:my-10 rounded-2xl border border-border bg-bg-surface p-4 md:p-6 overflow-x-auto">
+          <D4MonitorLoop />
+          <figcaption class="mt-3 text-xs text-text-muted text-center font-mono">AI visibility is not a one-time audit. Treat it as a continuous loop: audit, monitor, fix, measure, improve.</figcaption>
+        </figure>
       </section>
 
       {/* Limits */}

--- a/frontend/src/pages/guides/appear-in-chatgpt-perplexity.astro
+++ b/frontend/src/pages/guides/appear-in-chatgpt-perplexity.astro
@@ -1,5 +1,8 @@
 ---
 import Shell from '../../components/Shell.astro';
+import A1HeroAIDiscovery from '../../components/guide-visuals/A1HeroAIDiscovery.astro';
+import A2TechFoundations from '../../components/guide-visuals/A2TechFoundations.astro';
+import A3FailureModes from '../../components/guide-visuals/A3FailureModes.astro';
 
 const title =
   'How to Make Your Website Appear in ChatGPT and Perplexity Sources';
@@ -36,6 +39,11 @@ const dateModified = '2026-06-04';
         Published June 2026 · 12 min read
       </p>
     </header>
+
+    <figure class="my-8 md:my-10 rounded-2xl border border-border bg-bg-surface p-4 md:p-6 overflow-x-auto">
+      <A1HeroAIDiscovery />
+      <figcaption class="mt-3 text-xs text-text-muted text-center font-mono">The end-to-end path from a well-optimized website to an AI citation</figcaption>
+    </figure>
 
     <div class="space-y-12 md:space-y-16 [&_h2]:font-display [&_h2]:text-2xl [&_h2]:font-bold [&_h2]:text-text-primary [&_h2]:leading-tight [&_h2]:tracking-tight [&_h3]:font-display [&_h3]:text-lg [&_h3]:font-semibold [&_h3]:text-text-primary [&_p]:text-text-secondary [&_p]:leading-relaxed [&_li]:text-text-secondary [&_li]:leading-relaxed">
 
@@ -103,6 +111,10 @@ const dateModified = '2026-06-04';
           chance a crawler finishes fetching your page. Use permanent (301)
           redirects, return clean 200s, and keep your canonical URLs consistent.
         </p>
+        <figure class="my-8 md:my-10 rounded-2xl border border-border bg-bg-surface p-4 md:p-6 overflow-x-auto">
+          <A2TechFoundations />
+          <figcaption class="mt-3 text-xs text-text-muted text-center font-mono">Six technical foundations that must be in place before AI engines can reliably cite a page</figcaption>
+        </figure>
       </section>
 
       {/* Content checklist */}
@@ -168,6 +180,10 @@ const dateModified = '2026-06-04';
           <li>Stuffing keywords or fabricating facts — answer engines favor verifiable, well-sourced content.</li>
           <li>Treating llms.txt or schema as a magic switch. They help retrieval and parsing; they don't guarantee citations.</li>
         </ul>
+        <figure class="my-8 md:my-10 rounded-2xl border border-border bg-bg-surface p-4 md:p-6 overflow-x-auto">
+          <A3FailureModes />
+          <figcaption class="mt-3 text-xs text-text-muted text-center font-mono">The most common reasons a website fails to appear as a cited source</figcaption>
+        </figure>
       </section>
 
       {/* CTA */}

--- a/frontend/src/pages/guides/geo-vs-seo.astro
+++ b/frontend/src/pages/guides/geo-vs-seo.astro
@@ -1,5 +1,8 @@
 ---
 import Shell from '../../components/Shell.astro';
+import B1HeroSEOvsGEO from '../../components/guide-visuals/B1HeroSEOvsGEO.astro';
+import B2RankingVsCitation from '../../components/guide-visuals/B2RankingVsCitation.astro';
+import B3StaysSameChanges from '../../components/guide-visuals/B3StaysSameChanges.astro';
 
 const title = 'GEO vs SEO: What Changes When AI Engines Become the Interface';
 const description =
@@ -35,6 +38,11 @@ const dateModified = '2026-06-05';
       </p>
     </header>
 
+    <figure class="my-8 md:my-10 rounded-2xl border border-border bg-bg-surface p-4 md:p-6 overflow-x-auto">
+      <B1HeroSEOvsGEO />
+      <figcaption class="mt-3 text-xs text-text-muted text-center font-mono">SEO ranks links. GEO earns citations in synthesized answers. The optimization target is different.</figcaption>
+    </figure>
+
     <div class="space-y-12 md:space-y-16 [&_h2]:font-display [&_h2]:text-2xl [&_h2]:font-bold [&_h2]:text-text-primary [&_h2]:leading-tight [&_h2]:tracking-tight [&_h3]:font-display [&_h3]:text-lg [&_h3]:font-semibold [&_h3]:text-text-primary [&_p]:text-text-secondary [&_p]:leading-relaxed [&_li]:text-text-secondary [&_li]:leading-relaxed">
 
       {/* The core difference */}
@@ -58,6 +66,10 @@ const dateModified = '2026-06-05';
           optimization target has shifted for a meaningful share of queries,
           especially informational and comparison ones.
         </p>
+        <figure class="my-8 md:my-10 rounded-2xl border border-border bg-bg-surface p-4 md:p-6 overflow-x-auto">
+          <B2RankingVsCitation />
+          <figcaption class="mt-3 text-xs text-text-muted text-center font-mono">Traditional search surfaces a ranked list; AI answer engines synthesize one answer and cite sources inline.</figcaption>
+        </figure>
       </section>
 
       {/* What stays the same */}
@@ -77,6 +89,10 @@ const dateModified = '2026-06-05';
           If your SEO fundamentals are weak, GEO won't save you. Fix the
           foundation first.
         </p>
+        <figure class="my-8 md:my-10 rounded-2xl border border-border bg-bg-surface p-4 md:p-6 overflow-x-auto">
+          <B3StaysSameChanges />
+          <figcaption class="mt-3 text-xs text-text-muted text-center font-mono">Technical foundations carry over from SEO. What changes is the optimization target: quotability, entity clarity, and source trust.</figcaption>
+        </figure>
       </section>
 
       {/* What changes */}

--- a/frontend/src/pages/guides/llms-txt-wordpress.astro
+++ b/frontend/src/pages/guides/llms-txt-wordpress.astro
@@ -1,5 +1,8 @@
 ---
 import Shell from '../../components/Shell.astro';
+import C1HeroLlmsTxt from '../../components/guide-visuals/C1HeroLlmsTxt.astro';
+import C2LlmsTxtStructure from '../../components/guide-visuals/C2LlmsTxtStructure.astro';
+import C3WordPressOptions from '../../components/guide-visuals/C3WordPressOptions.astro';
 
 const title = 'llms.txt for WordPress and AI Visibility: A Practical Guide';
 const description =
@@ -36,6 +39,11 @@ const dateModified = '2026-06-05';
         Published June 2026 · 9 min read
       </p>
     </header>
+
+    <figure class="my-8 md:my-10 rounded-2xl border border-border bg-bg-surface p-4 md:p-6 overflow-x-auto">
+      <C1HeroLlmsTxt />
+      <figcaption class="mt-3 text-xs text-text-muted text-center font-mono">llms.txt is one signal layer — it complements robots.txt, sitemap, and schema rather than replacing any of them.</figcaption>
+    </figure>
 
     <div class="space-y-12 md:space-y-16 [&_h2]:font-display [&_h2]:text-2xl [&_h2]:font-bold [&_h2]:text-text-primary [&_h2]:leading-tight [&_h2]:tracking-tight [&_h3]:font-display [&_h3]:text-lg [&_h3]:font-semibold [&_h3]:text-text-primary [&_p]:text-text-secondary [&_p]:leading-relaxed [&_li]:text-text-secondary [&_li]:leading-relaxed">
 
@@ -114,11 +122,21 @@ const dateModified = '2026-06-05';
           <li>Include your most important pages. Don't try to list everything.</li>
           <li>Optionally link to an <code class="text-sm font-mono">llms-full.txt</code> at the bottom if you have one.</li>
         </ul>
+
+        <figure class="my-8 md:my-10 rounded-2xl border border-border bg-bg-surface p-4 md:p-6 overflow-x-auto">
+          <C2LlmsTxtStructure />
+          <figcaption class="mt-3 text-xs text-text-muted text-center font-mono">The recommended llms.txt structure: H1 site name, blockquote summary, H2 sections with annotated link lists.</figcaption>
+        </figure>
       </section>
 
       {/* WordPress implementation */}
       <section>
         <h2>Implementing on WordPress</h2>
+
+        <figure class="my-8 md:my-10 rounded-2xl border border-border bg-bg-surface p-4 md:p-6 overflow-x-auto">
+          <C3WordPressOptions />
+          <figcaption class="mt-3 text-xs text-text-muted text-center font-mono">Three practical paths for adding llms.txt to a WordPress site — choose based on hosting access.</figcaption>
+        </figure>
 
         <h3 class="mt-6">Option 1: manual file upload (simplest)</h3>
         <p class="mt-3">


### PR DESCRIPTION
## Summary

- Add 13 Astro SVG components in `frontend/src/components/guide-visuals/`
- Embed visuals into all 4 published guides via semantic `<figure>/<figcaption>` wrappers
- Consistent visual language: teal/indigo palette, responsive `viewBox`, accessible `<title>` + `role="img"` on each SVG

## SVG inventory

| Guide | Components |
|---|---|
| appear-in-chatgpt-perplexity | A1HeroAIDiscovery, A2TechFoundations, A3FailureModes |
| geo-vs-seo | B1HeroSEOvsGEO, B2RankingVsCitation, B3StaysSameChanges |
| llms-txt-wordpress | C1HeroLlmsTxt, C2LlmsTxtStructure, C3WordPressOptions |
| ai-visibility-checklist | D1HeroChecklist, D2TechChecklist, D3ContentChecklist, D4MonitorLoop |

## Test plan

- [x] `npm run build` clean (20 pages, 1.37s)
- [x] All 4 guides render with visuals
- [x] No broken internal links
- [x] Visual consistency across guides

🤖 Generated with [Claude Code](https://claude.com/claude-code)