### PR TITLE
feat(platform): Phase 0 foundation — AI Visibility Platform (entity spine, auth, ownership, audit-as-signal)

### DIFF
--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -1,0 +1,32 @@
+name: platform-ci
+
+# CI for the AI Visibility Platform (platform/). Independent of the OSS engine
+# CI (ci.yml), which remains the source of truth for the geo_optimizer package.
+
+on:
+  push:
+    paths:
+      - "platform/**"
+      - "pyproject.toml"
+      - ".github/workflows/platform-ci.yml"
+  pull_request:
+    paths:
+      - "platform/**"
+      - "pyproject.toml"
+      - ".github/workflows/platform-ci.yml"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install
+        run: pip install -e ".[platform-dev]"
+      - name: Lint
+        run: ruff check platform/geoready_platform
+      - name: Test
+        working-directory: platform
+        run: pytest -q

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,8 @@ local_cache/
 
 # Generated graph analysis output (graphify tool)
 graphify-out/
+
+# Platform (Phase 0) local artifacts
+platform/.env
+*.db
+geoready_platform.db

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,73 +1,306 @@
 # Roadmap
 
-> geo-optimizer-skill follows a deliberate release cadence. We ship in focused waves — each one validated, tested, and stable — rather than pushing frequent incremental patches. Quality over velocity.
+> ⚠️ **Target-vision document.** This roadmap describes where the **AI Visibility Platform** is going, not what exists today. Many modules, services, data models, and integrations referenced below — the entity spine, perception probe, execution connectors, attribution loop — are **aspirational and not yet implemented**. The open-source audit engine (`geo` CLI, core modules, MCP, integrations) is real and shipped; treat everything in the platform sections as planned work pending the Phase 0 execution plan. When in doubt, the codebase is the source of truth for current state; this file is the source of truth for direction.
 
-## Current Direction
-
-The project is entering its next phase of evolution. Focus areas for the upcoming cycle include:
-
-- Deeper structural analysis of how content surfaces in AI-generated responses
-- Expanded signal coverage across emerging retrieval and citation patterns
-- Scoring model refinements informed by ongoing research validation
-- Tighter integration between audit, remediation, and monitoring workflows
-- Continued hardening of the skill system and plugin architecture
-
-Some of these themes will span multiple releases. Specific scope may shift as research findings and community feedback inform priorities.
-
-## Release Calendar
-
-| Version | Window | Codename | Theme | Status |
-|---------|--------|----------|-------|--------|
-| v4.10.0 | Late May / Early Jun 2026 | **Veil** | Signal architecture refinement | Shipped |
-| v4.11.0 | May 2026 (advanced from Jul 2026) | **Static** | Expanded retrieval surface analysis | Shipped — MVP A |
-| v4.12.0 | May 2026 (advanced from Sep 2026) | **Ledger** | Scoring model recalibration | Shipped |
-| v4.13.0 | Jun 2026 | **Echo** | AI citation visibility (`geo citations`) | Shipped |
-| v4.14.0 | Jun 2026 (advanced from Nov 2026) | **Quiet Glass** | Structural pattern recognition (`geo authority`, `geo drift`, multimodal readiness) | Shipped |
-| v4.15.0-rc1 | Jan 2027 | **Threshold** | Pre-release validation cycle | Planned |
-| v4.15.0-rc2 / v4.16.0 | Mar 2027 | **Pale Signal** | Stabilization and edge resolution | Planned |
-| v5.0.0 | May 2027 | **Black Archive** | Next-generation audit framework | Planned |
-
-Release windows are estimates. Dates may shift based on validation outcomes and testing discipline. v4.11.0 and v4.12.0 both advanced ahead of their original windows because their scope was validated and stabilised earlier than planned. v4.13.0 (**Echo**) was inserted ahead of schedule to ship the one-shot AI citation check, and v4.14.0 (**Quiet Glass**) advanced from Nov 2026 once its structural-analysis scope (topic authority, drift, multimodal scaffolding) stabilised early. Later codenames keep their positions.
-
-## Static Cycle — MVP Track
-
-The **Static** codename groups four MVPs covering retrieval-surface visibility. Only MVP A is shipped; the remaining MVPs are sequenced across the v4.11–v4.14 cycle.
-
-| MVP | Scope | Status |
-|-----|-------|--------|
-| **A — Crawler Evidence & Access Simulation** | AI Crawler Activity Analytics (`/api/logs/analyze`, `geo logs`) and Agent Access Audit (`geo access`, browser-vs-bot simulation) | Shipped in v4.11.0 |
-| **B — Semantic Drift Monitoring** | Cross-snapshot drift detection over content and citation-readiness signals | Shipped — `geo drift` (CLI, one-shot) + continuous regression alerts in the GeoReady platform |
-| **C — AI Perception Snapshot** | Enriched simulated-perception extraction from page signals | Planned |
-| **D — WordPress Connector** | First-party connector for WordPress sites and headless setups | Planned |
-
-MVP B–D scope and exact target releases will be confirmed as MVP A adoption signal and validation feedback come in.
-
-## Release Philosophy
-
-Each release is a curated wave, not a deadline. We hold releases until they meet our quality bar:
-
-- Full test coverage for new capabilities
-- No regressions in existing audit checks
-- Security review for any new network-facing surface
-- Documentation updated before the tag is cut
-
-This means some windows may be quiet. That silence is intentional.
-
-## What's Ahead
-
-The v4.10–v4.13 cycle focuses on deepening the analytical foundation. New signal categories, refined scoring weights, and improved detection heuristics are under active research. Not all of this work will be visible in public commits — some validation happens offline before it reaches the codebase.
-
-The v4.14 release candidates mark the transition toward v5.0, which represents a broader architectural evolution. More details will surface as the earlier releases stabilize.
-
-## What This Roadmap Does Not Cover
-
-- Internal module-level implementation plans
-- Exact detector or check lists per release
-- Configuration migration specifics
-- Experimental features under active research
-
-For the skill system roadmap (internal skill catalog evolution), see [docs/skill-roadmap.md](skill-roadmap.md).
+> This roadmap covers two surfaces: the **open-source engine** (`geo` CLI, MCP, integrations) and the **AI Visibility Platform** built on top of it. The open-source engine is the funnel and the credibility layer; the platform is the business. They ship on different cadences and are planned separately below.
 
 ---
 
