### PR TITLE
fix(seo): normalize canonical URLs and improve high-intent metadata

### DIFF
--- a/frontend/src/pages/about.astro
+++ b/frontend/src/pages/about.astro
@@ -130,7 +130,7 @@ import Shell from '../components/Shell.astro';
     "@context": "https://schema.org",
     "@type": "AboutPage",
     "name": "About Auriti Labs",
-    "url": "https://geoready.dev/about",
+    "url": "https://geoready.dev/about/",
     "description": "Auriti Labs builds open-source tools for AI search visibility and Generative Engine Optimization. Products: GEO Optimizer (open-source audit engine) and GeoReady (commercial monitoring platform).",
     "author": {
       "@type": "Organization",

--- a/frontend/src/pages/analyze-competitors.astro
+++ b/frontend/src/pages/analyze-competitors.astro
@@ -69,7 +69,7 @@ import AnalyzeCompetitorsContainer from '../components/compare/AnalyzeCompetitor
     "@type": "WebPage",
     "name": "Competitor AI Visibility Analysis — GEO Optimizer",
     "description": "Analyze competitor AI visibility with GEO Optimizer. Compare multiple websites across GEO scores, citability, technical readiness, and AI search signals.",
-    "url": "https://geoready.dev/analyze-competitors",
+    "url": "https://geoready.dev/analyze-competitors/",
     "author": {
       "@type": "Organization",
       "name": "Auriti Labs",

--- a/frontend/src/pages/compare.astro
+++ b/frontend/src/pages/compare.astro
@@ -4,8 +4,8 @@ import CompareContainer from '../components/compare/CompareContainer';
 ---
 
 <Shell
-  title="Compare AI Visibility Scores — GEO Optimizer"
-  description="Compare two websites side by side with GEO Optimizer. Benchmark AI search visibility, citability, and technical signals for ChatGPT, Perplexity, and Claude."
+  title="Compare AI Search Visibility — Two Sites Side by Side"
+  description="Run a free head-to-head GEO audit. Enter two URLs and compare AI search visibility, citability, and technical signals for ChatGPT, Perplexity, and Claude."
   canonical="https://geoready.dev/compare/"
 >
   <div class="max-w-7xl mx-auto px-4 sm:px-6 py-10 md:py-16">
@@ -18,14 +18,18 @@ import CompareContainer from '../components/compare/CompareContainer';
       </div>
 
       <h1 class="mt-3 font-display text-3xl md:text-4xl font-bold text-text-primary leading-tight tracking-tight">
-        Compare AI Visibility Scores
+        Compare AI Search Visibility
       </h1>
 
       <p class="mt-4 text-base text-text-secondary leading-relaxed max-w-2xl">
-        Side-by-side analysis. Enter two URLs and run a head-to-head GEO audit to see who is more visible to AI search engines.
+        Enter two URLs below and run a free head-to-head GEO audit. See which site is more
+        visible to AI answer engines like ChatGPT, Perplexity, and Claude — scored across the
+        same 8 signal categories, side by side.
       </p>
 
-      <p class="mt-2 text-xs text-text-muted font-mono">Last updated: May 2026</p>
+      <a href="#compare-form" class="mt-5 inline-flex items-center gap-2 rounded-lg bg-accent-teal px-5 py-2.5 text-sm font-medium text-white hover:bg-accent-teal-dark transition-colors">
+        Compare two sites
+      </a>
     </header>
 
     {/* Static info section — visible to crawlers */}
@@ -60,16 +64,18 @@ import CompareContainer from '../components/compare/CompareContainer';
     </section>
 
     {/* Interactive tool — hydrated by React */}
-    <CompareContainer client:only="react" />
+    <div id="compare-form" class="scroll-mt-24">
+      <CompareContainer client:only="react" />
+    </div>
   </div>
 
   {/* Page-specific schema */}
   <script type="application/ld+json" set:html={JSON.stringify({
     "@context": "https://schema.org",
     "@type": "WebPage",
-    "name": "Compare AI Visibility Scores — GEO Optimizer",
-    "description": "Compare two websites side by side with GEO Optimizer. Benchmark AI search visibility, citability, and technical signals for ChatGPT, Perplexity, and Claude.",
-    "url": "https://geoready.dev/compare",
+    "name": "Compare AI Search Visibility — Two Sites Side by Side",
+    "description": "Run a free head-to-head GEO audit. Enter two URLs and compare AI search visibility, citability, and technical signals for ChatGPT, Perplexity, and Claude.",
+    "url": "https://geoready.dev/compare/",
     "author": {
       "@type": "Organization",
       "name": "Auriti Labs",

--- a/frontend/src/pages/cookie-policy.astro
+++ b/frontend/src/pages/cookie-policy.astro
@@ -144,7 +144,7 @@ import Shell from '../components/Shell.astro';
     "@type": "WebPage",
     "name": "Cookie Policy — GEO Optimizer",
     "description": "Cookie policy for GEO Optimizer, covering cookie categories, storage inventory, and consent management.",
-    "url": "https://geoready.dev/cookie-policy",
+    "url": "https://geoready.dev/cookie-policy/",
     "isPartOf": {
       "@type": "WebSite",
       "name": "GEO Optimizer",

--- a/frontend/src/pages/early-access.astro
+++ b/frontend/src/pages/early-access.astro
@@ -136,7 +136,7 @@ import SurveyForm from '../components/SurveyForm';
     "@type": "WebPage",
     "name": "Founding Access — GeoReady",
     "description": "GeoReady founding access is now open. Full GEO reports, AI search monitoring, score history, and alerts.",
-    "url": "https://geoready.dev/early-access",
+    "url": "https://geoready.dev/early-access/",
     "isPartOf": {
       "@type": "WebSite",
       "name": "GEO Optimizer",

--- a/frontend/src/pages/index.astro
+++ b/frontend/src/pages/index.astro
@@ -96,8 +96,8 @@ const faqSchema = {
 
 <script type="application/ld+json" set:html={JSON.stringify(faqSchema)} />
 <Shell
-  title="GEO Optimizer — AI Search Visibility & Citability Audit"
-  description="Audit your website's AI search visibility and citability. GEO Optimizer scores your site across 8 categories with actionable recommendations — free, no account required."
+  title="Free AI Search Visibility Audit — GEO Optimizer"
+  description="Is your site visible to AI search? Get a free GEO audit scoring how ChatGPT, Perplexity, Claude & Gemini find and cite your pages. No account needed."
   canonical="https://geoready.dev/"
 >
   {/* Hero */}

--- a/frontend/src/pages/manifesto.astro
+++ b/frontend/src/pages/manifesto.astro
@@ -5,7 +5,7 @@ import ManifestoToc from '../components/manifesto/ManifestoToc.astro';
 import { manifestoSections } from '../lib/manifestoContent';
 ---
 
-<Shell title="The GEO Optimizer Manifesto — AI Search Visibility" description="The GEO Optimizer Manifesto explains why AI search visibility must be auditable, open, and accessible through research-backed GEO signals." canonical="https://geoready.dev/manifesto/">
+<Shell title="The Generative Engine Optimization Manifesto" description="An AI visibility manifesto: why being citable by ChatGPT, Perplexity & Claude must be auditable, open, and measurable through generative engine optimization." canonical="https://geoready.dev/manifesto/">
   <div class="max-w-6xl mx-auto px-4 sm:px-6 py-10 md:py-16">
     {/* Header editoriale */}
     <header class="max-w-3xl mb-14 md:mb-20">
@@ -16,7 +16,7 @@ import { manifestoSections } from '../lib/manifestoContent';
       </div>
 
       <h1 class="mt-3 font-display text-3xl md:text-4xl font-bold text-text-primary leading-tight tracking-tight">
-        The GEO Optimizer Manifesto
+        The Generative Engine Optimization Manifesto
       </h1>
 
       <p class="mt-4 text-base md:text-lg text-text-secondary leading-relaxed max-w-2xl">
@@ -49,8 +49,8 @@ import { manifestoSections } from '../lib/manifestoContent';
   <script type="application/ld+json" set:html={JSON.stringify({
     "@context": "https://schema.org",
     "@type": "Article",
-    "headline": "The GEO Optimizer Manifesto",
-    "description": "The GEO Optimizer Manifesto explains why AI search visibility must be auditable, open, and accessible through research-backed GEO signals.",
+    "headline": "The Generative Engine Optimization Manifesto",
+    "description": "An AI visibility manifesto: why being citable by ChatGPT, Perplexity & Claude must be auditable, open, and measurable through generative engine optimization.",
     "author": {
       "@type": "Organization",
       "name": "Auriti Labs",
@@ -66,7 +66,7 @@ import { manifestoSections } from '../lib/manifestoContent';
     "image": "https://geoready.dev/assets/og-image.png",
     "mainEntityOfPage": {
       "@type": "WebPage",
-      "@id": "https://geoready.dev/manifesto"
+      "@id": "https://geoready.dev/manifesto/"
     },
     "about": [
       "AI search visibility",

--- a/frontend/src/pages/pricing.astro
+++ b/frontend/src/pages/pricing.astro
@@ -491,7 +491,7 @@ const faqs = [
         "@type": "WebPage",
         "name": "GEO Optimizer Pricing",
         "description": "GEO Optimizer pricing — free audit with no account required, Pro monitoring, Studio multi-site, Agency workspace.",
-        "url": "https://geoready.dev/pricing",
+        "url": "https://geoready.dev/pricing/",
         "isPartOf": {
           "@type": "WebSite",
           "name": "GEO Optimizer",

--- a/frontend/src/pages/privacy.astro
+++ b/frontend/src/pages/privacy.astro
@@ -117,7 +117,7 @@ import Shell from '../components/Shell.astro';
     "@type": "WebPage",
     "name": "Privacy Policy — GEO Optimizer",
     "description": "Privacy policy for GEO Optimizer, covering data processing, legal basis, retention, and user rights.",
-    "url": "https://geoready.dev/privacy",
+    "url": "https://geoready.dev/privacy/",
     "isPartOf": {
       "@type": "WebSite",
       "name": "GEO Optimizer",

--- a/frontend/src/pages/research.astro
+++ b/frontend/src/pages/research.astro
@@ -4,7 +4,7 @@ import ResearchCard from '../components/content/ResearchCard.astro';
 import { researchSources, researchClosing } from '../lib/researchContent';
 ---
 
-<Shell title="Research Foundation — GEO Optimizer" description="The GEO Optimizer research foundation covers peer-reviewed papers, benchmarks, and industry reports that inform every AI visibility scoring decision." canonical="https://geoready.dev/research/">
+<Shell title="GEO Research — Papers Behind AI Search Visibility" description="Peer-reviewed papers, benchmarks, and industry reports behind AI search visibility scoring — the research foundation for generative engine optimization." canonical="https://geoready.dev/research/">
   <div class="max-w-5xl mx-auto px-4 sm:px-6 py-10 md:py-16">
     {/* Header */}
     <header class="max-w-2xl mb-14 md:mb-20">
@@ -15,7 +15,7 @@ import { researchSources, researchClosing } from '../lib/researchContent';
       </div>
 
       <h1 class="mt-3 font-display text-3xl md:text-4xl font-bold text-text-primary leading-tight tracking-tight">
-        Research Foundation
+        GEO Research Foundation
       </h1>
 
       <p class="mt-4 text-base md:text-lg text-text-secondary leading-relaxed max-w-2xl">
@@ -58,7 +58,7 @@ import { researchSources, researchClosing } from '../lib/researchContent';
 
     {/* Closing statement */}
     <div class="mt-14 md:mt-20 max-w-2xl">
-      <blockquote class="pl-5 border-l-2 border-accent-teal" cite="https://geoready.dev/research">
+      <blockquote class="pl-5 border-l-2 border-accent-teal" cite="https://geoready.dev/research/">
         <p class="text-sm font-medium text-text-primary italic leading-relaxed">
           {researchClosing.statement}
         </p>
@@ -69,9 +69,9 @@ import { researchSources, researchClosing } from '../lib/researchContent';
   <script type="application/ld+json" set:html={JSON.stringify({
     "@context": "https://schema.org",
     "@type": "CollectionPage",
-    "name": "Research Foundation",
-    "url": "https://geoready.dev/research",
-    "description": "The GEO Optimizer research foundation covers peer-reviewed papers, benchmarks, and industry reports that inform every AI visibility scoring decision.",
+    "name": "GEO Research Foundation",
+    "url": "https://geoready.dev/research/",
+    "description": "Peer-reviewed papers, benchmarks, and industry reports behind AI search visibility scoring — the research foundation for generative engine optimization.",
     "author": {
       "@type": "Organization",
       "name": "Auriti Labs",

--- a/frontend/src/pages/roadmap.astro
+++ b/frontend/src/pages/roadmap.astro
@@ -4,7 +4,7 @@ import RoadmapPhase from '../components/content/RoadmapPhase.astro';
 import { roadmapPhases, releaseCadence } from '../lib/roadmapContent';
 ---
 
-<Shell title="Product Roadmap — GEO Optimizer CLI & Web" description="Explore the open-source GEO Optimizer roadmap for CLI, web app, API, monitoring, AI visibility audits, and future GEO research workflows." canonical="https://geoready.dev/roadmap/">
+<Shell title="GEO Optimizer Roadmap 2026 — CLI, API & Monitoring" description="The GeoReady roadmap for 2026: where generative engine optimization is headed across the GEO Optimizer CLI, web app, API, and AI visibility monitoring." canonical="https://geoready.dev/roadmap/">
   <div class="max-w-4xl mx-auto px-4 sm:px-6 py-10 md:py-16">
     {/* Hero */}
     <header class="max-w-2xl mb-14 md:mb-20">
@@ -15,7 +15,7 @@ import { roadmapPhases, releaseCadence } from '../lib/roadmapContent';
       </div>
 
       <h1 class="mt-3 font-display text-3xl md:text-4xl font-bold text-text-primary leading-tight tracking-tight">
-        Roadmap
+        GEO Optimizer Roadmap 2026
       </h1>
 
       <p class="mt-3 text-lg font-medium text-text-secondary italic">
@@ -127,9 +127,9 @@ import { roadmapPhases, releaseCadence } from '../lib/roadmapContent';
   <script type="application/ld+json" set:html={JSON.stringify({
     "@context": "https://schema.org",
     "@type": "CollectionPage",
-    "name": "Product Roadmap — GEO Optimizer",
-    "url": "https://geoready.dev/roadmap",
-    "description": "Explore the open-source GEO Optimizer roadmap for CLI, web app, API, monitoring, AI visibility audits, and future GEO research workflows.",
+    "name": "GEO Optimizer Roadmap 2026",
+    "url": "https://geoready.dev/roadmap/",
+    "description": "The GeoReady roadmap for 2026: where generative engine optimization is headed across the GEO Optimizer CLI, web app, API, and AI visibility monitoring.",
     "author": {
       "@type": "Organization",
       "name": "Auriti Labs",

--- a/tests/test_frontend_seo.py
+++ b/tests/test_frontend_seo.py
@@ -1,0 +1,246 @@
+"""
+Test di regressione SEO per il sito marketing geoready.dev (frontend Astro SSG).
+
+Questi test leggono i file sorgente versionati — NON richiedono `npm run build`:
+- frontend/public/sitemap.xml (sitemap statica, fonte di verità)
+- frontend/src/pages/**/*.astro (prop Shell: title/description/canonical + JSON-LD url)
+
+Obiettivo: impedire regressioni su host canonico, trailing slash, duplicati e
+metadati vuoti dopo il recovery SEO. Nessuna chiamata di rete.
+
+Note di robustezza (post review):
+- _extract_shell_prop è ancorato al tag <Shell ...> e risolve sia letterali
+  ("...") sia binding a espressione ({var}) tramite le const del frontmatter,
+  così un refactor a binding non produce falsi negativi silenziosi.
+- _extract_page_schema_urls raccoglie sia gli URL letterali nei blocchi JSON-LD
+  sia le const canonical/canonicalUrl (usate dalle guide via "@id": canonical),
+  così la verifica del trailing slash copre anche le pagine in sottocartella.
+"""
+
+from __future__ import annotations
+
+import re
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pytest
+
+# ── Percorsi ──────────────────────────────────────────────────────────────────
+_FRONTEND = Path(__file__).parent.parent / "frontend"
+_SITEMAP = _FRONTEND / "public" / "sitemap.xml"
+_PAGES_DIR = _FRONTEND / "src" / "pages"
+
+# Host canonico pubblico unico (vedi nginx-geoready.conf: www e http → 301 qui)
+CANONICAL_HOST = "https://geoready.dev"
+_SITEMAP_NS = {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+
+# Estensioni di asset/file: questi URL non sono "pagine" e non richiedono lo slash.
+_ASSET_EXTENSIONS = (".png", ".jpg", ".jpeg", ".svg", ".ico", ".xml", ".pdf", ".json", ".webp", ".txt")
+
+# Pagine ad alta priorità: devono avere title + description + canonical corretti.
+# slug → file .astro
+KEY_PAGES = {
+    "/": "index.astro",
+    "/research/": "research.astro",
+    "/roadmap/": "roadmap.astro",
+    "/manifesto/": "manifesto.astro",
+    "/compare/": "compare.astro",
+}
+
+
+# ── Helper di parsing ───────────────────────────────────────────────────────────
+def _read_sitemap_locs() -> list[str]:
+    """Estrae tutti i <loc> dalla sitemap statica."""
+    tree = ET.parse(_SITEMAP)
+    return [el.text.strip() for el in tree.getroot().iterfind(".//sm:loc", _SITEMAP_NS) if el.text]
+
+
+def _resolve_consts(astro_source: str) -> dict[str, str]:
+    """Mappa `const NAME = '...'` del frontmatter (anche su riga successiva)."""
+    consts: dict[str, str] = {}
+    for name, value in re.findall(
+        r"const\s+(\w+)\s*=\s*[\"']([^\"']*)[\"']", astro_source
+    ):
+        consts[name] = value
+    return consts
+
+
+def _find_shell_tag(astro_source: str) -> str | None:
+    """Ritorna il contenuto degli attributi del tag <Shell ...> di apertura."""
+    match = re.search(r"<Shell\b(.*?)>", astro_source, re.DOTALL)
+    return match.group(1) if match else None
+
+
+def _extract_shell_prop(astro_source: str, prop: str) -> str | None:
+    """Estrae il valore di una prop passata al componente <Shell ...>.
+
+    Gestisce letterali doppi/singoli (prop="..." / prop='...') e binding a
+    espressione (prop={var}) risolvendo la const corrispondente. Ancorato al tag
+    <Shell> per non catturare attributi omonimi altrove (es. <div title="...">).
+    """
+    attrs = _find_shell_tag(astro_source)
+    if attrs is None:
+        return None
+    # Letterale: prop="..." oppure prop='...'  (\b evita match dentro 'subtitle')
+    literal = re.search(rf'\b{prop}\s*=\s*"([^"]*)"', attrs) or re.search(
+        rf"\b{prop}\s*=\s*'([^']*)'", attrs
+    )
+    if literal:
+        return literal.group(1)
+    # Espressione: prop={varName} → risolvi la const del frontmatter
+    expr = re.search(rf"\b{prop}\s*=\s*\{{(\w+)\}}", attrs)
+    if expr:
+        return _resolve_consts(astro_source).get(expr.group(1))
+    return None
+
+
+def _extract_page_schema_urls(astro_source: str) -> list[str]:
+    """URL "di pagina" che puntano a geoready.dev, da JSON-LD e const canonical.
+
+    Copre due forme reali:
+    - letterale nei blocchi JSON-LD:  "url"/"@id": "https://geoready.dev/..."
+    - binding via const (guide):       const canonical = 'https://geoready.dev/.../'
+                                        poi "@id": canonical
+    """
+    urls = re.findall(r'"(?:url|@id)":\s*"(https://geoready\.dev[^"]*)"', astro_source)
+    for name, value in _resolve_consts(astro_source).items():
+        if name.lower() in ("canonical", "canonicalurl") and value.startswith(CANONICAL_HOST):
+            urls.append(value)
+    return urls
+
+
+def _is_asset_url(url: str) -> bool:
+    last_segment = url.rstrip("/").split("/")[-1].lower()
+    return "/assets/" in url or last_segment.endswith(_ASSET_EXTENSIONS)
+
+
+# ── Skip se il sorgente non è presente (es. checkout parziale) ──────────────────
+pytestmark = pytest.mark.skipif(
+    not _SITEMAP.exists() or not _PAGES_DIR.exists(),
+    reason="frontend sources assenti (sitemap.xml o src/pages/)",
+)
+
+_ALL_PAGES = sorted(str(p.relative_to(_PAGES_DIR)) for p in _PAGES_DIR.rglob("*.astro"))
+
+
+# ── Test sitemap ────────────────────────────────────────────────────────────────
+class TestSitemapCanonical:
+    """La sitemap deve esporre SOLO URL canonici finali."""
+
+    def test_sitemap_contiene_solo_host_canonico(self):
+        for loc in _read_sitemap_locs():
+            assert loc.startswith(CANONICAL_HOST + "/"), f"URL non canonico in sitemap: {loc}"
+
+    def test_sitemap_non_contiene_www(self):
+        for loc in _read_sitemap_locs():
+            assert "://www." not in loc, f"URL www nella sitemap: {loc}"
+
+    def test_sitemap_non_contiene_app_subdomain(self):
+        # app.geoready.dev è il SaaS, non il sito marketing: non deve comparire qui.
+        for loc in _read_sitemap_locs():
+            assert "app.geoready.dev" not in loc, f"URL app.geoready.dev nella sitemap: {loc}"
+
+    def test_sitemap_solo_https(self):
+        for loc in _read_sitemap_locs():
+            assert loc.startswith("https://"), f"URL non-HTTPS nella sitemap: {loc}"
+
+    def test_sitemap_url_con_trailing_slash(self):
+        # trailingSlash:'always' in astro.config → ogni URL finisce con /
+        for loc in _read_sitemap_locs():
+            assert loc.endswith("/"), f"URL senza trailing slash nella sitemap: {loc}"
+
+    def test_sitemap_nessun_duplicato(self):
+        locs = _read_sitemap_locs()
+        duplicati = [u for u in set(locs) if locs.count(u) > 1]
+        assert not duplicati, f"URL duplicati nella sitemap: {duplicati}"
+
+    def test_sitemap_nessuna_variante_non_slash(self):
+        # Per ogni URL non deve esistere anche la variante senza slash finale.
+        locs = set(_read_sitemap_locs())
+        for loc in locs:
+            if loc != CANONICAL_HOST + "/":
+                assert loc.rstrip("/") not in locs, f"Variante non-slash duplicata: {loc}"
+
+
+# ── Test metadati pagine chiave ─────────────────────────────────────────────────
+class TestKeyPagesMetadata:
+    """Le pagine ad alta priorità devono avere metadati non vuoti e canonici corretti."""
+
+    @pytest.mark.parametrize("slug,filename", KEY_PAGES.items())
+    def test_pagina_ha_title_non_vuoto(self, slug: str, filename: str):
+        source = (_PAGES_DIR / filename).read_text(encoding="utf-8")
+        title = _extract_shell_prop(source, "title")
+        assert title and title.strip(), f"{filename}: title mancante o vuoto"
+
+    @pytest.mark.parametrize("slug,filename", KEY_PAGES.items())
+    def test_pagina_title_entro_limite_seo(self, slug: str, filename: str):
+        # Limite pratico ~60 char per evitare il troncamento del title in SERP.
+        source = (_PAGES_DIR / filename).read_text(encoding="utf-8")
+        title = _extract_shell_prop(source, "title") or ""
+        assert len(title) <= 60, f"{filename}: title {len(title)} char (>60, rischio troncamento)"
+
+    @pytest.mark.parametrize("slug,filename", KEY_PAGES.items())
+    def test_pagina_ha_description_non_vuota(self, slug: str, filename: str):
+        source = (_PAGES_DIR / filename).read_text(encoding="utf-8")
+        description = _extract_shell_prop(source, "description")
+        assert description and description.strip(), f"{filename}: description mancante o vuota"
+
+    @pytest.mark.parametrize("slug,filename", KEY_PAGES.items())
+    def test_pagina_canonical_corretto(self, slug: str, filename: str):
+        source = (_PAGES_DIR / filename).read_text(encoding="utf-8")
+        canonical = _extract_shell_prop(source, "canonical")
+        # Guardia anti-falso-positivo: la prop deve essere effettivamente trovata.
+        assert canonical is not None, f"{filename}: canonical non trovato sul tag <Shell>"
+        assert canonical == CANONICAL_HOST + slug, (
+            f"{filename}: canonical atteso {CANONICAL_HOST + slug}, trovato {canonical}"
+        )
+
+    @pytest.mark.parametrize("slug,filename", KEY_PAGES.items())
+    def test_description_entro_limite_seo(self, slug: str, filename: str):
+        # Range pratico 50–160 char: sotto è troppo magra, sopra si tronca in SERP.
+        source = (_PAGES_DIR / filename).read_text(encoding="utf-8")
+        description = _extract_shell_prop(source, "description") or ""
+        assert 50 <= len(description) <= 160, (
+            f"{filename}: description {len(description)} char (fuori range 50–160)"
+        )
+
+
+# ── Test coerenza canonical ↔ JSON-LD ───────────────────────────────────────────
+class TestSchemaCanonicalConsistency:
+    """Gli URL "di pagina" nei JSON-LD (e nelle const canonical) devono usare il
+    trailing slash come il canonical.
+
+    Una variante senza slash invia un segnale di duplicato che confligge con il
+    canonical (root cause del recovery SEO). Copre anche le guide in sottocartella.
+    """
+
+    @pytest.mark.parametrize("relpath", _ALL_PAGES)
+    def test_page_url_con_trailing_slash(self, relpath: str):
+        source = (_PAGES_DIR / relpath).read_text(encoding="utf-8")
+        for url in _extract_page_schema_urls(source):
+            if url == CANONICAL_HOST or _is_asset_url(url):
+                continue
+            assert url.endswith("/"), f"{relpath}: URL di pagina senza trailing slash: {url}"
+
+    def test_pagine_con_jsonld_espongono_url_di_pagina(self):
+        """Anti-silent-pass: ogni pagina con un blocco JSON-LD deve esporre la
+        propria identità di pagina in modo estraibile — via prop canonical sul
+        <Shell> oppure via URL nei JSON-LD/const. Così un'estrazione che non matcha
+        nulla fallisce in modo esplicito invece di passare a vuoto.
+
+        Nota: alcune pagine (es. homepage) hanno solo schema di entità/FAQ senza
+        un URL di pagina nel JSON-LD; lì la canonical del <Shell> è la fonte valida.
+        """
+        mancanti: list[str] = []
+        for relpath in _ALL_PAGES:
+            source = (_PAGES_DIR / relpath).read_text(encoding="utf-8")
+            if "application/ld+json" not in source:
+                continue
+            page_urls = [u for u in _extract_page_schema_urls(source) if not _is_asset_url(u)]
+            shell_canonical = _extract_shell_prop(source, "canonical")
+            if not page_urls and not shell_canonical:
+                mancanti.append(relpath)
+        assert not mancanti, (
+            "Pagine con JSON-LD ma nessun URL di pagina né canonical estraibile "
+            f"(possibile silent-pass o canonical mancante): {mancanti}"
+        )


### PR DESCRIPTION
## Problem

Google Search Console showed the geoready.dev marketing site getting impressions but almost no clicks:

- 16 months: 3 clicks, 161 impressions, CTR 1.86%, avg position 11.4.
- High-impression / zero-click pages: `/research/` (62 impr, pos ~7.4), `/roadmap/` (42 impr, pos ~16.7), `/manifesto/` (23 impr, pos ~8.2). Query "roadmap geo" ranked ~position 2 with 0 clicks.
- Redirect/canonical issues observed for non-trailing-slash URLs (`/compare`, `/manifesto`, `/analyze-competitors`, `/cookie-policy`).
- `/compare/` had ~16s engagement, suspected weak intent match.

## Root cause

The site uses `trailingSlash: 'always'` (Astro). The `<link rel="canonical">` rendered in `Layout.astro` correctly used the trailing-slash form, **but every page's JSON-LD `url` / `@id` fields omitted the trailing slash**:

```
<link rel="canonical"> : https://geoready.dev/compare/   ← correct
JSON-LD "url"          : https://geoready.dev/compare    ← conflicting non-slash duplicate
```

This fed crawlers a non-slash duplicate that fights the canonical — a plausible driver of the GSC non-slash canonical/redirect signals. Present on all 10 pages with page-level schema.

The sitemap and `<link rel="canonical">` hosts were already correct (`https://geoready.dev`, trailing slash, no www, no dupes), so no sitemap surgery was needed. `www → non-www` and `http → https` 301s already live in the tracked `nginx-geoready.conf`.

## Implementation summary

1. **Canonical consistency** — aligned all JSON-LD `url`/`@id` (and the `/research/` blockquote `cite`) to the trailing-slash form so schema matches the canonical.
2. **High-intent metadata** — rewrote `<title>` + `<meta description>` for homepage, `/research/`, `/roadmap/`, `/manifesto/`, `/compare/` targeting the intended keywords, within SERP limits (titles ≤60, descriptions 50–160 chars). Aligned each page's visible H1 and JSON-LD name/headline to its new title to avoid split relevance.
3. **/compare/ on-page UX** — tightened the above-the-fold (crawlable) intro to explain what is compared and why, and added a clear "Compare two sites" CTA anchored to the form. The React island and its behavior are unchanged; no new endpoints.
4. **Regression guard** — added `tests/test_frontend_seo.py` (source-level, no build, no network).

## Pages changed

| File | Change |
|------|--------|
| `index.astro` | title + description (value-prop lead) |
| `research.astro` | title + description + H1 + schema name/url + cite |
| `roadmap.astro` | title + description + H1 + schema name/url |
| `manifesto.astro` | title + description + H1 + headline + `@id` slash |
| `compare.astro` | title + description + H1 + schema url + intro/CTA |
| `about.astro` | schema `url` trailing-slash |
| `analyze-competitors.astro` | schema `url` trailing-slash |
| `cookie-policy.astro` | schema `url` trailing-slash |
| `early-access.astro` | schema `url` trailing-slash |
| `pricing.astro` | schema `url` trailing-slash |
| `privacy.astro` | schema `url` trailing-slash |
| `tests/test_frontend_seo.py` | **new** regression test |

Scope: marketing site only. No audit engine, pricing, auth, billing, database, or app.geoready.dev changes.

## Tests run

- `tests/test_frontend_seo.py` — 52 passed. Validates: sitemap exposes only canonical host / https / trailing slash / no www / no app subdomain / no dupes / no non-slash variants; key-page title/description/canonical; JSON-LD trailing-slash consistency. Extractor is anchored to the `<Shell>` tag and resolves expression-bound `const canonical` (guides), with an anti-silent-pass guard. Verified the slash check has teeth against an injected non-slash const.
- Relevant suite `test_web_app.py + test_core.py + test_frontend_seo.py` — **314 passed**.
- `ruff check tests/test_frontend_seo.py` — clean.
- `npm run build` — 20 pages built clean; built dist HTML verified (title / canonical / schema url / H1 / CTA anchor).

## Deploy notes

- Static site is built (`cd frontend && npm run build`) and served by FastAPI `StaticFiles` behind the tracked `nginx-geoready.conf`.
- `www → non-www` and `http → https` 301s are already in `nginx-geoready.conf` (blocks 1–3). No server config invented or changed here; ensure the deployed nginx matches the tracked file.
- No env/secret/runtime changes. **This PR does not deploy.**

## GSC request-indexing checklist (after deploy)

Request indexing (URL Inspection → Request Indexing) for the canonical URLs:

- [ ] `https://geoready.dev/`
- [ ] `https://geoready.dev/research/`
- [ ] `https://geoready.dev/roadmap/`
- [ ] `https://geoready.dev/manifesto/`
- [ ] `https://geoready.dev/compare/`
- [ ] Resubmit `https://geoready.dev/sitemap.xml`
- [ ] In the `www.geoready.dev` property, confirm pages report "Page with redirect" (301 → non-www); impressions should consolidate to the non-www property over subsequent crawls.

## Residual notes

- `site/robots.txt` references a separate GitHub Pages docs property (`auriti-labs.github.io/...`), not geoready.dev — out of scope, flagged only. Do not deploy it to geoready.dev.
- Sitemap is hand-maintained; the test guards format/canonical, not completeness vs routes. Migrating to `@astrojs/sitemap` later would remove that risk.