### PR TITLE
fix(seo): improve guide indexation and demo report crawl policy

### DIFF
--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -81,6 +81,8 @@ Allow: /
 
 User-agent: *
 Allow: /
+Allow: /report/demo
+Allow: /report/demo/
 Disallow: /report/
 Disallow: /api/
 

--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -50,7 +50,7 @@
   </url>
   <url>
     <loc>https://geoready.dev/guides/</loc>
-    <lastmod>2026-06-04</lastmod>
+    <lastmod>2026-06-05</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -77,6 +77,12 @@
     <lastmod>2026-06-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://geoready.dev/report/demo/</loc>
+    <lastmod>2026-06-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
   </url>
   <url>
     <loc>https://geoready.dev/manifesto/</loc>

--- a/frontend/src/components/report/AuditReportContainer.tsx
+++ b/frontend/src/components/report/AuditReportContainer.tsx
@@ -27,11 +27,18 @@ type State =
   | { status: 'ready'; report: AuditReport; claim_token: string | null; expires_at: string | null };
 
 export default function AuditReportContainer({ reportId }: AuditReportContainerProps) {
-  const [state, setState] = useState<State>({ status: 'loading' });
+  // La demo è una pagina marketing indicizzabile: inizializza già con i dati mock
+  // così l'isola viene renderizzata lato server (SSG) con il contenuto completo
+  // del report, invece di uno shell vuoto idratato solo client-side.
+  const [state, setState] = useState<State>(() =>
+    reportId === 'demo'
+      ? { status: 'ready', report: mockAuditReport, claim_token: null, expires_at: null }
+      : { status: 'loading' }
+  );
 
   useEffect(() => {
     if (reportId === 'demo') {
-      setState({ status: 'ready', report: mockAuditReport, claim_token: null, expires_at: null });
+      // Stato già pronto dall'initializer; nessun fetch necessario per la demo.
       return;
     }
 

--- a/frontend/src/pages/guides/ai-visibility-checklist.astro
+++ b/frontend/src/pages/guides/ai-visibility-checklist.astro
@@ -5,10 +5,9 @@ import D2TechChecklist from '../../components/guide-visuals/D2TechChecklist.astr
 import D3ContentChecklist from '../../components/guide-visuals/D3ContentChecklist.astro';
 import D4MonitorLoop from '../../components/guide-visuals/D4MonitorLoop.astro';
 
-const title =
-  'AI Visibility Checklist: How to Make Your Website Easier to Find, Cite, and Recommend';
+const title = 'AI Visibility Checklist — Get Found and Cited by AI';
 const description =
-  'A practical checklist covering all the technical and content signals that affect whether AI answer engines can find, parse, and cite your website. Organized by category, with clear pass/fail criteria.';
+  'A practical checklist of the technical and content signals that decide whether AI answer engines can find, parse, and cite your site, organized by category.';
 const canonical = 'https://geoready.dev/guides/ai-visibility-checklist/';
 const datePublished = '2026-06-05';
 const dateModified = '2026-06-05';

--- a/frontend/src/pages/guides/geo-vs-seo.astro
+++ b/frontend/src/pages/guides/geo-vs-seo.astro
@@ -4,9 +4,9 @@ import B1HeroSEOvsGEO from '../../components/guide-visuals/B1HeroSEOvsGEO.astro'
 import B2RankingVsCitation from '../../components/guide-visuals/B2RankingVsCitation.astro';
 import B3StaysSameChanges from '../../components/guide-visuals/B3StaysSameChanges.astro';
 
-const title = 'GEO vs SEO: What Changes When AI Engines Become the Interface';
+const title = 'GEO vs SEO: What Changes for AI Answer Engines';
 const description =
-  'SEO and GEO share some foundations but diverge in what they optimize for. This guide explains the differences, what stays the same, and where you need to change your approach when AI engines become the answer interface.';
+  'SEO and GEO share technical foundations but optimize for different goals. What stays the same, what changes, and where to focus when AI engines answer queries.';
 const canonical = 'https://geoready.dev/guides/geo-vs-seo/';
 const datePublished = '2026-06-05';
 const dateModified = '2026-06-05';

--- a/frontend/src/pages/guides/llms-txt-wordpress.astro
+++ b/frontend/src/pages/guides/llms-txt-wordpress.astro
@@ -6,7 +6,7 @@ import C3WordPressOptions from '../../components/guide-visuals/C3WordPressOption
 
 const title = 'llms.txt for WordPress and AI Visibility: A Practical Guide';
 const description =
-  'llms.txt is a plain-text file that helps AI tools understand your site. This guide explains what it is, what it actually does, and how to implement it on WordPress — manually or with a plugin.';
+  'llms.txt helps AI tools understand your site. What it is, what it does, and how to implement it on WordPress — manually, via functions.php, or a plugin.';
 const canonical = 'https://geoready.dev/guides/llms-txt-wordpress/';
 const datePublished = '2026-06-05';
 const dateModified = '2026-06-05';

--- a/frontend/src/pages/index.astro
+++ b/frontend/src/pages/index.astro
@@ -147,7 +147,9 @@ const faqSchema = {
         <span class="text-text-muted">·</span>
         <a href="/manifesto/" class="text-accent-teal hover:text-accent-teal-dark transition-colors">Read the manifesto</a>
         <span class="text-text-muted">·</span>
-        <a href="/report/demo" class="text-accent-teal hover:text-accent-teal-dark transition-colors">View a demo report</a>
+        <a href="/guides/" class="text-accent-teal hover:text-accent-teal-dark transition-colors">AI visibility guides</a>
+        <span class="text-text-muted">·</span>
+        <a href="/report/demo/" class="text-accent-teal hover:text-accent-teal-dark transition-colors">View a demo report</a>
       </div>
     </div>
   </section>

--- a/frontend/src/pages/report/[id].astro
+++ b/frontend/src/pages/report/[id].astro
@@ -19,8 +19,12 @@ const title = isDemo
 const description = isDemo
   ? 'Preview a sample GEO Optimizer audit report with GEO scores, citability ratings, technical signals, and actionable AI search visibility recommendations.'
   : 'View your GEO Optimizer audit report with GEO scores, citability ratings, technical signals, and actionable AI search visibility recommendations.';
-const canonical = `https://geoready.dev/report/${decodedId}`;
-const robots = 'noindex, nofollow';
+// Public demo report is a marketing page (static mock data, no user data) and
+// should be indexable. Live token reports stay out of the index.
+const canonical = isDemo
+  ? 'https://geoready.dev/report/demo/'
+  : `https://geoready.dev/report/${decodedId}`;
+const robots = isDemo ? 'index, follow' : 'noindex, nofollow';
 ---
 
 <Shell title={title} description={description} canonical={canonical} robots={robots}>

--- a/frontend/src/pages/research.astro
+++ b/frontend/src/pages/research.astro
@@ -26,6 +26,13 @@ import { researchSources, researchClosing } from '../lib/researchContent';
       <p class="mt-4 text-sm text-text-secondary">
         These sources inform the design philosophy documented in the <a href="/manifesto/" class="text-accent-teal hover:underline">GEO Optimizer Manifesto</a>.
       </p>
+
+      <p class="mt-2 text-sm text-text-secondary">
+        To turn this research into practice, see the
+        <a href="/guides/ai-visibility-checklist/" class="text-accent-teal hover:underline">AI visibility checklist</a>,
+        the <a href="/guides/geo-vs-seo/" class="text-accent-teal hover:underline">GEO vs SEO comparison</a>, and the
+        <a href="/guides/llms-txt-wordpress/" class="text-accent-teal hover:underline">llms.txt implementation guide</a>.
+      </p>
     </header>
 
     {/* Type filter legend */}

--- a/tests/test_frontend_seo.py
+++ b/tests/test_frontend_seo.py
@@ -38,14 +38,21 @@ _SITEMAP_NS = {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
 _ASSET_EXTENSIONS = (".png", ".jpg", ".jpeg", ".svg", ".ico", ".xml", ".pdf", ".json", ".webp", ".txt")
 
 # Pagine ad alta priorità: devono avere title + description + canonical corretti.
-# slug → file .astro
+# slug → file .astro (anche in sottocartella, es. guides/)
 KEY_PAGES = {
     "/": "index.astro",
     "/research/": "research.astro",
     "/roadmap/": "roadmap.astro",
     "/manifesto/": "manifesto.astro",
     "/compare/": "compare.astro",
+    # Guide target del recovery indicizzazione: stessi standard SEO delle core.
+    "/guides/ai-visibility-checklist/": "guides/ai-visibility-checklist.astro",
+    "/guides/geo-vs-seo/": "guides/geo-vs-seo.astro",
+    "/guides/llms-txt-wordpress/": "guides/llms-txt-wordpress.astro",
 }
+
+# robots.txt: fonte di verità per la policy di crawl (vedi report/[id].astro).
+_ROBOTS = _FRONTEND / "public" / "robots.txt"
 
 
 # ── Helper di parsing ───────────────────────────────────────────────────────────
@@ -243,4 +250,197 @@ class TestSchemaCanonicalConsistency:
         assert not mancanti, (
             "Pagine con JSON-LD ma nessun URL di pagina né canonical estraibile "
             f"(possibile silent-pass o canonical mancante): {mancanti}"
+        )
+
+
+# ── Helper robots.txt ────────────────────────────────────────────────────────────
+def _robots_group(agent: str) -> list[str]:
+    """Ritorna le direttive (Allow/Disallow) del gruppo `User-agent: <agent>`.
+
+    robots.txt è una sequenza di gruppi introdotti da `User-agent:`. Estrae solo
+    le righe del gruppo richiesto, così i test non confondono le regole di un bot
+    con quelle del wildcard `*`.
+    """
+    if not _ROBOTS.exists():
+        return []
+    directives: list[str] = []
+    in_group = False
+    for raw in _ROBOTS.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        key, _, value = line.partition(":")
+        key = key.strip().lower()
+        value = value.strip()
+        if key == "user-agent":
+            in_group = value == agent
+            continue
+        if in_group and key in ("allow", "disallow"):
+            directives.append(f"{key}:{value}")
+    return directives
+
+
+# ── Test policy robots.txt (crawl) ───────────────────────────────────────────────
+class TestRobotsPolicy:
+    """La policy di crawl deve esporre solo la demo pubblica di /report/, tenendo
+    privati i report con token e gli endpoint API."""
+
+    pytestmark = pytest.mark.skipif(not _ROBOTS.exists(), reason="robots.txt assente")
+
+    def test_demo_report_e_consentito_al_wildcard(self):
+        directives = _robots_group("*")
+        assert "allow:/report/demo" in directives, "Manca Allow: /report/demo per *"
+        assert "allow:/report/demo/" in directives, "Manca Allow: /report/demo/ per *"
+
+    def test_report_resta_disallow(self):
+        # I report con token (es. /report/<hash>) non devono essere crawlabili.
+        assert "disallow:/report/" in _robots_group("*"), "Manca Disallow: /report/"
+
+    def test_api_resta_disallow(self):
+        assert "disallow:/api/" in _robots_group("*"), "Manca Disallow: /api/"
+
+    def test_allow_demo_precede_disallow_report(self):
+        # Per i matcher robots (longest-match) l'ordine non è vincolante, ma teniamo
+        # Allow più specifico prima del Disallow generico per chiarezza e per i
+        # crawler che applicano la prima regola corrispondente.
+        directives = _robots_group("*")
+        assert directives.index("allow:/report/demo") < directives.index("disallow:/report/"), (
+            "Allow: /report/demo deve precedere Disallow: /report/"
+        )
+
+    def test_sitemap_dichiarata(self):
+        content = _ROBOTS.read_text(encoding="utf-8")
+        assert "Sitemap: https://geoready.dev/sitemap.xml" in content, (
+            "Riferimento alla sitemap mancante in robots.txt"
+        )
+
+
+# ── Test link interni verso le guide ─────────────────────────────────────────────
+# Guide target del recovery indicizzazione.
+_TARGET_GUIDES = (
+    "/guides/ai-visibility-checklist/",
+    "/guides/geo-vs-seo/",
+    "/guides/llms-txt-wordpress/",
+)
+_GUIDES_HUB = _PAGES_DIR / "guides" / "index.astro"
+_HOMEPAGE = _PAGES_DIR / "index.astro"
+_RESEARCH = _PAGES_DIR / "research.astro"
+
+
+def _hrefs(source: str) -> list[str]:
+    """Tutti gli href interni (path assoluti) presenti nel sorgente.
+
+    Cattura sia l'attributo letterale `href="/..."` sia la forma a oggetto dati
+    `href: '/...'` / `href: "/..."` (usata, es., dall'array `guides` dell'hub che
+    poi rende i link via `href={g.href}`).
+    """
+    attr = re.findall(r'href="(/[^"]*)"', source)
+    data = re.findall(r"""href:\s*['"](/[^'"]*)['"]""", source)
+    return attr + data
+
+
+class TestGuideInternalLinks:
+    """Le 3 guide non indicizzate devono ricevere link editoriali dalle pagine forti
+    e nessun link non-slash deve essere introdotto (coerenza con il canonical)."""
+
+    def test_hub_linka_tutte_le_guide_target(self):
+        source = _GUIDES_HUB.read_text(encoding="utf-8")
+        hrefs = _hrefs(source)
+        for guide in _TARGET_GUIDES:
+            assert guide in hrefs, f"Hub guide non linka {guide}"
+
+    def test_homepage_linka_hub_guide(self):
+        hrefs = _hrefs(_HOMEPAGE.read_text(encoding="utf-8"))
+        assert "/guides/" in hrefs, "Homepage non linka l'hub /guides/"
+
+    def test_research_linka_almeno_una_guida_target(self):
+        hrefs = set(_hrefs(_RESEARCH.read_text(encoding="utf-8")))
+        assert hrefs & set(_TARGET_GUIDES), (
+            "La pagina research non linka nessuna guida target"
+        )
+
+    @pytest.mark.parametrize("relpath", _ALL_PAGES)
+    def test_nessun_link_guide_senza_slash(self, relpath: str):
+        # Un link /guides/<slug> senza slash finale invierebbe il segnale di
+        # duplicato che il canonical (slash) corregge → vietato introdurlo.
+        source = (_PAGES_DIR / relpath).read_text(encoding="utf-8")
+        for href in _hrefs(source):
+            path = href.split("#")[0].split("?")[0]
+            if path.startswith("/guides/") and len(path) > len("/guides/"):
+                assert path.endswith("/"), f"{relpath}: link guide senza slash: {href}"
+
+    @pytest.mark.parametrize("relpath", _ALL_PAGES)
+    def test_link_demo_report_con_slash(self, relpath: str):
+        # /report/demo è indicizzabile e canonicalizzato con slash: i link devono
+        # puntare a /report/demo/ per non generare una variante non-slash.
+        source = (_PAGES_DIR / relpath).read_text(encoding="utf-8")
+        for href in _hrefs(source):
+            path = href.split("#")[0].split("?")[0]
+            if path == "/report/demo":
+                pytest.fail(f"{relpath}: link a /report/demo senza slash (usare /report/demo/)")
+
+
+# ── Test SEO del report demo ─────────────────────────────────────────────────────
+class TestDemoReportSeo:
+    """La demo pubblica deve essere indicizzabile con canonical slash; i report con
+    token devono restare noindex."""
+
+    _REPORT_PAGE = _PAGES_DIR / "report" / "[id].astro"
+    pytestmark = pytest.mark.skipif(
+        not (_PAGES_DIR / "report" / "[id].astro").exists(),
+        reason="pagina report/[id].astro assente",
+    )
+
+    def test_demo_e_indicizzabile(self):
+        source = self._REPORT_PAGE.read_text(encoding="utf-8")
+        assert "isDemo ? 'index, follow'" in source, (
+            "La demo deve usare robots 'index, follow'"
+        )
+        assert "'noindex, nofollow'" in source, (
+            "I report con token devono restare 'noindex, nofollow'"
+        )
+
+    def test_demo_canonical_con_slash(self):
+        source = self._REPORT_PAGE.read_text(encoding="utf-8")
+        assert "https://geoready.dev/report/demo/" in source, (
+            "Il canonical della demo deve essere /report/demo/ (con slash)"
+        )
+
+    def test_demo_island_inizializza_con_mock(self):
+        """L'isola del report deve inizializzare lo stato dai dati mock per la demo,
+        così l'HTML statico (SSG) contiene il contenuto del report e non un guscio
+        vuoto: una pagina index,follow senza contenuto crawlabile finirebbe in
+        'Crawled - currently not indexed'."""
+        container = _FRONTEND / "src" / "components" / "report" / "AuditReportContainer.tsx"
+        if not container.exists():
+            pytest.skip("AuditReportContainer.tsx assente")
+        source = container.read_text(encoding="utf-8")
+        # L'initializer di useState deve gestire il ramo demo (non solo useEffect).
+        assert re.search(
+            r"useState<State>\(\s*\(\)\s*=>", source
+        ), "useState della demo deve usare un initializer lazy con i dati mock"
+
+
+# ── Test contenuto crawlabile della demo (build artefatti) ───────────────────────
+_DIST = _FRONTEND / "dist"
+_DEMO_HTML = _DIST / "report" / "demo" / "index.html"
+
+
+@pytest.mark.skipif(
+    not _DEMO_HTML.exists(),
+    reason="build assente (dist/report/demo/index.html) — eseguire `npm run build`",
+)
+class TestDemoBuiltContent:
+    """Se la build è presente, l'HTML statico della demo deve contenere il corpo
+    del report (non lo spinner di loading)."""
+
+    def test_html_demo_contiene_corpo_report(self):
+        html = _DEMO_HTML.read_text(encoding="utf-8")
+        for marker in ("Category Breakdown", "Technical Signals", "Recommendations"):
+            assert marker in html, f"HTML demo senza sezione '{marker}' (shell vuoto?)"
+
+    def test_html_demo_non_e_solo_spinner(self):
+        html = _DEMO_HTML.read_text(encoding="utf-8")
+        assert "Running audit" not in html, (
+            "HTML demo mostra solo lo spinner 'Running audit' — contenuto non server-rendered"
         )


### PR DESCRIPTION
## Problem

Three useful guide pages were in the sitemap but **not indexed** by Google, and the public demo report (`/report/demo`) was **blocked from indexing** despite being a legitimate marketing page. The root causes:

- The 3 guides were reachable mainly via sitemap + the guides hub + one low-authority sibling — **no inbound links from the strong indexed pages** (homepage, research). Their titles/descriptions also exceeded SERP limits.
- `/report/demo` was **double-blocked**: `robots.txt` `Disallow: /report/` *and* a hardcoded `noindex, nofollow` meta applied to every report id. Even unblocking robots alone would not have indexed it.

## GSC triage context

Page Indexing triage (saved internally) found:
- **Page with redirect: 17** — all expected canonical 301s. Not touched.
- **Blocked by robots.txt: 2** — `https://geoready.dev/report/demo` (fixable, public demo) and `https://geoready.dev/api/audit/pdf?url=` (correct, stays blocked).
- **Crawled / Discovered, not indexed: 3** — `/guides/ai-visibility-checklist/`, `/guides/geo-vs-seo/`, `/guides/llms-txt-wordpress/`.
- Core marketing pages already indexed, canonical, trailing-slash aligned.

This PR addresses the demo report and the 3 guides. The 17 redirects and `/api/` blocks are correct and left as-is.

## /report/demo policy decision

**Made indexable.** It renders static `mockAuditReport` (`example.com`, fake scores) — no user data, no token, no PII (`claim_token: null`, `expires_at: null`). It is clearly labeled "Demo Report".

- `robots.txt`: allow `/report/demo` + `/report/demo/`, keep `/report/` and `/api/` disallowed.
- `report/[id].astro`: demo serves `robots: index, follow` + canonical `https://geoready.dev/report/demo/` (trailing slash); all other ids keep `noindex, nofollow`.
- `AuditReportContainer.tsx`: the demo island now initializes from mock data via a lazy `useState` initializer, so the report body is **server-rendered into the static HTML** (Category Breakdown, Technical Signals, Recommendations) instead of a client-only `Running audit…` shell. Without this, an `index, follow` empty shell would land in "Crawled - currently not indexed". *(Caught by adversarial review.)*

## Privacy / crawlability boundary for tokenized reports

The fix is scoped strictly to the `demo` id:

- `/report/<token>` (e.g. `/report/100680ad…`) stays `noindex, nofollow` **and** under `Disallow: /report/`.
- Under Google's longest-match rule, `Allow: /report/demo` does **not** unblock token reports — `demo` is not a prefix of a hash id.
- Token report HTML does **not** server-render report content (still client-loaded), so no private report body is baked into static output.
- `/report/audit/` and `/api/` remain blocked / `noindex`.

## Guide indexation improvements

The 3 guides were already deep, native-English content — the fix is link equity + SERP-fit metadata, not padding:

| Guide | Title | Description |
|-------|-------|-------------|
| ai-visibility-checklist | 88 → 51 chars | → 156 chars |
| geo-vs-seo | 61 → 46 chars | → 159 chars |
| llms-txt-wordpress | 59 (OK) | → 152 chars |

Primary keywords kept; titles remain unique. `sitemap.xml`: added `/report/demo/`; bumped guides hub `lastmod`.

## Internal links added

- **Homepage** → `/guides/` hub (new); demo link fixed to `/report/demo/`.
- **Research page** → editorial deep-links to all 3 target guides.
- Guides hub already linked all 4 guides (unchanged).

## robots.txt before / after

```diff
 User-agent: *
 Allow: /
+Allow: /report/demo
+Allow: /report/demo/
 Disallow: /report/
 Disallow: /api/
```

## Tests run

- `tests/test_frontend_seo.py`: **118 passed** (+66 new: robots crawl policy, guide internal-link + trailing-slash invariants, demo report SEO, server-rendered demo content).
- Backend/web (`test_web_app`, `test_web_history`): **42 passed**.
- `ruff check tests/test_frontend_seo.py`: clean.
- Adversarial SEO review on the diff: 1 real bug found (empty demo shell) → fixed and re-verified; all other checks OK.

## Build result

`npm run build` → **20 pages, clean**. Verified in `dist/`:
- `/report/demo/`: `index, follow` + canonical `/report/demo/` + report body present, spinner gone.
- `/report/<token>/` and `/report/audit/`: stay `noindex, nofollow`, no report body rendered.

## Deploy notes

- Frontend-only (Astro SSG). `dist/` is gitignored and built inside Docker (`Dockerfile.web`) — not committed.
- **No nginx changes, no redirect changes, no app/scoring changes.** Trailing-slash `/report/demo/` is served by the existing `trailingSlash: 'always'` build.
- Standard code-only deploy path (rebuild image + recreate `geo-web` container).

## Post-deploy GSC manual checklist

Do **not** click "validate fix" before deploy. After deploy:

1. Validate "Blocked by robots.txt" for `https://geoready.dev/report/demo` (now unblocked). Leave `/api/audit/pdf` as-is (correctly blocked).
2. Request Indexing: `/report/demo/`, `/guides/ai-visibility-checklist/`, `/guides/geo-vs-seo/`, `/guides/llms-txt-wordpress/`.
3. Resubmit `https://geoready.dev/sitemap.xml`.
4. After ~48h: confirm fresh crawl dates + that the demo renders report content (not just header) in URL Inspection; confirm a token URL still returns "Excluded by robots.txt".
