### PR TITLE
fix(cli): report in English only, and explain a skipped section

### DIFF
--- a/src/geo_optimizer/cli/formatters.py
+++ b/src/geo_optimizer/cli/formatters.py
@@ -373,25 +373,25 @@ def format_audit_text(result: AuditResult) -> str:
         lines.append(f"  [{bar}] {be_pts}/10")
         if be.brand_name_consistent:
             names = ", ".join(be.names_found[:3]) if be.names_found else ""
-            lines.append(f"  ✅ Brand name coerente{f' ({names})' if names else ''}")
+            lines.append(f"  ✅ Brand name consistent{f' ({names})' if names else ''}")
         else:
-            lines.append("  ⚠️  Brand name incoerente tra schema, meta e contenuto")
+            lines.append("  ⚠️  Brand name inconsistent across schema, meta and content")
         if be.kg_pillar_count > 0:
             lines.append(f"  ✅ {be.kg_pillar_count}/4 Knowledge Graph pillars")
         else:
-            lines.append("  ⚠️  Nessun link a Knowledge Graph (Wikipedia, Wikidata, LinkedIn)")
+            lines.append("  ⚠️  No Knowledge Graph links (Wikipedia, Wikidata, LinkedIn)")
         if be.has_about_link:
-            lines.append("  ✅ About page collegata")
+            lines.append("  ✅ About page linked")
         else:
-            lines.append("  ⚠️  About page non rilevata")
+            lines.append("  ⚠️  About page not detected")
         if be.has_contact_info:
-            lines.append("  ✅ Informazioni di contatto presenti")
+            lines.append("  ✅ Contact information present")
         else:
-            lines.append("  ⚠️  Informazioni di contatto mancanti")
+            lines.append("  ⚠️  Contact information missing")
         if be.faq_depth > 0:
-            lines.append(f"  ✅ {be.faq_depth} FAQ trovate")
+            lines.append(f"  ✅ {be.faq_depth} FAQs found")
         if be.has_recent_articles:
-            lines.append("  ✅ Articoli con dateModified trovati")
+            lines.append("  ✅ Articles with dateModified found")
 
     # CDN Check
     if result.cdn_check and result.cdn_check.checked:
@@ -465,13 +465,21 @@ def format_audit_text(result: AuditResult) -> str:
         lines.append(f"  Chunk readiness: {rc.chunk_readiness_score}/100")
 
     # Embedding Proximity (#354)
+    # Printed even when skipped (#509): the check needs the optional
+    # sentence-transformers extra, and silently omitting the section left a hole in
+    # the numbering — 13 followed by 15 — which reads as a bug rather than as a
+    # missing optional dependency. The reason is already recorded upstream in
+    # audit_embedding.py; this only surfaces it.
     ep = getattr(result, "embedding_proximity", None)
-    if ep and ep.checked and not ep.skipped_reason:
+    if ep and ep.checked:
         lines.append("")
         lines.append(_section_header("14. EMBEDDING PROXIMITY"))
-        lines.append(f"  Model: {ep.model_name}")
-        lines.append(f"  Avg similarity: {ep.avg_similarity:.4f} | Top: {ep.top_similarity:.4f}")
-        lines.append(f"  Retrievable chunks: {ep.retrievable_chunks}/{ep.total_chunks}")
+        if ep.skipped_reason:
+            lines.append(f"  ⏭️  Skipped: {ep.skipped_reason}")
+        else:
+            lines.append(f"  Model: {ep.model_name}")
+            lines.append(f"  Avg similarity: {ep.avg_similarity:.4f} | Top: {ep.top_similarity:.4f}")
+            lines.append(f"  Retrievable chunks: {ep.retrievable_chunks}/{ep.total_chunks}")
 
     # Content Decay Predictor (#383)
     cd = getattr(result, "content_decay", None)

--- a/src/geo_optimizer/cli/rich_formatter.py
+++ b/src/geo_optimizer/cli/rich_formatter.py
@@ -391,7 +391,7 @@ def _build_schema_card(result: AuditResult, score: int, max_score: int) -> Panel
     content_parts.append(Text())
 
     if not result.schema.found_types:
-        content_parts.append(Text("  Nessuno schema trovato", style=f"italic {_COLORS['dim']}"))
+        content_parts.append(Text("  No schema found", style=f"italic {_COLORS['dim']}"))
     else:
         # Schemas found as inline tags
         types_text = Text("  ")
@@ -674,9 +674,9 @@ def _build_brand_entity_card(result: AuditResult, score: int, max_score: int) ->
     # Brand name consistency
     coherence = Text("  ")
     if be.brand_name_consistent:
-        coherence.append("✓ Brand name coerente", style=_COLORS["excellent"])
+        coherence.append("✓ Brand name consistent", style=_COLORS["excellent"])
     else:
-        coherence.append("✗ Brand name incoerente", style=_COLORS["critical"])
+        coherence.append("✗ Brand name inconsistent", style=_COLORS["critical"])
     if be.names_found:
         coherence.append(f"  ({', '.join(be.names_found[:3])})", style=_COLORS["dim"])
     content_parts.append(coherence)

--- a/tests/test_coverage_m1.py
+++ b/tests/test_coverage_m1.py
@@ -715,14 +715,17 @@ class TestRichFormatter:
         reason="rich non installato",
     )
     def test_format_audit_rich_schema_nessuno(self):
-        """Senza schema, l'output mostra 'Nessuno schema'."""
+        """Senza schema, l'output segnala l'assenza in inglese."""
         from geo_optimizer.cli.rich_formatter import format_audit_rich
 
         result = _crea_audit_result_vuoto()
         output = format_audit_rich(result)
 
-        # v2: testo in italiano "Nessuno schema trovato"
-        assert "Nessuno schema" in output
+        # Era "Nessuno schema trovato": una delle stringhe italiane hardcoded
+        # nel report inglese, segnalate nella issue #509. Il test asseriva il bug
+        # come comportamento atteso, quindi è stato aggiornato insieme al fix.
+        assert "No schema found" in output
+        assert "Nessuno schema" not in output
 
     def test_score_color_returns_color(self):
         """_score_color() ritorna un colore hex basato sulla percentuale."""