-*This roadmap reflects current planning as of April 2026. Items may evolve as research and validation continue.*
+## 1. What We Are Building
+
+This is **not** a GEO dashboard, an SEO tool, or a scorecard.
+
+This is an **AI Visibility / AI Recommendation Readiness Platform**. Its purpose is to help businesses become **accurately understood, trusted, cited, and recommended** by AI systems — ChatGPT, Claude, Gemini, Perplexity, and the models that follow.
+
+**The score is not the product. The outcome is the product.** We measure and improve discoverability, recommendation likelihood, citation quality, factual accuracy, and trust — and we prove the business impact.
+
+### The core operating loop
+
+```
+Audit → Explain → Fix → Implement → Verify → Monitor → Prove Business Impact
+```
+
+Two of these stages are where most competitors stop and where we must not: **Implement** (we do the work, not just recommend it) and **Prove Business Impact** (we connect the work to citations, traffic, and revenue). These are mandatory, not optional.
+
+### The one-line strategy
+
+Everyone can build a Score. Almost no one will build the robotic arm (execution) and the proof loop (attribution), and no one can backfill the historical dataset we start accumulating on day one. **We win on execution + proof + compounding data — not on audit depth.**
+
+---
+
+## 2. Non-Negotiable Principles
+
+1. **Lead with perception, not the audit.** The first thing a user sees is *what AI actually says about their business*, never a 100-point score.
+2. **Demote the single-site audit to a signal source.** The 47-method engine is a component that feeds the entity's perception picture — it is not the headline.
+3. **Surface the few issues that move recommendation**, not all 47. Compute everything server-side; show what matters.
+4. **Never claim we can make an AI rank or recommend a business.** We improve the *inputs* AI systems consume and we *measure* what changes. Claims are measured (citation lift) or clearly labeled correlational/attributed (traffic, revenue). Overclaiming causation forfeits the research-authority moat.
+5. **Execution requires verified ownership.** No scheduled crawling or auto-fixing of a domain/profile the org has not proven it controls. This is both an abuse guard and a trust signal.
+6. **Reuse the engine; do not rewrite it.** The platform wraps existing core modules as workers. Rewrites are the enemy of shipping.
+
+---
+
+## 3. The Wedge (How We Get In The Door)
+
+Two entry points, both visceral, both fear/curiosity-driven, both sellable in a 5-minute demo:
+
+- **AI Perception Probe** — show a business exactly what ChatGPT / Perplexity / Gemini say (and get wrong) when a real buyer asks for a recommendation. Free, public, alarming.
+- **Hallucination & Misinformation Defense** — "AI is telling your customers something false about you" (wrong hours, "permanently closed," wrong price, a competitor's product attributed to you). Premium, urgent, high willingness to pay.
+
+The buyer is the **agency first** — they onboard dozens of client entities, market the free Probe to win their own pitches, need a monthly deliverable, and create switching costs and data density. Agencies are the channel *and* the moat, not just a tier.
+
+---
+
+## 4. Platform Roadmap (Phased, Ruthless)
+
+> Phases are sequenced by *value-to-defensibility*, not by feature count. Each phase must be independently demoable and saleable. Dates are directional; gates are firm.
+
+### Phase 0 — Foundation & Entity Spine *(internal, no UI)*
+
+**Goal:** Stand up the platform spine with the **business entity** — not the audit — as the core object.
+
+- Entity-centric data model: `business_entity` is the root; `entity_signal`, `perception`, `intervention`, `impact` hang off it. Audits write *signals onto an entity*.
+- Platform API (extend existing FastAPI `web/app.py`), auth (JWT + org-scoped API keys), Postgres, Redis + Celery worker pool.
+- Wrap `run_full_audit_async()` as a signal-producing worker — **no engine rewrite**.
+- Refactor `core/fixer.py` to emit **structured fix proposals** (no disk writes) — prerequisite for execution.
+- Domain/profile ownership verification (DNS TXT / file) — gates execution, prevents competitor abuse.
+
+**Exit gate:** Create an entity by URL → it accumulates website signals + a baseline. No dashboard yet.
+
+### Phase 1 — The Wedge: Perception Probe + One Real Fix `[MVP]`
+
+**Goal:** A non-technical user sees something alarming in 5 minutes, and we fix one thing automatically. This is the minimum viable *category-defining* product.
+
+1. **AI Perception Probe** — buyer-intent prompt set generated from entity category + geo; multi-engine runner (Perplexity Sonar already integrated; add ChatGPT, Gemini). Capture: mentioned? recommended? what's said? accurate? competitors named? Every probe stored timestamped — **history accrues from day one.**
+2. **Share-of-Model v1** — % of buyer-intent prompts where the entity is recommended vs. competitors.
+3. **Hallucination detection v1** — flag factual conflicts between what AI says and the entity's verified truth (reuse `factual_accuracy.py`, `hallucination_bait.py`).
+4. **Gap-linked diagnosis** — surface only the 3–5 issues plausibly driving the perception gap (reuse engine, suppress the other 42). AI explanation layer (Claude) ties each issue to a perception consequence.
+5. **One-click auto-execution for ONE fix type** — llms.txt + schema/JSON-LD + robots.txt via **one connector** (WordPress plugin *or* JS snippet/edge proxy). Validation gate: every generated fix must pass its own check + parse-validity before being offered.
+6. **Verify by re-probe** — approve once → implement → re-probe → show perception delta + alert.
+7. **Minimal UI (Next.js)** — the home screen is the Probe result, not a gauge. Reuse `ScoreGauge`/`CategoryBreakdown` only to *explain the gap*.
+
+**Exit gate (the demo test):** An agency adds a client by URL, sees "ChatGPT recommends 3 competitors and says you're closed," clicks once, we fix it, and re-probe shows movement. If the demo lands, scale. If you're showing a score, stop and re-frame.
+
+### Phase 2 — Proof v1 + Verification Loop
+
+**Goal:** Make improvement *measured*, not asserted. This is the first half of the proof moat.
+
+- **Measured citation/recommendation lift** (Attribution Stage 1): baseline → re-probe → Share-of-Model and citation-frequency delta over time, across engines. This is measured, not modeled — the strongest honest claim.
+- **Verification workflow** — before/after diff tied to specific interventions; explain when a fix didn't move the needle and why.
+- **Continuous monitoring** — scheduled re-probes (daily/weekly/monthly) on verified entities; alerts on score drop, lost recommendation, new hallucination, bot blocked. *Every alert includes previous value, current value, what changed, and a one-click fix.*
+- **Historical trend analysis** — perception + coherence over time. The retention hook.
+
+**Exit gate:** A user can show "before: recommended in 1/20 prompts, 3 misinformation incidents; after: 8/20, 0 incidents" — measured, dated, repeatable.
+
+### Phase 3 — Agency Workflows + Entity Coherence
+
+**Goal:** Turn the wedge into a defensible recurring business via the agency channel and the hardest-to-copy diagnosis.
+
+- **Multi-entity management, team roles, white-label reports, client portal** (read-only client view).
+- **Proof-of-improvement report** as the monthly deliverable — shareable branded link (`/r/{slug}`), headlined by Share-of-Model trend and citation lift, *not* a score.
+- **Cross-web entity coherence (v1, deliberately scoped)** — reconcile core attributes (name, address, phone, hours, category) across owned + authoritative sources (website, GBP, Wikidata, LinkedIn). Detect conflicts, link them to perception failures, rank by impact × fixability. **Resist premature graph complexity** — start with the handful of attributes that demonstrably drive recommendation; do not build a general knowledge-graph engine yet.
+- **Competitor comparison** — Share-of-Model vs. named competitors for the same buyer prompts.
+- **More connectors / execution surfaces** — GBP fields via API; additional CMS push paths.
+
+**Exit gate:** 10–20 agencies running real client entities, with at least one auto-executed fix per entity and a monthly proof report. KPI: **# of entities under continuous monitoring with ≥1 executed fix** (the moat accruing), not raw MRR.
+
+### Phase 4 — Proof v2: The Bridge to Revenue
+
+**Goal:** Move proof from "AI cites you more" to "AI is sending you customers."
+
+- **AI-referred traffic (Attribution Stage 2)** — detect AI-source visits (referrers, assistant user-agents, UTM); GA4 / Search Console connectors; correlate against intervention dates. Labeled correlational.
+- **Benchmarking (network effect)** — with enough entities, tell any business its percentile for AI recommendation in its category/geo. Only possible with scale; impossible for a new entrant to match.
+- **Deeper coherence** — distributed sources (reviews, directories) via official APIs/partners. *Integrate, don't rebuild Yext/BrightLocal.*
+- **Public API v1 + webhooks** — agency integration surface; CLI becomes an API client.
+
+### Phase 5 — Proof v3 + Enterprise
+
+**Goal:** CFO-grade proof and the brand-risk buyer.
+
+- **CRM & revenue attribution (Attribution Stage 3)** — call-tracking, form/booking, e-commerce; attribute AI-referred conversions to interventions. Always labeled attributed/estimated.
+- **Multi-location / franchise coherence & hallucination defense** — board-level brand-risk product priced to the risk.
+- **Custom rubrics, dedicated crawl workers, SLAs.** SSO *only when an enterprise contract requires it* — not before.
+
+---
+
+## 5. What We Will NOT Build (Initially)
+
+Ruthless cuts. Each of these is a trap that turns a category-defining company into a feature-rich tool.
+
+- **No dashboard-first thinking.** The Probe and execution are the product; charts come after.
+- **No engine rewrite.** Wrap and reuse. The 47-method engine and 1,720 tests stay intact.
+- **No enterprise SSO** until a paying enterprise contract demands it (Phase 5+).
+- **No PDF report factory.** One shareable branded link in Phase 3; defer heavy PDF/format work.
+- **No premature entity-graph complexity.** Phase 3 reconciles a handful of high-impact attributes across a few authoritative sources — not a general knowledge graph.
+- **No new investment in OSS CLI features, the 7 output formats, or SARIF/JUnit.** OSS stays frozen as the free funnel.
+- **No surfacing of all 47 methods in the UI.** Compute server-side; show the few that move recommendation.
+- **No claim that we make AI rank or recommend a business.** Ever.
+- **No scheduled crawling / auto-fixing of unverified domains.**
+- **No building of a reviews/citations/directory product.** Integrate with the incumbents that already own it.
+
+---
+
+## 6. The Moat (How This Stays Defensible)
+
+If Semrush, Ahrefs, or Moz ships an "AI Visibility Score" tomorrow, we still win — because the score was never the moat. Ranked by durability:
+
+| Moat | Why it compounds / can't be copied |
+|------|------------------------------------|
+| **Execution automation** | Measurement companies won't aggressively auto-modify customer sites/profiles — it's off-strategy and a support burden for them. We own the robotic arm. |
+| **Historical entity + perception dataset** | Starts accruing on day one for every entity, including free-tier. Incumbents structurally cannot backfill "how AI's opinion evolved over years." |
+| **Proof-of-improvement (measured → attributed)** | The Stage 1→3 attribution loop makes ROI unarguable. Hard to build, deadly once built. |
+| **Benchmarking / network effect** | Percentile-by-category requires scale; improves with every entity; impossible for a new entrant to match. |
+| **Agency adoption & workflow lock-in** | White-label + client portals + history wired into agency delivery make switching organizational surgery. Agencies are distribution + data density. |
+| **Recommendation / "Share of Model" tracking** | We define and popularize the category metric; when incumbents enter, they play on our field with our terminology. |
+| **Research authority** | Keep publishing (KDD/ICLR-grade). Be the team that *defines* how AI visibility is measured. Incumbent entry validates the category instead of killing it. |
+
+**Not a moat (stop treating these as crown jewels):** the score, the rubric, the UI, "AI-powered fixes" as a phrase. Everyone has Claude's API. Depth of audit loses to distribution.
+
+---
+
+## 7. Pricing Direction (Value, Not Features)
+
+Anchored to the value of *one additional customer acquired through AI*, not to feature count.
+
+- **Free public Probe** — the hook and demand-gen engine. CAC we eat on purpose.
+- **Pro (~$99–199/mo)** — continuous monitoring, alerts, hallucination detection, auto-execution for one entity. Priced to signal "protects my revenue," not "another tool."
+- **Agency (~$500–1,500/mo, tiered by client entities)** — the revenue engine. White-label, bulk execution, client portal, proof reports.
+- **Enterprise / multi-location ($2k–10k+/mo)** — hallucination defense + coherence across many locations as brand-risk insurance.
+
+Principle: the more we *do for them* and the more we *prove*, the further we move from per-seat SaaS toward outcome/managed-service economics — the fattest margins and the worst comparison surface for incumbents.
+
+---
+
+## 8. Open-Source Engine Track (The Funnel)
+
+The OSS engine continues on its quality-over-velocity cadence, but receives **no new feature investment** beyond what keeps it credible and current:
+
+- **Maintain:** the 27-bot database (new AI models launch monthly — staleness makes the audit wrong), security hardening, scoring accuracy.
+- **Keep frozen as funnel:** CLI, MCP server, Astro integration, GitHub Action.
+- The OSS tool's job is developer-led top-of-funnel and research credibility, not revenue.
+
+(Prior CLI release calendar — Veil through Black Archive — is retained for continuity in the changelog; new energy goes to the platform.)
+
+---
+
+## 9. The Three Things That Decide Everything
+
+1. **Ship execution before incumbents commoditize the score.** Speed on the *unglamorous* parts (execution, attribution) is the whole game.
+2. **Start accumulating perception history now**, for every entity, free or paid. The dataset is the only moat that grows while you sleep.
+3. **Win agencies, not businesses.** They are customer, channel, and data-density engine at once.
+
+---
+
+*This roadmap supersedes the prior CLI-centric direction. It reflects strategy as of June 2026. Phases are sequenced by defensibility; dates are directional and gates are firm. The score is not the product — the outcome is.*
+
+---
+
+## Appendix A — Phase 0 Execution Plan (Implementation Checklist)
+
+> This is a build checklist, not strategy. It defines the exact folders, modules, services, data models, APIs, and infrastructure to stand up **before** any feature work, in dependency order. The governing constraint: **wrap and reuse the existing audit engine — do not rewrite it.** Phase 0 is "done" when an entity can be created by URL, its ownership verified, an audit run as a background job, and the results stored as signals on that entity — with zero UI.
+
+### Guiding rules for Phase 0
+
+- The existing Python package `src/geo_optimizer/` is **frozen** except for the two surgical refactors listed in Step 4. No changes to `core/audit*.py`, `core/scoring.py`, `models/results.py`, `utils/`, or `tests/`.
+- Everything new lives under a **new top-level `platform/` tree**, isolated from the OSS package so the CLI/PyPI build stays clean.
+- Reuse `utils/http.py`, `utils/validators.py`, `utils/robots_parser.py` as-is for all crawling — do not write new HTTP code.
+- No feature work (probe, fixes, dashboard) until every box below is checked.
+
+### Step 0 — Repo & environment scaffolding *(no app logic)*
+
+- [ ] Create `platform/` top-level tree:
+  ```
+  platform/
+    api/            # FastAPI app (the platform API; separate from src/.../web)
+    workers/        # Celery tasks (audit/signal workers)
+    db/             # SQLAlchemy models + Alembic migrations
+    services/       # business logic (entities, ownership, audits-as-signals)
+    schemas/        # Pydantic request/response models
+    core_bridge/    # thin adapters that call src/geo_optimizer (no rewrite)
+    tests/          # platform tests (separate from OSS tests/)
+  ```
+- [ ] Add `platform/` deps to a separate dependency group (`pyproject.toml` `[project.optional-dependencies] platform`) — do **not** pollute core install. Pins: FastAPI, Uvicorn, SQLAlchemy 2.x, Alembic, Pydantic v2, Celery, redis, psycopg, python-jose (JWT), httpx (already a dep).
+- [ ] `docker-compose.yml` for local dev: Postgres 16, Redis 7, API, one Celery worker. Reuse existing `Dockerfile` patterns.
+- [ ] `.env.example` for platform config (DB URL, Redis URL, JWT secret, AI provider keys — keys unused until later phases but slotted now).
+
+### Step 1 — Database & the entity spine *(the foundation everything hangs off)*
+
+- [ ] Alembic baseline migration. Tables, minimal but final-shaped:
+  - `orgs (id, name, plan, created_at)`
+  - `users (id, email, name, created_at)` + `org_members (org_id, user_id, role)`
+  - `business_entity (id, org_id, canonical_name, category, geo, website_url, verified_at, created_at, archived_at)`
+  - `entity_signal (id, entity_id, source, signal_type, value_jsonb, ai_reachable, fetched_at)` — the audit writes rows here
+  - `audit_jobs (id, entity_id, org_id, status, triggered_by, score, score_breakdown_jsonb, full_result_jsonb, started_at, completed_at, error, created_at)`
+  - **Stub-only (create empty, no logic yet):** `perception`, `intervention`, `impact` — shape them now to avoid future migrations, populate in later phases.
+- [ ] Enforce `org_id` on every tenant table; add `(entity_id, created_at)` and `(org_id, status)` indexes on `audit_jobs`.
+- [ ] Enable PostgreSQL **row-level security** scaffolding (policies keyed on `org_id`) — even if app-level checks come first, wire RLS now.
+
+### Step 2 — Auth & tenancy *(gate before any endpoint does work)*
+
+- [ ] JWT session auth + **org-scoped API keys** (store hashed; never retrievable). Choose managed (Supabase Auth) or self-hosted `python-jose` — pick one, document it, move on.
+- [ ] Middleware that resolves `org_id` from token/key on every request and injects it into the DB session (drives RLS).
+- [ ] Roles enum: `owner | admin | editor | viewer` (client/agency roles deferred to Phase 3).
+- [ ] Per-key rate limiting (Redis token bucket) — Free tier quota enforced here.
+
+### Step 3 — Domain ownership verification *(hard prerequisite for execution & monitoring)*
+
+- [ ] `services/ownership.py`: issue a verification token per entity; verify via **DNS TXT record** or **/.well-known file**.
+- [ ] `business_entity.verified_at` set only on success. **No background crawl or auto-fix may run on an unverified entity** — assert this in the worker, not just the UI.
+- [ ] Reuse `utils/validators.py` for all URL/IP safety (anti-SSRF) — no new validation code.
+
+### Step 4 — Two surgical engine refactors *(the ONLY changes to `src/geo_optimizer/`)*
+
+- [ ] **Refactor `core/fixer.py`** to return structured `FixProposal` objects (content + instructions + target check) instead of writing files to disk. Preserve the existing file-writing path behind a flag so the CLI keeps working. Add tests in OSS `tests/`.
+- [ ] **Make `core/scoring.py` purely re-scorable** if not already — `score(result) -> breakdown`, no side effects — so historical `full_result_jsonb` can be re-scored when the rubric changes. Likely a no-op verification; confirm and document.
+- [ ] Everything else in `src/geo_optimizer/` stays untouched.
+
+### Step 5 — Core bridge & audit-as-signal worker *(wrap, don't rewrite)*
+
+- [ ] `core_bridge/audit_adapter.py`: thin async function that calls existing `run_full_audit_async(url)`, serializes `AuditResult` (from `models/results.py`) to JSON-safe dict, and maps category outputs → `entity_signal` rows.
+- [ ] `workers/audit_task.py` (Celery): consume `{audit_job_id}`, set status `running`, call the adapter, write `audit_jobs.full_result_jsonb` + `score` + `score_breakdown_jsonb` + `entity_signal` rows, set status `complete`/`failed`. Enforce: ownership-verified, 60s hard timeout, bounded HTTP fetches (reuse engine limits).
+- [ ] Redis as broker + result backend. One worker in compose; concurrency bounded (I/O-bound, ~10–20 async audits/worker).
+
+### Step 6 — Platform API (minimal surface) *(no UI; verifiable via curl/tests)*
+
+- [ ] `api/main.py` FastAPI app, mounted separately from `src/.../web/app.py`.
+- [ ] Endpoints (Phase 0 scope only):
+  ```
+  POST   /v1/orgs                         create org
+  POST   /v1/entities                     create entity (url, name, category, geo)
+  POST   /v1/entities/{id}/verify         start/confirm ownership verification
+  POST   /v1/entities/{id}/audits         enqueue audit  -> returns audit_job_id
+  GET    /v1/audits/{job_id}              poll status + result
+  GET    /v1/entities/{id}/signals        list signals for entity
+  GET    /healthz                         liveness/readiness
+  ```
+- [ ] Pydantic schemas in `platform/schemas/`. OpenAPI auto-doc on.
+- [ ] All endpoints org-scoped and ownership-aware; audit enqueue refuses unverified entities.
+
+### Step 7 — Observability & safety floor *(non-negotiable before real users)*
+
+- [ ] Structured logging (request id, org id, entity id) — never log API keys or raw crawled HTML.
+- [ ] Sentry (or equivalent) on API + workers.
+- [ ] Worker dead-letter handling: failed jobs land in `audit_jobs.error`, not silent loss.
+- [ ] Basic CI for `platform/`: lint (ruff, reuse config) + `platform/tests/` on PR. Keep OSS CI untouched.
+- [ ] Data hygiene: confirm no raw HTML persisted (only derived signals/results); deletion of an entity cascades to its signals + audit_jobs.
+
+### Phase 0 Definition of Done (exit gate)
+
+All true, verifiable without a UI:
+
+1. `docker-compose up` brings up API + worker + Postgres + Redis.
+2. Create org → create entity → verify ownership (DNS or file) → `verified_at` set.
+3. `POST /v1/entities/{id}/audits` on a verified entity enqueues a job; the **existing engine** runs unchanged inside the worker.
+4. Result is stored as `audit_jobs.full_result_jsonb` + score + `entity_signal` rows; `GET /v1/audits/{job_id}` returns it.
+5. Unverified entity → audit enqueue is **refused**.
+6. Tenant isolation holds: org A cannot read org B's entities/audits (RLS + app check).
+7. OSS CLI, MCP, and `tests/` are **green and unchanged** (the freeze held).
+
+### Explicitly OUT of Phase 0 (do not build yet)
+
+- ❌ Any dashboard / Next.js UI — Phase 1.
+- ❌ AI Perception Probe, Share-of-Model, hallucination detection — Phase 1.
+- ❌ AI-generated fixes or one-click execution — Phase 1 (the `FixProposal` *shape* exists; the engine that fills it does not).
+- ❌ `perception` / `intervention` / `impact` table logic — stub schema only.
+- ❌ Monitoring scheduler, alerts, attribution, connectors, white-label, billing — later phases.
+
+**The Phase 0 trap to avoid:** building anything a user can *see* before the entity spine + ownership + audit-as-signal worker are solid. Phase 0 produces no demo. That is correct. The demo is Phase 1, and it is only possible — and only safe — on top of a spine that already isolates tenants, verifies ownership, and reuses the engine without forking it.

--- a/platform/.env.example
+++ b/platform/.env.example
@@ -1,0 +1,30 @@
+# GeoReady Platform — environment configuration (Phase 0)
+# Copy to .env and adjust. NEVER commit real secrets.
+
+# ── Database ──────────────────────────────────────────────────────────────────
+# Local dev defaults to SQLite. Production uses Postgres:
+#   GR_DATABASE_URL=postgresql+psycopg://geoready:geoready@localhost:5432/geoready
+GR_DATABASE_URL=sqlite:///./geoready_platform.db
+
+# ── Cache / Celery broker ─────────────────────────────────────────────────────
+GR_REDIS_URL=redis://localhost:6379/0
+
+# ── Auth ──────────────────────────────────────────────────────────────────────
+# MUST be set to a strong random value in production.
+GR_JWT_SECRET=dev-insecure-change-me
+GR_JWT_ALG=HS256
+GR_JWT_TTL_SECONDS=3600
+
+# ── Worker execution ──────────────────────────────────────────────────────────
+# true  -> Celery runs tasks inline (no broker needed; dev/test/single-process)
+# false -> real workers consume from Redis (production)
+GR_CELERY_EAGER=false
+GR_AUDIT_TIMEOUT_SECONDS=60
+
+# ── Quotas ────────────────────────────────────────────────────────────────────
+GR_FREE_AUDITS_PER_DAY=5
+
+# ── AI provider keys (slotted now, unused until later phases) ──────────────────
+OPENAI_API_KEY=
+ANTHROPIC_API_KEY=
+PERPLEXITY_API_KEY=

--- a/platform/README.md
+++ b/platform/README.md
@@ -1,0 +1,98 @@
+# GeoReady AI Visibility Platform — Phase 0 Foundation
+
+This directory is the commercial **AI Visibility Platform**. It is intentionally
+isolated from the open-source `geo_optimizer` engine (`../src`): the platform
+**wraps and reuses** the engine via `geoready_platform/core_bridge/` and never
+modifies it.
+
+> ⚠️ Phase 0 only. This is the foundation (entity spine, auth, ownership, the
+> audit-as-signal worker, and a minimal API). There is **no UI, no perception
+> probe, no AI fixes, and no attribution** yet — those are later phases. See
+> [`../docs/ROADMAP.md`](../docs/ROADMAP.md), Appendix A.
+
+## Why `geoready_platform/` and not `platform/`
+
+Python's standard library owns the `platform` module. Naming our importable
+package `platform` would shadow it and break dependencies that `import platform`.
+The roadmap's `platform/` **directory** is preserved as the container; the
+importable package is `geoready_platform`, and `platform/` is placed on
+`sys.path` (see `pytest.ini` and `docker-compose.yml`).
+
+## Architecture (dependency order)
+
+```
+config.py            env-driven settings (SQLite default; Postgres in prod)
+db/base.py           SQLAlchemy engine, session, Base
+db/models.py         entity spine: Org/User/ApiKey, BusinessEntity,
+                     EntitySignal, AuditJob  (+ stub: Perception/Intervention/Impact)
+services/auth.py     PBKDF2 hashing, API keys, JWT
+services/ownership   DNS-TXT / well-known-file domain verification
+services/entities    org-scoped entity CRUD + verification
+services/audits      enqueue (ownership + quota gated) + execute_audit_job
+core_bridge/         the ONLY code that touches the engine (audit + fix adapters)
+workers/             Celery app + audit task (delegates to services.audits)
+api/                 FastAPI app, deps (auth/org scoping), routers
+alembic/             migrations (baseline creates tables; Postgres RLS policies)
+```
+
+## Operating loop (target)
+
+`Audit → Explain → Fix → Implement → Verify → Monitor → Prove Business Impact`
+
+Phase 0 implements only the **Audit** stage as a queued, ownership-gated,
+tenant-isolated job that writes results as *signals on an entity*.
+
+## Local development
+
+```bash
+# from repo root
+pip install -e ".[platform,async]"
+
+# run migrations (SQLite by default)
+cd platform && alembic upgrade head
+
+# API
+uvicorn geoready_platform.api.main:app --reload   # http://localhost:8000/docs
+
+# real workers (otherwise set GR_CELERY_EAGER=true to run inline)
+celery -A geoready_platform.workers.celery_app worker --loglevel=info
+```
+
+Or the full stack (Postgres + Redis + API + worker):
+
+```bash
+cd platform && docker compose up
+```
+
+## Tests
+
+```bash
+pip install -e ".[platform-dev]"
+cd platform && pytest
+```
+
+Tests run on a throwaway SQLite DB with Celery in eager mode and the engine
+stubbed at the bridge boundary — **no network access**. The OSS engine test
+suite under `../tests` is untouched and runs independently.
+
+## Phase 0 endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET`  | `/healthz` | liveness + DB check |
+| `POST` | `/v1/orgs` | create org; returns API key **once** |
+| `POST` | `/v1/entities` | create entity |
+| `GET`  | `/v1/entities` | list org entities |
+| `GET`  | `/v1/entities/{id}` | get entity |
+| `POST` | `/v1/entities/{id}/verify` | start ownership verification |
+| `POST` | `/v1/entities/{id}/verify/confirm` | confirm ownership |
+| `POST` | `/v1/entities/{id}/audits` | enqueue audit (verified only) |
+| `GET`  | `/v1/audits/{job_id}` | poll audit status/result |
+| `GET`  | `/v1/entities/{id}/signals` | list entity signals |
+
+## Hard rules (do not violate)
+
+- The engine (`../src/geo_optimizer`) is frozen; touch it only via `core_bridge`.
+- No crawl/audit on an entity whose ownership is not verified.
+- Every tenant query is scoped by `org_id` (app layer) and RLS (Postgres).
+- Never log API keys or raw crawled HTML; only derived signals are persisted.

--- a/platform/alembic.ini
+++ b/platform/alembic.ini
@@ -1,0 +1,42 @@
+# Alembic config for the GeoReady platform.
+# The DB URL is injected at runtime from GR_DATABASE_URL (see alembic/env.py),
+# so the sqlalchemy.url below is only a placeholder.
+
+[alembic]
+script_location = %(here)s/alembic
+prepend_sys_path = .
+sqlalchemy.url = sqlite:///./geoready_platform.db
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARNING
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARNING
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/platform/alembic/env.py
+++ b/platform/alembic/env.py
@@ -1,0 +1,60 @@
+"""Alembic environment.
+
+The DB URL comes from ``GR_DATABASE_URL`` (via platform Settings) so migrations
+target the same database as the app. ``target_metadata`` is the platform Base
+metadata, enabling autogenerate for future migrations.
+"""
+
+from __future__ import annotations
+
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+from geoready_platform.config import get_settings
+from geoready_platform.db.base import Base
+
+# Import models so they register on Base.metadata.
+from geoready_platform.db import models  # noqa: F401
+
+config = context.config
+config.set_main_option("sqlalchemy.url", get_settings().database_url)
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    context.configure(
+        url=get_settings().database_url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        render_as_batch=True,
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            render_as_batch=True,
+        )
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/platform/alembic/script.py.mako
+++ b/platform/alembic/script.py.mako
@@ -1,0 +1,24 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/platform/alembic/versions/0001_baseline.py
+++ b/platform/alembic/versions/0001_baseline.py
@@ -1,0 +1,60 @@
+"""Baseline schema: entity spine + tenancy + stub tables, with Postgres RLS.
+
+The baseline creates all tables from the platform model metadata (the single
+source of truth) rather than hand-maintaining create_table blocks. Subsequent
+migrations should use proper autogenerate diffs.
+
+On PostgreSQL it additionally enables row-level security on tenant-scoped tables
+with org-scoped policies keyed on the ``app.current_org`` session setting. This
+is defense-in-depth behind the application-layer org scoping; in production the
+app should connect as a non-owner role and ``SET app.current_org`` per request.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+from geoready_platform.db.base import Base
+
+# Import models so metadata is populated.
+from geoready_platform.db import models  # noqa: F401
+
+revision = "0001_baseline"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+_TENANT_TABLES = (
+    "business_entity",
+    "entity_signal",
+    "audit_jobs",
+    "org_members",
+    "api_keys",
+    "perception",
+    "intervention",
+    "impact",
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    Base.metadata.create_all(bind=bind)
+
+    if bind.dialect.name == "postgresql":
+        for table in _TENANT_TABLES:
+            op.execute(f"ALTER TABLE {table} ENABLE ROW LEVEL SECURITY")
+            op.execute(
+                f"""
+                CREATE POLICY {table}_org_isolation ON {table}
+                USING (org_id = current_setting('app.current_org', true))
+                """
+            )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        for table in _TENANT_TABLES:
+            op.execute(f"DROP POLICY IF EXISTS {table}_org_isolation ON {table}")
+            op.execute(f"ALTER TABLE {table} DISABLE ROW LEVEL SECURITY")
+    Base.metadata.drop_all(bind=bind)

--- a/platform/docker-compose.yml
+++ b/platform/docker-compose.yml
@@ -1,0 +1,75 @@
+# Local development stack for the GeoReady platform (Phase 0).
+#   docker compose up
+# Brings up Postgres, Redis, the API, and one Celery worker. The API and worker
+# images install the engine + platform extras and mount the repo for live dev.
+
+services:
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: geoready
+      POSTGRES_PASSWORD: geoready
+      POSTGRES_DB: geoready
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U geoready"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  api:
+    image: python:3.11-slim
+    working_dir: /repo
+    command: >
+      bash -c "pip install -e '.[platform,async]' &&
+               cd platform && alembic upgrade head &&
+               uvicorn geoready_platform.api.main:app --host 0.0.0.0 --port 8000"
+    environment:
+      GR_DATABASE_URL: postgresql+psycopg://geoready:geoready@postgres:5432/geoready
+      GR_REDIS_URL: redis://redis:6379/0
+      GR_JWT_SECRET: dev-insecure-change-me
+      GR_CELERY_EAGER: "false"
+    volumes:
+      - ..:/repo
+    ports:
+      - "8000:8000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
+  worker:
+    image: python:3.11-slim
+    working_dir: /repo
+    command: >
+      bash -c "pip install -e '.[platform,async]' &&
+               celery -A geoready_platform.workers.celery_app worker --loglevel=info"
+    environment:
+      GR_DATABASE_URL: postgresql+psycopg://geoready:geoready@postgres:5432/geoready
+      GR_REDIS_URL: redis://redis:6379/0
+      GR_JWT_SECRET: dev-insecure-change-me
+      GR_CELERY_EAGER: "false"
+    volumes:
+      - ..:/repo
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
+volumes:
+  pgdata:

--- a/platform/geoready_platform/__init__.py
+++ b/platform/geoready_platform/__init__.py
@@ -1,0 +1,20 @@
+"""GeoReady AI Visibility Platform.
+
+Phase 0 foundation. This package is intentionally isolated from the
+open-source ``geo_optimizer`` engine: it *wraps and reuses* the engine via
+``geoready_platform.core_bridge`` and never modifies it.
+
+NOTE ON NAMING: the importable package is ``geoready_platform`` (not
+``platform``) because Python's standard library already owns the ``platform``
+module — shadowing it would break dependencies that ``import platform``.
+The roadmap's ``platform/`` directory is preserved as the container; this
+package lives inside it and ``platform/`` is placed on ``sys.path``.
+
+See ``docs/ROADMAP.md`` (Appendix A — Phase 0 Execution Plan) for scope.
+"""
+
+from __future__ import annotations
+
+__all__ = ["__version__"]
+
+__version__ = "0.0.0"  # platform is pre-MVP (Phase 0 foundation only)

--- a/platform/geoready_platform/api/__init__.py
+++ b/platform/geoready_platform/api/__init__.py
@@ -1,0 +1,1 @@
+"""Platform HTTP API (FastAPI). Mounted separately from the OSS web demo."""

--- a/platform/geoready_platform/api/deps.py
+++ b/platform/geoready_platform/api/deps.py
@@ -1,0 +1,96 @@
+"""FastAPI dependencies: DB session, authenticated principal, org scoping.
+
+Two auth schemes are accepted:
+- ``Authorization: Bearer <jwt>``  (interactive sessions)
+- ``X-API-Key: gr_...``            (programmatic / CLI)
+
+Both resolve to a :class:`Principal` carrying ``org_id`` — every downstream
+service call is scoped by it, which is the application-layer half of tenant
+isolation (the other half being Postgres RLS).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+import jwt
+from fastapi import Depends, Header, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from geoready_platform.db.base import get_sessionmaker
+from geoready_platform.db.models import ApiKey
+from geoready_platform.services.auth import decode_access_token, verify_secret
+
+
+@dataclass
+class Principal:
+    org_id: str
+    user_id: str | None
+    role: str
+    auth_type: str  # "jwt" | "api_key"
+
+
+def get_db() -> Iterator[Session]:
+    session = get_sessionmaker()()
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
+def _principal_from_jwt(token: str) -> Principal:
+    try:
+        payload = decode_access_token(token)
+    except jwt.PyJWTError as exc:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, f"Invalid token: {exc}") from exc
+    org_id = payload.get("org_id")
+    if not org_id:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Token missing org_id")
+    return Principal(org_id=org_id, user_id=payload.get("sub"), role=payload.get("role", "viewer"), auth_type="jwt")
+
+
+def _principal_from_api_key(session: Session, api_key: str) -> Principal:
+    prefix = api_key[:12]
+    rows = session.execute(select(ApiKey).where(ApiKey.prefix == prefix, ApiKey.revoked_at.is_(None))).scalars().all()
+    for row in rows:
+        if verify_secret(api_key, row.key_hash):
+            return Principal(org_id=row.org_id, user_id=None, role="editor", auth_type="api_key")
+    raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Invalid API key")
+
+
+def get_principal(
+    session: Session = Depends(get_db),
+    authorization: str | None = Header(default=None),
+    x_api_key: str | None = Header(default=None),
+) -> Principal:
+    if x_api_key:
+        return _principal_from_api_key(session, x_api_key)
+    if authorization and authorization.lower().startswith("bearer "):
+        return _principal_from_jwt(authorization.split(" ", 1)[1].strip())
+    raise HTTPException(
+        status.HTTP_401_UNAUTHORIZED,
+        "Missing credentials (provide 'Authorization: Bearer <jwt>' or 'X-API-Key')",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+
+
+def require_role(*allowed: str):
+    """Dependency factory enforcing a minimum role set."""
+
+    def _checker(principal: Principal = Depends(get_principal)) -> Principal:
+        if principal.role not in allowed:
+            raise HTTPException(status.HTTP_403_FORBIDDEN, f"Requires role in {allowed}")
+        return principal
+
+    return _checker
+
+
+def utcnow() -> datetime:
+    return datetime.now(timezone.utc)

--- a/platform/geoready_platform/api/main.py
+++ b/platform/geoready_platform/api/main.py
@@ -1,0 +1,36 @@
+"""FastAPI application factory for the platform API.
+
+Mounted independently from the OSS ``geo_optimizer.web`` demo. Structured
+logging is configured with request/org/entity context; raw crawled HTML and
+credentials are never logged.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import FastAPI
+
+from geoready_platform import __version__
+from geoready_platform.api.routers import audits, entities, health, orgs
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s %(message)s",
+)
+
+
+def create_app() -> FastAPI:
+    app = FastAPI(
+        title="GeoReady AI Visibility Platform API",
+        version=__version__,
+        description="Phase 0 foundation: orgs, entities, ownership verification, audit-as-signal jobs.",
+    )
+    app.include_router(health.router)
+    app.include_router(orgs.router)
+    app.include_router(entities.router)
+    app.include_router(audits.router)
+    return app
+
+
+app = create_app()

--- a/platform/geoready_platform/api/routers/__init__.py
+++ b/platform/geoready_platform/api/routers/__init__.py
@@ -1,0 +1,1 @@
+"""API routers."""

--- a/platform/geoready_platform/api/routers/audits.py
+++ b/platform/geoready_platform/api/routers/audits.py
@@ -1,0 +1,25 @@
+"""Audit polling endpoint."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from geoready_platform.api.deps import Principal, get_db, get_principal
+from geoready_platform.schemas.models import AuditOut
+from geoready_platform.services import audits as audit_svc
+
+router = APIRouter(prefix="/v1/audits", tags=["audits"])
+
+
+@router.get("/{job_id}", response_model=AuditOut)
+def get_audit(
+    job_id: str,
+    session: Session = Depends(get_db),
+    principal: Principal = Depends(get_principal),
+) -> AuditOut:
+    try:
+        job = audit_svc.get_audit(session, org_id=principal.org_id, job_id=job_id)
+    except audit_svc.AuditJobNotFoundError:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Audit job not found") from None
+    return AuditOut.model_validate(job)

--- a/platform/geoready_platform/api/routers/entities.py
+++ b/platform/geoready_platform/api/routers/entities.py
@@ -1,0 +1,142 @@
+"""Entity CRUD (minimal), ownership verification, audit enqueue, signals."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from geoready_platform.api.deps import Principal, get_db, get_principal
+from geoready_platform.db.models import EntitySignal
+from geoready_platform.schemas.models import (
+    AuditEnqueuedOut,
+    EntityCreate,
+    EntityOut,
+    SignalOut,
+    VerifyConfirmOut,
+    VerifyStart,
+    VerifyStartOut,
+)
+from geoready_platform.services import audits as audit_svc
+from geoready_platform.services import entities as entity_svc
+from geoready_platform.services.ownership import DNS_RECORD_PREFIX, TOKEN_PREFIX, WELL_KNOWN_PATH
+
+router = APIRouter(prefix="/v1/entities", tags=["entities"])
+
+
+@router.post("", response_model=EntityOut, status_code=201)
+def create_entity(
+    body: EntityCreate,
+    session: Session = Depends(get_db),
+    principal: Principal = Depends(get_principal),
+) -> EntityOut:
+    entity = entity_svc.create_entity(
+        session,
+        org_id=principal.org_id,
+        canonical_name=body.canonical_name,
+        website_url=body.website_url,
+        category=body.category,
+        geo=body.geo,
+    )
+    return EntityOut.model_validate(entity)
+
+
+@router.get("", response_model=list[EntityOut])
+def list_entities(
+    session: Session = Depends(get_db),
+    principal: Principal = Depends(get_principal),
+) -> list[EntityOut]:
+    return [EntityOut.model_validate(e) for e in entity_svc.list_entities(session, org_id=principal.org_id)]
+
+
+@router.get("/{entity_id}", response_model=EntityOut)
+def get_entity(
+    entity_id: str,
+    session: Session = Depends(get_db),
+    principal: Principal = Depends(get_principal),
+) -> EntityOut:
+    try:
+        entity = entity_svc.get_entity(session, org_id=principal.org_id, entity_id=entity_id)
+    except entity_svc.EntityNotFoundError:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Entity not found") from None
+    return EntityOut.model_validate(entity)
+
+
+@router.post("/{entity_id}/verify", response_model=VerifyStartOut)
+def start_verification(
+    entity_id: str,
+    body: VerifyStart,
+    session: Session = Depends(get_db),
+    principal: Principal = Depends(get_principal),
+) -> VerifyStartOut:
+    try:
+        entity = entity_svc.start_verification(
+            session, org_id=principal.org_id, entity_id=entity_id, method=body.method
+        )
+    except entity_svc.EntityNotFoundError:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Entity not found") from None
+    except entity_svc.OwnershipVerificationError as exc:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, str(exc)) from None
+
+    token = entity.verification_token or ""
+    if body.method == "dns":
+        instructions = f"Create a TXT record at '{DNS_RECORD_PREFIX}.<your-domain>' with value '{TOKEN_PREFIX}{token}'."
+    else:
+        instructions = f"Publish '{token}' at 'https://<your-domain>{WELL_KNOWN_PATH}'."
+    return VerifyStartOut(method=body.method, token=token, instructions=instructions)
+
+
+@router.post("/{entity_id}/verify/confirm", response_model=VerifyConfirmOut)
+def confirm_verification(
+    entity_id: str,
+    session: Session = Depends(get_db),
+    principal: Principal = Depends(get_principal),
+) -> VerifyConfirmOut:
+    try:
+        entity = entity_svc.confirm_verification(session, org_id=principal.org_id, entity_id=entity_id)
+    except entity_svc.EntityNotFoundError:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Entity not found") from None
+    except entity_svc.OwnershipVerificationError as exc:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, str(exc)) from None
+    return VerifyConfirmOut(verified=entity.is_verified, verified_at=entity.verified_at)
+
+
+@router.post("/{entity_id}/audits", response_model=AuditEnqueuedOut, status_code=202)
+def enqueue_audit(
+    entity_id: str,
+    session: Session = Depends(get_db),
+    principal: Principal = Depends(get_principal),
+) -> AuditEnqueuedOut:
+    try:
+        job = audit_svc.enqueue_audit(session, org_id=principal.org_id, entity_id=entity_id)
+    except entity_svc.EntityNotFoundError:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Entity not found") from None
+    except audit_svc.EntityNotVerifiedError as exc:
+        raise HTTPException(status.HTTP_403_FORBIDDEN, str(exc)) from None
+    except audit_svc.QuotaExceededError as exc:
+        raise HTTPException(status.HTTP_429_TOO_MANY_REQUESTS, str(exc)) from None
+    return AuditEnqueuedOut(audit_job_id=job.id, status=job.status)
+
+
+@router.get("/{entity_id}/signals", response_model=list[SignalOut])
+def list_signals(
+    entity_id: str,
+    session: Session = Depends(get_db),
+    principal: Principal = Depends(get_principal),
+) -> list[SignalOut]:
+    # Ensure the entity belongs to the caller's org before returning signals.
+    try:
+        entity_svc.get_entity(session, org_id=principal.org_id, entity_id=entity_id)
+    except entity_svc.EntityNotFoundError:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Entity not found") from None
+
+    rows = (
+        session.execute(
+            select(EntitySignal)
+            .where(EntitySignal.entity_id == entity_id, EntitySignal.org_id == principal.org_id)
+            .order_by(EntitySignal.fetched_at.desc())
+        )
+        .scalars()
+        .all()
+    )
+    return [SignalOut.model_validate(r) for r in rows]

--- a/platform/geoready_platform/api/routers/health.py
+++ b/platform/geoready_platform/api/routers/health.py
@@ -1,0 +1,21 @@
+"""Liveness / readiness."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from geoready_platform.api.deps import get_db
+
+router = APIRouter(tags=["health"])
+
+
+@router.get("/healthz")
+def healthz(session: Session = Depends(get_db)) -> dict:
+    db_ok = True
+    try:
+        session.execute(text("SELECT 1"))
+    except Exception:  # noqa: BLE001
+        db_ok = False
+    return {"status": "ok" if db_ok else "degraded", "db": db_ok}

--- a/platform/geoready_platform/api/routers/orgs.py
+++ b/platform/geoready_platform/api/routers/orgs.py
@@ -1,0 +1,35 @@
+"""Org provisioning. Creating an org bootstraps an owner user + an API key.
+
+The API key is returned exactly once in the response and never again.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from geoready_platform.api.deps import get_db
+from geoready_platform.db.models import ApiKey, Org, OrgMember, Role, User
+from geoready_platform.schemas.models import OrgCreate, OrgCreated, OrgOut
+from geoready_platform.services.auth import generate_api_key
+
+router = APIRouter(prefix="/v1/orgs", tags=["orgs"])
+
+
+@router.post("", response_model=OrgCreated, status_code=201)
+def create_org(body: OrgCreate, session: Session = Depends(get_db)) -> OrgCreated:
+    org = Org(name=body.name)
+    session.add(org)
+    session.flush()
+
+    user = User(email=body.owner_email, name=body.owner_name)
+    session.add(user)
+    session.flush()
+
+    session.add(OrgMember(org_id=org.id, user_id=user.id, role=Role.owner.value))
+
+    full_key, prefix, key_hash = generate_api_key()
+    session.add(ApiKey(org_id=org.id, name="default", prefix=prefix, key_hash=key_hash))
+    session.flush()
+
+    return OrgCreated(org=OrgOut.model_validate(org), api_key=full_key)

--- a/platform/geoready_platform/config.py
+++ b/platform/geoready_platform/config.py
@@ -1,0 +1,67 @@
+"""Platform configuration loaded from environment variables.
+
+Deliberately dependency-light: a plain settings object backed by ``os.environ``
+with sane local-dev defaults. No secrets are hard-coded; production must supply
+``GR_JWT_SECRET`` and a real ``GR_DATABASE_URL``.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from functools import lru_cache
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+@dataclass(frozen=True)
+class Settings:
+    """Runtime configuration for the platform API and workers."""
+
+    # ─── Database ────────────────────────────────────────────────────────────
+    # Default to a local SQLite file so the foundation is runnable and testable
+    # without Postgres. Production sets GR_DATABASE_URL to a postgres+psycopg URL.
+    database_url: str = field(
+        default_factory=lambda: os.environ.get("GR_DATABASE_URL", "sqlite:///./geoready_platform.db")
+    )
+
+    # ─── Cache / broker ──────────────────────────────────────────────────────
+    redis_url: str = field(default_factory=lambda: os.environ.get("GR_REDIS_URL", "redis://localhost:6379/0"))
+
+    # ─── Auth ────────────────────────────────────────────────────────────────
+    jwt_secret: str = field(default_factory=lambda: os.environ.get("GR_JWT_SECRET", "dev-insecure-change-me"))
+    jwt_algorithm: str = field(default_factory=lambda: os.environ.get("GR_JWT_ALG", "HS256"))
+    jwt_ttl_seconds: int = field(default_factory=lambda: int(os.environ.get("GR_JWT_TTL_SECONDS", "3600")))
+
+    # ─── AI provider keys (slotted now, unused until later phases) ────────────
+    openai_api_key: str | None = field(default_factory=lambda: os.environ.get("OPENAI_API_KEY"))
+    anthropic_api_key: str | None = field(default_factory=lambda: os.environ.get("ANTHROPIC_API_KEY"))
+    perplexity_api_key: str | None = field(default_factory=lambda: os.environ.get("PERPLEXITY_API_KEY"))
+
+    # ─── Worker execution ────────────────────────────────────────────────────
+    # When true, Celery runs tasks inline (no broker needed) — used by tests and
+    # by single-process local dev. Production runs real workers (eager=False).
+    celery_eager: bool = field(default_factory=lambda: _env_bool("GR_CELERY_EAGER", False))
+    audit_timeout_seconds: int = field(default_factory=lambda: int(os.environ.get("GR_AUDIT_TIMEOUT_SECONDS", "60")))
+
+    # ─── Rate limiting (per API key) ─────────────────────────────────────────
+    free_audits_per_day: int = field(default_factory=lambda: int(os.environ.get("GR_FREE_AUDITS_PER_DAY", "5")))
+
+    @property
+    def is_sqlite(self) -> bool:
+        return self.database_url.startswith("sqlite")
+
+    @property
+    def is_postgres(self) -> bool:
+        return self.database_url.startswith(("postgres", "postgresql"))
+
+
+@lru_cache(maxsize=1)
+def get_settings() -> Settings:
+    """Return a cached Settings instance (read once per process)."""
+    return Settings()

--- a/platform/geoready_platform/core_bridge/__init__.py
+++ b/platform/geoready_platform/core_bridge/__init__.py
@@ -1,0 +1,6 @@
+"""Thin adapters over the open-source ``geo_optimizer`` engine.
+
+This is the ONLY place the platform touches the engine. The engine is frozen;
+these adapters call its public functions and translate dataclasses into
+platform-friendly, JSON-safe payloads. No engine code is modified.
+"""

--- a/platform/geoready_platform/core_bridge/audit_adapter.py
+++ b/platform/geoready_platform/core_bridge/audit_adapter.py
@@ -1,0 +1,82 @@
+"""Audit adapter: run the engine, return a JSON-safe payload + signal rows.
+
+Wraps ``geo_optimizer.core.audit.run_full_audit_async`` (async, parallel fetch)
+and serializes the returned ``AuditResult`` dataclass with ``dataclasses.asdict``
+(all nested results are dataclasses, so this is total and lossless).
+
+The audit's per-category breakdown is mapped to ``entity_signal`` rows: the
+audit is demoted to *one signal source* feeding the entity, per the roadmap.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+from dataclasses import dataclass, field
+from typing import Any
+
+from geoready_platform.config import get_settings
+
+
+@dataclass
+class AuditPayload:
+    """Normalized, JSON-safe result of one audit run."""
+
+    url: str
+    score: int
+    band: str
+    score_breakdown: dict[str, int]
+    full_result: dict[str, Any]
+    signals: list[dict[str, Any]] = field(default_factory=list)
+
+
+def _to_jsonable(value: Any) -> Any:
+    """Best-effort conversion of engine objects to JSON-safe primitives."""
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return {k: _to_jsonable(v) for k, v in dataclasses.asdict(value).items()}
+    if isinstance(value, dict):
+        return {str(k): _to_jsonable(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_to_jsonable(v) for v in value]
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    return str(value)  # datetimes, enums, etc. — degrade gracefully
+
+
+def _build_signals(breakdown: dict[str, int], result_dict: dict[str, Any]) -> list[dict[str, Any]]:
+    """Map the audit's category breakdown into entity-signal rows."""
+    signals: list[dict[str, Any]] = []
+    for category, score in (breakdown or {}).items():
+        detail = result_dict.get(category)
+        signals.append(
+            {
+                "source": "website_audit",
+                "signal_type": category,
+                "value": {"score": score, "detail": detail if isinstance(detail, dict) else None},
+            }
+        )
+    return signals
+
+
+async def run_audit_async(url: str) -> AuditPayload:
+    """Run the engine audit with a hard timeout and return a normalized payload."""
+    from geo_optimizer.core.audit import run_full_audit_async
+
+    settings = get_settings()
+    result = await asyncio.wait_for(run_full_audit_async(url), timeout=settings.audit_timeout_seconds)
+
+    result_dict = _to_jsonable(result)
+    breakdown = result_dict.get("score_breakdown") or {}
+    return AuditPayload(
+        url=getattr(result, "url", url),
+        score=int(getattr(result, "score", 0) or 0),
+        band=str(getattr(result, "band", "critical") or "critical"),
+        score_breakdown=breakdown,
+        full_result=result_dict,
+        signals=_build_signals(breakdown, result_dict),
+    )
+
+
+def run_audit(url: str) -> AuditPayload:
+    """Synchronous convenience wrapper around :func:`run_audit_async`."""
+    return asyncio.run(run_audit_async(url))

--- a/platform/geoready_platform/core_bridge/fix_adapter.py
+++ b/platform/geoready_platform/core_bridge/fix_adapter.py
@@ -1,0 +1,69 @@
+"""Fix adapter: expose the engine's structured fixes as ``FixProposal`` dicts.
+
+Phase 0 finding: ``geo_optimizer.core.fixer`` ALREADY returns structured
+``FixPlan``/``FixItem`` dataclasses and does NOT write to disk (disk writing
+lives in the CLI layer). The roadmap's planned "refactor fixer to stop writing
+files" is therefore unnecessary — we adapt the existing structured output here
+instead of modifying the engine, honoring the "do not rewrite working
+components" rule.
+
+This adapter is intentionally minimal in Phase 0: the AI fix *engine* that
+fills these proposals arrives in Phase 1. Here we only normalize the engine's
+deterministic fixes into the platform's proposal shape so the data contract is
+fixed early.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class FixProposal:
+    """Platform-shaped fix proposal (superset of the engine's FixItem)."""
+
+    category: str
+    description: str
+    content: str
+    file_name: str
+    action: str  # create | append | snippet
+    ai_generated: bool = False  # always False in Phase 0 (deterministic engine fixes)
+
+
+@dataclass
+class FixProposalSet:
+    url: str
+    score_before: int
+    score_estimated_after: int
+    proposals: list[FixProposal] = field(default_factory=list)
+    skipped: list[str] = field(default_factory=list)
+
+
+def build_fix_proposals(url: str, audit_result: Any | None = None, only: set[str] | None = None) -> FixProposalSet:
+    """Run the engine's fix generator and map FixItems -> FixProposals.
+
+    ``audit_result`` may be a pre-computed engine ``AuditResult`` to avoid a
+    second audit. Passing ``None`` lets the engine audit internally.
+    """
+    from geo_optimizer.core.fixer import run_all_fixes
+
+    plan = run_all_fixes(url, audit_result=audit_result, only=only)
+    proposals = [
+        FixProposal(
+            category=item.category,
+            description=item.description,
+            content=item.content,
+            file_name=item.file_name,
+            action=item.action,
+            ai_generated=False,
+        )
+        for item in plan.fixes
+    ]
+    return FixProposalSet(
+        url=plan.url,
+        score_before=plan.score_before,
+        score_estimated_after=plan.score_estimated_after,
+        proposals=proposals,
+        skipped=list(plan.skipped),
+    )

--- a/platform/geoready_platform/db/__init__.py
+++ b/platform/geoready_platform/db/__init__.py
@@ -1,0 +1,7 @@
+"""Database layer: engine, session factory, ORM Base and models."""
+
+from __future__ import annotations
+
+from geoready_platform.db.base import Base, get_engine, get_sessionmaker, session_scope
+
+__all__ = ["Base", "get_engine", "get_sessionmaker", "session_scope"]

--- a/platform/geoready_platform/db/base.py
+++ b/platform/geoready_platform/db/base.py
@@ -1,0 +1,47 @@
+"""SQLAlchemy engine, session factory, and declarative Base.
+
+Engine creation is lazy and cached so importing models never opens a
+connection. SQLite gets ``check_same_thread=False`` for FastAPI/Celery use.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from functools import lru_cache
+
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker
+
+from geoready_platform.config import get_settings
+
+
+class Base(DeclarativeBase):
+    """Declarative base for all platform ORM models."""
+
+
+@lru_cache(maxsize=1)
+def get_engine() -> Engine:
+    settings = get_settings()
+    connect_args = {"check_same_thread": False} if settings.is_sqlite else {}
+    return create_engine(settings.database_url, future=True, connect_args=connect_args)
+
+
+@lru_cache(maxsize=1)
+def get_sessionmaker() -> sessionmaker[Session]:
+    return sessionmaker(bind=get_engine(), autoflush=False, expire_on_commit=False, future=True)
+
+
+@contextmanager
+def session_scope() -> Iterator[Session]:
+    """Transactional session scope: commit on success, rollback on error."""
+    session = get_sessionmaker()()
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()

--- a/platform/geoready_platform/db/models.py
+++ b/platform/geoready_platform/db/models.py
@@ -1,0 +1,267 @@
+"""ORM models — the entity spine.
+
+Design principles (Phase 0):
+- The **business entity** is the root object; audits write *signals onto an
+  entity*. Audits are demoted to one signal source, not the product.
+- Every tenant-scoped table carries ``org_id`` so isolation can be enforced at
+  both the application layer (always) and via PostgreSQL RLS (production).
+- ``perception``, ``intervention``, ``impact`` are created **stub-only** now so
+  their shape is fixed and future phases avoid migrations. They carry no logic
+  in Phase 0.
+- Portable types only (String UUIDs, generic JSON) so the suite runs on SQLite
+  in tests and Postgres in production.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from enum import Enum
+
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from geoready_platform.db.base import Base
+
+
+def _uuid() -> str:
+    return str(uuid.uuid4())
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class Role(str, Enum):
+    owner = "owner"
+    admin = "admin"
+    editor = "editor"
+    viewer = "viewer"
+
+
+class AuditStatus(str, Enum):
+    queued = "queued"
+    running = "running"
+    complete = "complete"
+    failed = "failed"
+
+
+class TriggeredBy(str, Enum):
+    manual = "manual"
+    scheduled = "scheduled"
+    api = "api"
+    verify = "verify"
+
+
+# ─── Tenancy ────────────────────────────────────────────────────────────────
+
+
+class Org(Base):
+    __tablename__ = "orgs"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    plan: Mapped[str] = mapped_column(String(32), nullable=False, default="free")
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
+
+    members: Mapped[list[OrgMember]] = relationship(back_populates="org", cascade="all, delete-orphan")
+    entities: Mapped[list[BusinessEntity]] = relationship(back_populates="org", cascade="all, delete-orphan")
+    api_keys: Mapped[list[ApiKey]] = relationship(back_populates="org", cascade="all, delete-orphan")
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
+    email: Mapped[str] = mapped_column(String(320), nullable=False, unique=True)
+    name: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    password_hash: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
+
+
+class OrgMember(Base):
+    __tablename__ = "org_members"
+    __table_args__ = (UniqueConstraint("org_id", "user_id", name="uq_org_member"),)
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
+    org_id: Mapped[str] = mapped_column(ForeignKey("orgs.id", ondelete="CASCADE"), nullable=False)
+    user_id: Mapped[str] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    role: Mapped[str] = mapped_column(String(16), nullable=False, default=Role.owner.value)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
+
+    org: Mapped[Org] = relationship(back_populates="members")
+
+
+class ApiKey(Base):
+    """Org-scoped API key. Only the bcrypt/pbkdf2 hash is stored, never the key."""
+
+    __tablename__ = "api_keys"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
+    org_id: Mapped[str] = mapped_column(ForeignKey("orgs.id", ondelete="CASCADE"), nullable=False)
+    name: Mapped[str] = mapped_column(String(255), nullable=False, default="default")
+    prefix: Mapped[str] = mapped_column(String(16), nullable=False)  # non-secret lookup hint
+    key_hash: Mapped[str] = mapped_column(String(255), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
+    revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    org: Mapped[Org] = relationship(back_populates="api_keys")
+
+
+# ─── Entity spine ───────────────────────────────────────────────────────────
+
+
+class BusinessEntity(Base):
+    __tablename__ = "business_entity"
+    __table_args__ = (Index("ix_entity_org", "org_id"),)
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
+    org_id: Mapped[str] = mapped_column(ForeignKey("orgs.id", ondelete="CASCADE"), nullable=False)
+    canonical_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    category: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    geo: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    website_url: Mapped[str] = mapped_column(String(2048), nullable=False)
+
+    # Ownership verification (Phase 0 gate for any crawl/fix).
+    verification_method: Mapped[str | None] = mapped_column(String(16), nullable=True)  # dns | file
+    verification_token: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    verified_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
+    archived_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    org: Mapped[Org] = relationship(back_populates="entities")
+    signals: Mapped[list[EntitySignal]] = relationship(back_populates="entity", cascade="all, delete-orphan")
+    audits: Mapped[list[AuditJob]] = relationship(back_populates="entity", cascade="all, delete-orphan")
+
+    @property
+    def is_verified(self) -> bool:
+        return self.verified_at is not None
+
+
+class EntitySignal(Base):
+    """A perceived fact about the entity from one source (e.g. website audit)."""
+
+    __tablename__ = "entity_signal"
+    __table_args__ = (Index("ix_signal_entity_created", "entity_id", "fetched_at"),)
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
+    entity_id: Mapped[str] = mapped_column(ForeignKey("business_entity.id", ondelete="CASCADE"), nullable=False)
+    org_id: Mapped[str] = mapped_column(ForeignKey("orgs.id", ondelete="CASCADE"), nullable=False)
+    source: Mapped[str] = mapped_column(String(64), nullable=False)  # e.g. "website_audit"
+    signal_type: Mapped[str] = mapped_column(String(128), nullable=False)  # e.g. "robots", "schema"
+    value: Mapped[dict] = mapped_column("value_jsonb", JSON, nullable=False, default=dict)
+    ai_reachable: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    fetched_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
+
+    entity: Mapped[BusinessEntity] = relationship(back_populates="signals")
+
+
+class AuditJob(Base):
+    __tablename__ = "audit_jobs"
+    __table_args__ = (
+        Index("ix_audit_entity_created", "entity_id", "created_at"),
+        Index("ix_audit_org_status", "org_id", "status"),
+    )
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
+    entity_id: Mapped[str] = mapped_column(ForeignKey("business_entity.id", ondelete="CASCADE"), nullable=False)
+    org_id: Mapped[str] = mapped_column(ForeignKey("orgs.id", ondelete="CASCADE"), nullable=False)
+
+    status: Mapped[str] = mapped_column(String(16), nullable=False, default=AuditStatus.queued.value)
+    triggered_by: Mapped[str] = mapped_column(String(16), nullable=False, default=TriggeredBy.api.value)
+
+    score: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    band: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    score_breakdown: Mapped[dict | None] = mapped_column("score_breakdown_jsonb", JSON, nullable=True)
+    full_result: Mapped[dict | None] = mapped_column("full_result_jsonb", JSON, nullable=True)
+    error: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
+
+    entity: Mapped[BusinessEntity] = relationship(back_populates="audits")
+
+
+# ─── Stub tables (shape only — NO Phase 0 logic) ────────────────────────────
+# Created now so future phases (perception probe, execution, attribution) do not
+# require migrations. Intentionally minimal; columns will be extended later.
+
+
+class Perception(Base):
+    """What an AI engine says about an entity. Populated in Phase 1+."""
+
+    __tablename__ = "perception"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
+    entity_id: Mapped[str] = mapped_column(ForeignKey("business_entity.id", ondelete="CASCADE"), nullable=False)
+    org_id: Mapped[str] = mapped_column(ForeignKey("orgs.id", ondelete="CASCADE"), nullable=False)
+    engine: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    prompt: Mapped[str | None] = mapped_column(Text, nullable=True)
+    recommended: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    raw_response: Mapped[str | None] = mapped_column(Text, nullable=True)
+    details: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    probed_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
+
+
+class Intervention(Base):
+    """A change proposed/executed to improve perception. Populated in Phase 1+."""
+
+    __tablename__ = "intervention"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
+    entity_id: Mapped[str] = mapped_column(ForeignKey("business_entity.id", ondelete="CASCADE"), nullable=False)
+    org_id: Mapped[str] = mapped_column(ForeignKey("orgs.id", ondelete="CASCADE"), nullable=False)
+    fix_type: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    proposed_content: Mapped[str | None] = mapped_column(Text, nullable=True)
+    status: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    executed_via: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    details: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
+    executed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+
+class Impact(Base):
+    """Measured/attributed business impact. Populated in Phase 2+."""
+
+    __tablename__ = "impact"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
+    entity_id: Mapped[str] = mapped_column(ForeignKey("business_entity.id", ondelete="CASCADE"), nullable=False)
+    org_id: Mapped[str] = mapped_column(ForeignKey("orgs.id", ondelete="CASCADE"), nullable=False)
+    intervention_id: Mapped[str | None] = mapped_column(
+        ForeignKey("intervention.id", ondelete="SET NULL"), nullable=True
+    )
+    details: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    confidence_label: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    period_start: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    period_end: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
+
+
+__all__ = [
+    "Role",
+    "AuditStatus",
+    "TriggeredBy",
+    "Org",
+    "User",
+    "OrgMember",
+    "ApiKey",
+    "BusinessEntity",
+    "EntitySignal",
+    "AuditJob",
+    "Perception",
+    "Intervention",
+    "Impact",
+]

--- a/platform/geoready_platform/schemas/__init__.py
+++ b/platform/geoready_platform/schemas/__init__.py
@@ -1,0 +1,1 @@
+"""Pydantic request/response models for the platform API."""

--- a/platform/geoready_platform/schemas/models.py
+++ b/platform/geoready_platform/schemas/models.py
@@ -1,0 +1,104 @@
+"""API request/response schemas (Pydantic v2)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ORMModel(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+
+# ─── Orgs ────────────────────────────────────────────────────────────────────
+
+
+class OrgCreate(BaseModel):
+    name: str = Field(min_length=1, max_length=255)
+    owner_email: str = Field(min_length=3, max_length=320)
+    owner_name: str | None = None
+
+
+class OrgOut(ORMModel):
+    id: str
+    name: str
+    plan: str
+    created_at: datetime
+
+
+class OrgCreated(BaseModel):
+    org: OrgOut
+    api_key: str = Field(description="Shown once only — store it securely.")
+
+
+# ─── Entities ────────────────────────────────────────────────────────────────
+
+
+class EntityCreate(BaseModel):
+    canonical_name: str = Field(min_length=1, max_length=255)
+    website_url: str = Field(min_length=4, max_length=2048)
+    category: str | None = None
+    geo: str | None = None
+
+
+class EntityOut(ORMModel):
+    id: str
+    org_id: str
+    canonical_name: str
+    website_url: str
+    category: str | None
+    geo: str | None
+    verified_at: datetime | None
+    created_at: datetime
+
+
+class VerifyStart(BaseModel):
+    method: str = Field(description="'dns' or 'file'")
+
+
+class VerifyStartOut(BaseModel):
+    method: str
+    token: str
+    instructions: str
+
+
+class VerifyConfirmOut(BaseModel):
+    verified: bool
+    verified_at: datetime | None
+
+
+# ─── Signals ─────────────────────────────────────────────────────────────────
+
+
+class SignalOut(ORMModel):
+    id: str
+    entity_id: str
+    source: str
+    signal_type: str
+    value: dict[str, Any]
+    fetched_at: datetime
+
+
+# ─── Audits ──────────────────────────────────────────────────────────────────
+
+
+class AuditEnqueuedOut(BaseModel):
+    audit_job_id: str
+    status: str
+
+
+class AuditOut(ORMModel):
+    id: str
+    entity_id: str
+    status: str
+    triggered_by: str
+    score: int | None
+    band: str | None
+    score_breakdown: dict[str, Any] | None
+    full_result: dict[str, Any] | None
+    error: str | None
+    created_at: datetime
+    started_at: datetime | None
+    completed_at: datetime | None

--- a/platform/geoready_platform/services/__init__.py
+++ b/platform/geoready_platform/services/__init__.py
@@ -1,0 +1,1 @@
+"""Business-logic services: auth, ownership, entities, audits."""

--- a/platform/geoready_platform/services/audits.py
+++ b/platform/geoready_platform/services/audits.py
@@ -1,0 +1,156 @@
+"""Audit service: enqueue jobs and execute them via the engine bridge.
+
+``enqueue_audit`` enforces the ownership gate and creates a queued ``AuditJob``,
+then dispatches the Celery task. ``execute_audit_job`` is the pure execution
+function the worker calls; tests call it directly (no broker needed).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from geoready_platform.config import get_settings
+from geoready_platform.core_bridge.audit_adapter import run_audit
+from geoready_platform.db.base import session_scope
+from geoready_platform.db.models import AuditJob, AuditStatus, BusinessEntity, EntitySignal, TriggeredBy
+from geoready_platform.services.entities import get_entity
+
+
+class EntityNotVerifiedError(Exception):
+    pass
+
+
+class QuotaExceededError(Exception):
+    pass
+
+
+class AuditJobNotFoundError(Exception):
+    pass
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _check_quota(session: Session, org_id: str) -> None:
+    settings = get_settings()
+    since = _utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+    count = session.execute(
+        select(func.count(AuditJob.id)).where(AuditJob.org_id == org_id, AuditJob.created_at >= since)
+    ).scalar_one()
+    if count >= settings.free_audits_per_day:
+        raise QuotaExceededError(f"Daily audit quota ({settings.free_audits_per_day}) reached")
+
+
+def enqueue_audit(
+    session: Session,
+    *,
+    org_id: str,
+    entity_id: str,
+    triggered_by: str = TriggeredBy.api.value,
+) -> AuditJob:
+    """Create a queued audit job. Refuses unverified entities and over-quota orgs."""
+    entity = get_entity(session, org_id=org_id, entity_id=entity_id)
+    if not entity.is_verified:
+        raise EntityNotVerifiedError("Entity ownership is not verified; audits are refused")
+
+    _check_quota(session, org_id)
+
+    job = AuditJob(
+        entity_id=entity.id,
+        org_id=org_id,
+        status=AuditStatus.queued.value,
+        triggered_by=triggered_by,
+    )
+    session.add(job)
+    session.flush()
+    job_id = job.id
+
+    # The worker reads the job from a *separate* session/connection, so the job
+    # must be durably committed before we dispatch — otherwise the worker (eager
+    # or remote) cannot find it. Commit here makes the invariant explicit.
+    session.commit()
+
+    # Dispatch the worker. Import locally to avoid importing Celery at module load.
+    from geoready_platform.workers.audit_task import run_audit_job
+
+    settings = get_settings()
+    if settings.celery_eager:
+        run_audit_job.apply(args=[job_id])
+    else:
+        run_audit_job.delay(job_id)
+
+    return job
+
+
+def get_audit(session: Session, *, org_id: str, job_id: str) -> AuditJob:
+    job = session.execute(
+        select(AuditJob).where(AuditJob.id == job_id, AuditJob.org_id == org_id)
+    ).scalar_one_or_none()
+    if job is None:
+        raise AuditJobNotFoundError(job_id)
+    return job
+
+
+def execute_audit_job(job_id: str) -> None:
+    """Run the engine for a queued job and persist results + signals.
+
+    Opens its own session (it runs inside a worker). Re-asserts the ownership
+    gate as a defense-in-depth check, then runs the frozen engine via the
+    bridge. Failures are recorded on the job, never swallowed silently.
+    """
+    with session_scope() as session:
+        job = session.get(AuditJob, job_id)
+        if job is None:
+            raise AuditJobNotFoundError(job_id)
+        entity = session.get(BusinessEntity, job.entity_id)
+        if entity is None or not entity.is_verified:
+            job.status = AuditStatus.failed.value
+            job.error = "Entity missing or not verified at execution time"
+            job.completed_at = _utcnow()
+            return
+
+        job.status = AuditStatus.running.value
+        job.started_at = _utcnow()
+        session.flush()
+
+        url = entity.website_url
+        org_id = entity.org_id
+        entity_id = entity.id
+
+    # Run the (potentially slow) audit OUTSIDE the DB transaction.
+    try:
+        payload = run_audit(url)
+    except Exception as exc:  # noqa: BLE001 — record any engine/timeout failure
+        with session_scope() as session:
+            job = session.get(AuditJob, job_id)
+            if job is not None:
+                job.status = AuditStatus.failed.value
+                job.error = f"{type(exc).__name__}: {exc}"
+                job.completed_at = _utcnow()
+        return
+
+    with session_scope() as session:
+        job = session.get(AuditJob, job_id)
+        if job is None:
+            raise AuditJobNotFoundError(job_id)
+        job.status = AuditStatus.complete.value
+        job.score = payload.score
+        job.band = payload.band
+        job.score_breakdown = payload.score_breakdown
+        job.full_result = payload.full_result
+        job.completed_at = _utcnow()
+
+        for sig in payload.signals:
+            session.add(
+                EntitySignal(
+                    entity_id=entity_id,
+                    org_id=org_id,
+                    source=sig["source"],
+                    signal_type=sig["signal_type"],
+                    value=sig["value"],
+                )
+            )

--- a/platform/geoready_platform/services/auth.py
+++ b/platform/geoready_platform/services/auth.py
@@ -1,0 +1,80 @@
+"""Authentication & credential primitives.
+
+- Passwords and API keys are hashed with PBKDF2-HMAC-SHA256 (stdlib only —
+  no bcrypt build dependency, which keeps Windows/CI setup frictionless).
+- API keys are returned in cleartext exactly once at creation; only the hash
+  and a non-secret ``prefix`` are persisted.
+- JWTs are HS256 via PyJWT.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import secrets
+from datetime import datetime, timedelta, timezone
+
+import jwt
+
+from geoready_platform.config import get_settings
+
+_PBKDF2_ROUNDS = 240_000
+_API_KEY_PREFIX = "gr_"
+
+
+# ─── Password / key hashing ──────────────────────────────────────────────────
+
+
+def hash_secret(secret: str) -> str:
+    """Return ``pbkdf2$<rounds>$<salt_hex>$<hash_hex>``."""
+    salt = secrets.token_bytes(16)
+    dk = hashlib.pbkdf2_hmac("sha256", secret.encode("utf-8"), salt, _PBKDF2_ROUNDS)
+    return f"pbkdf2${_PBKDF2_ROUNDS}${salt.hex()}${dk.hex()}"
+
+
+def verify_secret(secret: str, stored: str) -> bool:
+    try:
+        scheme, rounds_s, salt_hex, hash_hex = stored.split("$")
+        if scheme != "pbkdf2":
+            return False
+        dk = hashlib.pbkdf2_hmac("sha256", secret.encode("utf-8"), bytes.fromhex(salt_hex), int(rounds_s))
+        return hmac.compare_digest(dk.hex(), hash_hex)
+    except (ValueError, AttributeError):
+        return False
+
+
+# ─── API keys ────────────────────────────────────────────────────────────────
+
+
+def generate_api_key() -> tuple[str, str, str]:
+    """Return ``(full_key, prefix, key_hash)``. ``full_key`` is shown once only."""
+    body = secrets.token_urlsafe(32)
+    full_key = f"{_API_KEY_PREFIX}{body}"
+    prefix = full_key[:12]
+    return full_key, prefix, hash_secret(full_key)
+
+
+def api_key_prefix(full_key: str) -> str:
+    return full_key[:12]
+
+
+# ─── JWT ─────────────────────────────────────────────────────────────────────
+
+
+def create_access_token(*, user_id: str, org_id: str, role: str) -> str:
+    settings = get_settings()
+    now = datetime.now(timezone.utc)
+    payload = {
+        "sub": user_id,
+        "org_id": org_id,
+        "role": role,
+        "iat": int(now.timestamp()),
+        "exp": int((now + timedelta(seconds=settings.jwt_ttl_seconds)).timestamp()),
+    }
+    return jwt.encode(payload, settings.jwt_secret, algorithm=settings.jwt_algorithm)
+
+
+def decode_access_token(token: str) -> dict:
+    """Decode and verify a JWT. Raises ``jwt.PyJWTError`` on failure."""
+    settings = get_settings()
+    return jwt.decode(token, settings.jwt_secret, algorithms=[settings.jwt_algorithm])

--- a/platform/geoready_platform/services/entities.py
+++ b/platform/geoready_platform/services/entities.py
@@ -1,0 +1,93 @@
+"""Entity service: create/list/get entities and run ownership verification.
+
+Every query is scoped by ``org_id`` at the application layer. Combined with the
+Postgres RLS policies (see the baseline migration), this gives defense in depth
+for tenant isolation.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from geoready_platform.db.models import BusinessEntity
+from geoready_platform.services import ownership
+
+
+class EntityNotFoundError(Exception):
+    pass
+
+
+class OwnershipVerificationError(Exception):
+    pass
+
+
+def create_entity(
+    session: Session,
+    *,
+    org_id: str,
+    canonical_name: str,
+    website_url: str,
+    category: str | None = None,
+    geo: str | None = None,
+) -> BusinessEntity:
+    entity = BusinessEntity(
+        org_id=org_id,
+        canonical_name=canonical_name,
+        website_url=website_url,
+        category=category,
+        geo=geo,
+    )
+    session.add(entity)
+    session.flush()
+    return entity
+
+
+def get_entity(session: Session, *, org_id: str, entity_id: str) -> BusinessEntity:
+    stmt = select(BusinessEntity).where(
+        BusinessEntity.id == entity_id,
+        BusinessEntity.org_id == org_id,
+        BusinessEntity.archived_at.is_(None),
+    )
+    entity = session.execute(stmt).scalar_one_or_none()
+    if entity is None:
+        raise EntityNotFoundError(entity_id)
+    return entity
+
+
+def list_entities(session: Session, *, org_id: str) -> list[BusinessEntity]:
+    stmt = (
+        select(BusinessEntity)
+        .where(BusinessEntity.org_id == org_id, BusinessEntity.archived_at.is_(None))
+        .order_by(BusinessEntity.created_at.desc())
+    )
+    return list(session.execute(stmt).scalars().all())
+
+
+def start_verification(session: Session, *, org_id: str, entity_id: str, method: str) -> BusinessEntity:
+    """Issue a verification token and record the chosen method (dns | file)."""
+    if method not in {"dns", "file"}:
+        raise OwnershipVerificationError(f"Unknown method {method!r} (expected 'dns' or 'file')")
+    entity = get_entity(session, org_id=org_id, entity_id=entity_id)
+    entity.verification_method = method
+    entity.verification_token = ownership.generate_verification_token()
+    entity.verified_at = None
+    session.flush()
+    return entity
+
+
+def confirm_verification(session: Session, *, org_id: str, entity_id: str) -> BusinessEntity:
+    """Re-check the token via the recorded method; set ``verified_at`` on success."""
+    entity = get_entity(session, org_id=org_id, entity_id=entity_id)
+    if not entity.verification_token or not entity.verification_method:
+        raise OwnershipVerificationError("Verification has not been started for this entity")
+
+    ok, err = ownership.verify(entity.website_url, entity.verification_token, entity.verification_method)
+    if not ok:
+        raise OwnershipVerificationError(err or "Verification failed")
+
+    entity.verified_at = datetime.now(timezone.utc)
+    session.flush()
+    return entity

--- a/platform/geoready_platform/services/ownership.py
+++ b/platform/geoready_platform/services/ownership.py
@@ -1,0 +1,84 @@
+"""Domain ownership verification — the hard gate before any crawl or fix.
+
+Two methods, both proving control of the domain:
+- **DNS**: a TXT record at ``_geoready.<domain>`` containing the token.
+- **File**: ``https://<domain>/.well-known/geoready-verification.txt`` whose
+  body contains the token.
+
+All HTTP goes through the engine's anti-SSRF ``fetch_url``; URL safety is checked
+with ``validate_public_url``. No bypass for unverified entities exists anywhere
+in the platform — the worker re-asserts verification before running an audit.
+"""
+
+from __future__ import annotations
+
+import secrets
+from urllib.parse import urlparse
+
+WELL_KNOWN_PATH = "/.well-known/geoready-verification.txt"
+DNS_RECORD_PREFIX = "_geoready"
+TOKEN_PREFIX = "geoready-verification="
+
+
+def generate_verification_token() -> str:
+    return secrets.token_urlsafe(24)
+
+
+def _domain_of(website_url: str) -> str:
+    parsed = urlparse(website_url if "://" in website_url else f"https://{website_url}")
+    return (parsed.netloc or parsed.path).split(":")[0].lower().strip("/")
+
+
+def verify_via_file(website_url: str, token: str) -> tuple[bool, str | None]:
+    """Fetch the well-known file and check it contains the token."""
+    from geo_optimizer.utils.http import fetch_url
+
+    domain = _domain_of(website_url)
+    if not domain:
+        return False, "Could not determine domain from website_url"
+
+    target = f"https://{domain}{WELL_KNOWN_PATH}"
+    response, err = fetch_url(target, timeout=10)
+    if err or response is None:
+        return False, f"Could not fetch {WELL_KNOWN_PATH}: {err or 'no response'}"
+    if response.status_code != 200:
+        return False, f"{WELL_KNOWN_PATH} returned HTTP {response.status_code}"
+
+    body = (response.text or "").strip()
+    if token in body:
+        return True, None
+    return False, "Verification file did not contain the expected token"
+
+
+def verify_via_dns(website_url: str, token: str) -> tuple[bool, str | None]:
+    """Look up the TXT record and check it contains the token."""
+    try:
+        import dns.resolver  # type: ignore
+    except ImportError:
+        return False, "DNS verification requires the 'dnspython' dependency"
+
+    domain = _domain_of(website_url)
+    if not domain:
+        return False, "Could not determine domain from website_url"
+
+    record_name = f"{DNS_RECORD_PREFIX}.{domain}"
+    try:
+        answers = dns.resolver.resolve(record_name, "TXT")
+    except Exception as exc:  # noqa: BLE001 — resolver raises many subclasses
+        return False, f"DNS lookup failed for {record_name}: {exc}"
+
+    expected = f"{TOKEN_PREFIX}{token}"
+    for rdata in answers:
+        txt = b"".join(getattr(rdata, "strings", [])).decode("utf-8", "ignore") or str(rdata).strip('"')
+        if expected in txt or token in txt:
+            return True, None
+    return False, "No matching TXT record found"
+
+
+def verify(website_url: str, token: str, method: str) -> tuple[bool, str | None]:
+    """Dispatch to the chosen verification method."""
+    if method == "dns":
+        return verify_via_dns(website_url, token)
+    if method == "file":
+        return verify_via_file(website_url, token)
+    return False, f"Unknown verification method: {method!r} (expected 'dns' or 'file')"

--- a/platform/geoready_platform/workers/__init__.py
+++ b/platform/geoready_platform/workers/__init__.py
@@ -1,0 +1,1 @@
+"""Celery worker layer: audit jobs run here, wrapping the engine bridge."""

--- a/platform/geoready_platform/workers/audit_task.py
+++ b/platform/geoready_platform/workers/audit_task.py
@@ -1,0 +1,31 @@
+"""The audit Celery task.
+
+Thin wrapper: all logic lives in ``services.audits.execute_audit_job`` so it can
+be unit-tested without a broker. A hard time limit bounds runaway audits in
+addition to the per-audit asyncio timeout in the bridge.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from geoready_platform.config import get_settings
+from geoready_platform.workers.celery_app import celery_app
+
+logger = logging.getLogger(__name__)
+_settings = get_settings()
+
+
+@celery_app.task(
+    name="geoready_platform.run_audit_job",
+    bind=True,
+    max_retries=0,
+    time_limit=_settings.audit_timeout_seconds + 15,
+    soft_time_limit=_settings.audit_timeout_seconds + 5,
+)
+def run_audit_job(self, job_id: str) -> str:  # noqa: ANN001 — Celery self
+    from geoready_platform.services.audits import execute_audit_job
+
+    logger.info("Running audit job %s", job_id)
+    execute_audit_job(job_id)
+    return job_id

--- a/platform/geoready_platform/workers/celery_app.py
+++ b/platform/geoready_platform/workers/celery_app.py
@@ -1,0 +1,29 @@
+"""Celery application.
+
+Broker/backend default to Redis. ``task_always_eager`` is driven by
+``GR_CELERY_EAGER`` so tests and single-process dev can run tasks inline with
+no broker. Production runs ``celery -A geoready_platform.workers.celery_app worker``.
+"""
+
+from __future__ import annotations
+
+from celery import Celery
+
+from geoready_platform.config import get_settings
+
+settings = get_settings()
+
+celery_app = Celery(
+    "geoready_platform",
+    broker=settings.redis_url,
+    backend=settings.redis_url,
+    include=["geoready_platform.workers.audit_task"],
+)
+
+celery_app.conf.update(
+    task_always_eager=settings.celery_eager,
+    task_eager_propagates=settings.celery_eager,
+    task_acks_late=True,
+    worker_prefetch_multiplier=1,  # I/O-bound audits: fair dispatch
+    task_track_started=True,
+)

--- a/platform/pytest.ini
+++ b/platform/pytest.ini
@@ -1,0 +1,8 @@
+# Isolated pytest config for the platform. Kept separate from the root
+# pyproject.toml so the OSS engine's test config stays untouched.
+# Run from the platform/ directory:  cd platform && pytest
+[pytest]
+testpaths = tests
+pythonpath = . ../src
+filterwarnings =
+    ignore::DeprecationWarning

--- a/platform/tests/conftest.py
+++ b/platform/tests/conftest.py
@@ -1,0 +1,56 @@
+"""Test fixtures. Configures an isolated SQLite DB and eager Celery BEFORE any
+platform module is imported (settings/engine are cached on first use).
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+# ── Configure environment before importing the app/config (cached settings) ──
+_TMP_DB = os.path.join(tempfile.gettempdir(), "geoready_platform_test.db")
+if os.path.exists(_TMP_DB):
+    os.remove(_TMP_DB)
+os.environ["GR_DATABASE_URL"] = f"sqlite:///{_TMP_DB}"
+os.environ["GR_CELERY_EAGER"] = "true"
+os.environ["GR_JWT_SECRET"] = "test-secret"
+os.environ["GR_FREE_AUDITS_PER_DAY"] = "5"
+
+import pytest  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from geoready_platform.api.main import create_app  # noqa: E402
+from geoready_platform.db.base import get_engine  # noqa: E402
+from geoready_platform.db.models import Base  # noqa: E402
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _create_schema():
+    engine = get_engine()
+    Base.metadata.create_all(bind=engine)
+    yield
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    return TestClient(create_app())
+
+
+@pytest.fixture()
+def org_key(client: TestClient) -> dict:
+    """Create an org and return {'org_id', 'api_key', 'headers'}."""
+    import uuid
+
+    resp = client.post(
+        "/v1/orgs",
+        json={"name": "Acme Agency", "owner_email": f"owner-{uuid.uuid4()}@acme.test", "owner_name": "Owner"},
+    )
+    assert resp.status_code == 201, resp.text
+    data = resp.json()
+    api_key = data["api_key"]
+    return {
+        "org_id": data["org"]["id"],
+        "api_key": api_key,
+        "headers": {"X-API-Key": api_key},
+    }

--- a/platform/tests/test_audit_flow.py
+++ b/platform/tests/test_audit_flow.py
@@ -1,0 +1,85 @@
+"""End-to-end Phase 0 flow: create -> verify -> audit -> signals.
+
+The engine is stubbed at the bridge boundary so no network access occurs and
+the test exercises the platform wiring, not the audit engine itself.
+"""
+
+from __future__ import annotations
+
+import geoready_platform.services.audits as audit_svc
+import geoready_platform.services.ownership as ownership
+from geoready_platform.core_bridge.audit_adapter import AuditPayload
+
+
+def _fake_payload(url: str) -> AuditPayload:
+    return AuditPayload(
+        url=url,
+        score=66,
+        band="good",
+        score_breakdown={"robots": 18, "schema": 10},
+        full_result={"url": url, "score": 66, "score_breakdown": {"robots": 18, "schema": 10}},
+        signals=[
+            {"source": "website_audit", "signal_type": "robots", "value": {"score": 18, "detail": None}},
+            {"source": "website_audit", "signal_type": "schema", "value": {"score": 10, "detail": None}},
+        ],
+    )
+
+
+def _verified_entity(client, headers, monkeypatch, url="https://acme.test"):
+    eid = client.post(
+        "/v1/entities",
+        json={"canonical_name": "Acme", "website_url": url},
+        headers=headers,
+    ).json()["id"]
+    client.post(f"/v1/entities/{eid}/verify", json={"method": "file"}, headers=headers)
+    monkeypatch.setattr(ownership, "verify", lambda u, t, m: (True, None))
+    client.post(f"/v1/entities/{eid}/verify/confirm", headers=headers)
+    return eid
+
+
+def test_audit_refused_when_unverified(client, org_key):
+    eid = client.post(
+        "/v1/entities",
+        json={"canonical_name": "Acme", "website_url": "https://acme.test"},
+        headers=org_key["headers"],
+    ).json()["id"]
+    resp = client.post(f"/v1/entities/{eid}/audits", headers=org_key["headers"])
+    assert resp.status_code == 403
+    assert "not verified" in resp.text.lower()
+
+
+def test_full_audit_pipeline_writes_signals(client, org_key, monkeypatch):
+    headers = org_key["headers"]
+    monkeypatch.setattr(audit_svc, "run_audit", _fake_payload)
+    eid = _verified_entity(client, headers, monkeypatch)
+
+    resp = client.post(f"/v1/entities/{eid}/audits", headers=headers)
+    assert resp.status_code == 202, resp.text
+    job_id = resp.json()["audit_job_id"]
+
+    # Eager mode: the job is already complete by the time we poll.
+    job = client.get(f"/v1/audits/{job_id}", headers=headers).json()
+    assert job["status"] == "complete"
+    assert job["score"] == 66
+    assert job["band"] == "good"
+    assert job["full_result"]["score"] == 66
+
+    signals = client.get(f"/v1/entities/{eid}/signals", headers=headers).json()
+    types = {s["signal_type"] for s in signals}
+    assert {"robots", "schema"} <= types
+    assert all(s["source"] == "website_audit" for s in signals)
+
+
+def test_audit_failure_is_recorded_not_swallowed(client, org_key, monkeypatch):
+    headers = org_key["headers"]
+
+    def _boom(url):
+        raise RuntimeError("engine exploded")
+
+    monkeypatch.setattr(audit_svc, "run_audit", _boom)
+    eid = _verified_entity(client, headers, monkeypatch)
+
+    job_id = client.post(f"/v1/entities/{eid}/audits", headers=headers).json()["audit_job_id"]
+    job = client.get(f"/v1/audits/{job_id}", headers=headers).json()
+    assert job["status"] == "failed"
+    assert "engine exploded" in job["error"]

--- a/platform/tests/test_core_bridge.py
+++ b/platform/tests/test_core_bridge.py
@@ -1,0 +1,53 @@
+"""Core-bridge adapter unit tests — verify wrapping/serialization without network."""
+
+from __future__ import annotations
+
+from geoready_platform.core_bridge import audit_adapter
+
+
+def test_to_jsonable_handles_dataclasses_and_nested():
+    from dataclasses import dataclass
+
+    @dataclass
+    class Inner:
+        a: int
+
+    @dataclass
+    class Outer:
+        name: str
+        inner: Inner
+        items: list
+
+    out = audit_adapter._to_jsonable(Outer(name="x", inner=Inner(a=1), items=[Inner(a=2)]))
+    assert out == {"name": "x", "inner": {"a": 1}, "items": [{"a": 2}]}
+
+
+def test_build_signals_maps_breakdown_categories():
+    signals = audit_adapter._build_signals(
+        {"robots": 18, "schema": 10},
+        {"robots": {"found": True}, "schema": {"types": ["Org"]}},
+    )
+    by_type = {s["signal_type"]: s for s in signals}
+    assert by_type["robots"]["value"]["score"] == 18
+    assert by_type["robots"]["value"]["detail"] == {"found": True}
+    assert all(s["source"] == "website_audit" for s in signals)
+
+
+def test_run_audit_async_uses_engine(monkeypatch):
+    import asyncio
+
+    from geo_optimizer.models.results import AuditResult
+
+    async def _fake_engine(url, project_config=None):
+        return AuditResult(url=url, score=42, band="foundation", score_breakdown={"robots": 18})
+
+    # Patch the engine entry point the adapter imports lazily.
+    import geo_optimizer.core.audit as engine
+
+    monkeypatch.setattr(engine, "run_full_audit_async", _fake_engine)
+
+    payload = asyncio.run(audit_adapter.run_audit_async("https://x.test"))
+    assert payload.score == 42
+    assert payload.band == "foundation"
+    assert payload.score_breakdown == {"robots": 18}
+    assert any(s["signal_type"] == "robots" for s in payload.signals)

--- a/platform/tests/test_health_and_auth.py
+++ b/platform/tests/test_health_and_auth.py
@@ -1,0 +1,30 @@
+"""Health, org provisioning, and auth gating."""
+
+from __future__ import annotations
+
+
+def test_healthz(client):
+    resp = client.get("/healthz")
+    assert resp.status_code == 200
+    assert resp.json()["db"] is True
+
+
+def test_create_org_returns_api_key_once(client):
+    resp = client.post(
+        "/v1/orgs",
+        json={"name": "Org One", "owner_email": "a@b.test"},
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["api_key"].startswith("gr_")
+    assert body["org"]["plan"] == "free"
+
+
+def test_unauthenticated_requests_are_rejected(client):
+    assert client.get("/v1/entities").status_code == 401
+    assert client.post("/v1/entities", json={}).status_code == 401
+
+
+def test_invalid_api_key_rejected(client):
+    resp = client.get("/v1/entities", headers={"X-API-Key": "gr_not_a_real_key"})
+    assert resp.status_code == 401

--- a/platform/tests/test_ownership.py
+++ b/platform/tests/test_ownership.py
@@ -1,0 +1,49 @@
+"""Ownership verification gating."""
+
+from __future__ import annotations
+
+import geoready_platform.services.ownership as ownership
+
+
+def _make_entity(client, headers):
+    resp = client.post(
+        "/v1/entities",
+        json={"canonical_name": "Acme", "website_url": "https://acme.test"},
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+def test_start_verification_returns_token(client, org_key):
+    entity_id = _make_entity(client, org_key["headers"])
+    resp = client.post(
+        f"/v1/entities/{entity_id}/verify",
+        json={"method": "file"},
+        headers=org_key["headers"],
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["method"] == "file"
+    assert body["token"]
+    assert "/.well-known/" in body["instructions"]
+
+
+def test_confirm_verification_success(client, org_key, monkeypatch):
+    entity_id = _make_entity(client, org_key["headers"])
+    client.post(f"/v1/entities/{entity_id}/verify", json={"method": "file"}, headers=org_key["headers"])
+
+    monkeypatch.setattr(ownership, "verify", lambda url, token, method: (True, None))
+    resp = client.post(f"/v1/entities/{entity_id}/verify/confirm", headers=org_key["headers"])
+    assert resp.status_code == 200
+    assert resp.json()["verified"] is True
+
+
+def test_confirm_verification_failure(client, org_key, monkeypatch):
+    entity_id = _make_entity(client, org_key["headers"])
+    client.post(f"/v1/entities/{entity_id}/verify", json={"method": "dns"}, headers=org_key["headers"])
+
+    monkeypatch.setattr(ownership, "verify", lambda url, token, method: (False, "No record"))
+    resp = client.post(f"/v1/entities/{entity_id}/verify/confirm", headers=org_key["headers"])
+    assert resp.status_code == 400
+    assert "No record" in resp.text

--- a/platform/tests/test_tenancy.py
+++ b/platform/tests/test_tenancy.py
@@ -1,0 +1,30 @@
+"""Tenant isolation: one org cannot read another org's entities or audits."""
+
+from __future__ import annotations
+
+
+def _new_org(client):
+    import uuid
+
+    data = client.post(
+        "/v1/orgs",
+        json={"name": "Org", "owner_email": f"u-{uuid.uuid4()}@x.test"},
+    ).json()
+    return {"X-API-Key": data["api_key"]}
+
+
+def test_cross_org_entity_isolation(client):
+    org_a = _new_org(client)
+    org_b = _new_org(client)
+
+    eid = client.post(
+        "/v1/entities",
+        json={"canonical_name": "A Corp", "website_url": "https://a.test"},
+        headers=org_a,
+    ).json()["id"]
+
+    # Org B must not see or fetch Org A's entity.
+    assert client.get(f"/v1/entities/{eid}", headers=org_b).status_code == 404
+    assert client.get("/v1/entities", headers=org_b).json() == []
+    assert client.post(f"/v1/entities/{eid}/audits", headers=org_b).status_code == 404
+    assert client.get(f"/v1/entities/{eid}/signals", headers=org_b).status_code == 404

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,28 @@ dev = [
 all = [
     "geo-optimizer-skill[async,web,mcp,pdf,config]",
 ]
+# ── AI Visibility Platform (Phase 0) ──────────────────────────────────────────
+# Isolated dependency group for the geoready_platform/ tree. NOT installed by the
+# default package; the platform wraps the OSS engine and ships separately.
+platform = [
+    "fastapi>=0.110.0,<1.0",
+    "uvicorn[standard]>=0.27.0,<1.0",
+    "sqlalchemy>=2.0,<3.0",
+    "alembic>=1.13,<2.0",
+    "pydantic>=2.6,<3.0",
+    "celery>=5.3,<6.0",
+    "redis>=5.0,<6.0",
+    "pyjwt>=2.8,<3.0",
+    "dnspython>=2.6,<3.0",
+    "httpx>=0.27.0,<1.0",
+    "psycopg[binary]>=3.1,<4.0",
+]
+platform-dev = [
+    "geo-optimizer-skill[platform,async]",
+    "pytest>=7.0,<10.0",
+    "pytest-cov>=4.0,<8.0",
+    "ruff>=0.8.0",
+]
 
 [project.urls]
 Homepage = "https://github.com/auriti-labs/geo-optimizer-skill"
@@ -136,6 +158,9 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "tests/test_integration.py" = ["E402"]
+# FastAPI's Depends()/Header() in argument defaults is the framework's intended
+# idiom, not a bug — B008 is a false positive across the platform API layer.
+"platform/**" = ["B008"]
 
 [tool.mypy]
 python_version = "3.10"


### PR DESCRIPTION
## Summary

Phase 0 of the AI Visibility Platform, built strictly per `docs/ROADMAP.md` (Appendix A). It stands up the platform **foundation only** — no UI, no perception probe, no AI fixes, no attribution. The core loop stage delivered is **Audit**, implemented as a queued, ownership-gated, tenant-isolated job that writes results as *signals on a business entity*.

All new code is isolated under `platform/` and **wraps** the open-source engine via `core_bridge/` rather than modifying it.

## 1. What Phase 0 adds

- **Entity spine** (`db/models.py`): Org / User / OrgMember / ApiKey, BusinessEntity, EntitySignal, AuditJob — plus **stub-only** Perception / Intervention / Impact tables (shape fixed now to avoid future migrations).
- **Auth & tenancy**: PBKDF2 hashing (stdlib, no bcrypt build dep), org-scoped API keys (hash stored, key shown once), HS256 JWT; principal resolution + `org_id` scoping on every request; daily audit quota.
- **Domain ownership verification**: DNS-TXT or well-known-file, reusing the engine's anti-SSRF `fetch_url`. Gate enforced in the service **and** re-asserted in the worker.
- **Engine bridge** (`core_bridge/`): the only code touching the engine. `audit_adapter` wraps `run_full_audit_async` and maps the score breakdown to entity-signal rows; `fix_adapter` exposes the engine's already-structured fixes as `FixProposal`s.
- **Worker**: Celery task delegating to `services.audits.execute_audit_job`; eager mode for tests/single-process dev.
- **API**: orgs, entities, verify/confirm, audit enqueue/poll, signals, health.
- **Infra**: Alembic baseline (+ Postgres RLS policies), `docker-compose` (PG + Redis + API + worker), `.env.example`, isolated `pytest.ini`, paths-filtered `platform-ci.yml`.

## 2. `src/geo_optimizer/` is untouched

Verified: `git diff main...HEAD -- src/` is **empty** — the OSS engine is byte-for-byte identical to `main`. The engine is consumed only through `core_bridge/`.

> Note on Step 4: the roadmap assumed `core/fixer.py` writes files and needed refactoring. It already returns structured `FixItem`/`FixPlan` dataclasses (disk-writing lives in the CLI) and scoring is already pure — so the engine was left frozen and the shaping was done in `core_bridge/fix_adapter.py`.

## 3. Test results

- **Platform tests**: `14 passed` (SQLite, eager Celery, engine stubbed at the bridge boundary — no network). Covers health/auth, ownership gating, the create→verify→audit→signals pipeline, failure recording, tenant isolation, and the bridge adapter.
- **Alembic**: `upgrade head` creates all 11 tables; **upgrade→downgrade roundtrip** verified clean.
- **OSS engine**: full collection succeeds (1744 tests collected); fixer/scoring slice `26 passed`. No engine regressions possible (zero `src/` changes).
- **Lint**: `ruff check platform/geoready_platform` clean.

## 4. Deliberate naming decision: `geoready_platform`

Python's stdlib owns the `platform` module; a top-level importable `platform` package would shadow it and break dependencies that `import platform` (e.g. requests/httpx). The roadmap's `platform/` **directory** is kept as the container, and the importable package inside it is **`geoready_platform`** (`platform/` is placed on `sys.path`). This is the one intentional deviation from the literal roadmap text — documented in the package docstring and `platform/README.md`.

## 5. Known non-blocking risks

- **RLS scaffolded, not fully enforced.** The baseline enables Postgres RLS policies keyed on `current_setting('app.current_org')`, but the app does not yet `SET app.current_org` per request and the table owner bypasses RLS. **Today tenant isolation rests on the application-layer `org_id` scoping** (tested).
- **Postgres behavior not covered in CI.** Tests run on SQLite; the Postgres path (RLS, JSON ops, concurrency) is exercised only via `docker-compose` manually.
- **Quota is a DB-count daily limit**, not the Redis token bucket the roadmap mentioned. Simpler and testable; swap later.
- **Dev JWT secret** defaults to `dev-insecure-change-me` and **must be overridden** (`GR_JWT_SECRET`) in production; no startup enforcement yet.

## 6. Phase 1 hardening items

- [ ] **Enforce RLS end-to-end**: connect as a non-owner DB role and `SET app.current_org` per request (defense-in-depth behind app scoping).
- [ ] **Add Postgres to CI**: run the platform suite against a Postgres service to cover RLS/JSON/concurrency.
- [ ] (Follow-ups) Redis token-bucket rate limiting; startup assertion that `GR_JWT_SECRET` was changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)