--- a/tests/test_issue_509_i18n_and_skipped_sections.py
+++ b/tests/test_issue_509_i18n_and_skipped_sections.py
@@ -1,0 +1,113 @@
+"""Issue #509 — no Italian in the English report, and no silent section gaps.
+
+Two defects reported together by a user running 4.15.0 on Windows:
+  * section 8 printed four Italian strings inside an otherwise English report;
+  * the numbering jumped 13 -> 15, which reads as a bug.
+
+The second one was not a bug in the section: EMBEDDING PROXIMITY is conditional on
+the optional sentence-transformers extra. The bug was that the formatter recorded
+why it skipped and then never said so.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parent.parent / "src/geo_optimizer/cli"
+
+# Italian words that leaked. Matched as whole words so English text that merely
+# contains these letter sequences does not trip the test.
+_ITALIAN = (
+    "coerente",
+    "incoerente",
+    "presenti",
+    "mancanti",
+    "trovate",
+    "trovati",
+    "collegata",
+    "rilevata",
+    "Nessuno",
+    "Nessun",
+    "Articoli",
+    "Informazioni",
+)
+
+
+def _user_facing_strings(path: Path) -> list[str]:
+    """String literals from the file, minus comments and docstrings."""
+    text = path.read_text(encoding="utf-8")
+    text = re.sub(r'""".*?"""', "", text, flags=re.DOTALL)
+    text = re.sub(r"^\s*#.*$", "", text, flags=re.MULTILINE)
+    return re.findall(r'"([^"\n]{4,})"', text)
+
+
+class TestNoItalianLeak:
+    def test_text_formatter_is_english(self):
+        offenders = [
+            s for s in _user_facing_strings(_SRC / "formatters.py") if any(re.search(rf"\b{w}\b", s) for w in _ITALIAN)
+        ]
+        assert not offenders, f"Italian strings still in the text formatter: {offenders}"
+
+    def test_rich_formatter_is_english(self):
+        offenders = [
+            s
+            for s in _user_facing_strings(_SRC / "rich_formatter.py")
+            if any(re.search(rf"\b{w}\b", s) for w in _ITALIAN)
+        ]
+        assert not offenders, f"Italian strings still in the rich formatter: {offenders}"
+
+    def test_the_exact_strings_from_the_report_are_gone(self):
+        """The four lines the reporter pasted, verbatim."""
+        blob = (_SRC / "formatters.py").read_text(encoding="utf-8")
+        for reported in (
+            "Brand name coerente",
+            "About page collegata",
+            "Informazioni di contatto presenti",
+            "Knowledge Graph pillars",  # this one stays: it is English
+        ):
+            if reported == "Knowledge Graph pillars":
+                assert reported in blob, "the English label was removed by mistake"
+            else:
+                assert reported not in blob, f"still present: {reported}"
+
+
+class TestSkippedSectionIsExplained:
+    """A conditional section must say it was skipped, not vanish."""
+
+    def _render(self, *, skipped: str | None):
+        """Render a real AuditResult, reusing the fixture helper the suite already
+        has. A hand-rolled stand-in silently diverges from the dataclass and turns a
+        formatter change into an unrelated AttributeError."""
+        from geo_optimizer.cli.formatters import format_audit_text
+        from geo_optimizer.models.results import EmbeddingProximityResult
+        from tests.test_v21_coverage import _make_audit_result
+
+        ep = EmbeddingProximityResult(
+            checked=True,
+            skipped_reason=skipped,
+            model_name="all-MiniLM-L6-v2",
+            avg_similarity=0.42,
+            top_similarity=0.81,
+            retrievable_chunks=3,
+            total_chunks=7,
+        )
+        result = _make_audit_result()
+        result.embedding_proximity = ep
+        return format_audit_text(result)
+
+    def test_skipped_section_states_the_reason(self):
+        out = self._render(skipped="sentence-transformers not installed (pip install geo-optimizer-skill[embedding])")
+        assert "14. EMBEDDING PROXIMITY" in out, "the section header must still appear"
+        assert "Skipped" in out
+        assert "sentence-transformers" in out, "the actionable reason must reach the user"
+
+    def test_numbering_has_no_hole_when_skipped(self):
+        """The reporter's actual symptom: 13 followed by 15."""
+        out = self._render(skipped="sentence-transformers not installed")
+        assert "14." in out
+
+    def test_completed_section_still_prints_the_metrics(self):
+        out = self._render(skipped=None)
+        assert "Model: all-MiniLM-L6-v2" in out
+        assert "Skipped" not in out


### PR DESCRIPTION
Closes #509.

Two defects reported together by a user running 4.15.0 on Windows.

## Language leak

Twelve strings were hardcoded in Italian inside an otherwise English report — nine in the text formatter's `BRAND & ENTITY SIGNALS` section, three in the rich formatter. Every English user saw them; nothing configuration-dependent.

The reporter listed four; the other eight sit on the negative branches their site happened not to hit. The i18n layer is imported "for future use" only (see the module docstring), so the consistent fix is English literals rather than a half-wired `gettext` call.

## The "missing" section 14

Not a missing section. `EMBEDDING PROXIMITY` is conditional on the optional `sentence-transformers` extra, and the formatter used `skipped_reason` **solely to hide the section** — never to print it. The reason string already exists upstream in `audit_embedding.py` and names the exact pip command, so the user got a hole in the numbering (13 followed by 15) instead of one actionable line.

The header now always prints when the check ran:

```
  14. EMBEDDING PROXIMITY
  ⏭️  Skipped: sentence-transformers not installed (pip install geo-optimizer-skill[embedding])
```

## Note on an existing test

`test_coverage_m1.py` asserted `"Nessuno schema" in output`, pinning the bug in place as expected behaviour. Updated alongside the fix; it now asserts the English string and the absence of Italian.

## Verification

- 6 new tests, covering both defects — including the exact strings pasted in the issue and the numbering gap
- Suite: **1777 passed, 0 failed**
- Ruff: clean on every touched file