### PR TITLE
ci(cms): bring the scheduled-publish workflow onto the default branch

### DIFF
--- a/.github/workflows/sanity-scheduled-publish.yml
+++ b/.github/workflows/sanity-scheduled-publish.yml
@@ -1,0 +1,85 @@
+name: Publish scheduled Sanity articles
+
+on:
+  schedule:
+    - cron: '*/10 * * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Verify the due articles without changing Sanity or deploying.
+        required: false
+        default: true
+        type: boolean
+      force_deploy:
+        description: Rebuild the static site even when no article is promoted (recovery only).
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sanity-scheduled-publish
+  cancel-in-progress: false
+
+env:
+  DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
+  FORCE_DEPLOY: ${{ github.event_name == 'workflow_dispatch' && inputs.force_deploy || 'false' }}
+
+jobs:
+  publish:
+    name: Publish due articles and rebuild GeoReady
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        run: npm ci --prefix frontend
+
+      - name: Verify production automation configuration
+        env:
+          SANITY_API_TOKEN: ${{ secrets.SANITY_API_TOKEN }}
+          GEOREADY_DEPLOY_WEBHOOK_URL: ${{ secrets.GEOREADY_DEPLOY_WEBHOOK_URL }}
+        run: |
+          if [[ "$DRY_RUN" == "true" ]]; then
+            exit 0
+          fi
+          if [[ -z "$SANITY_API_TOKEN" ]]; then
+            echo "::error::Missing SANITY_API_TOKEN repository secret."
+            exit 1
+          fi
+          if [[ -z "$GEOREADY_DEPLOY_WEBHOOK_URL" ]]; then
+            echo "::error::Missing GEOREADY_DEPLOY_WEBHOOK_URL repository secret."
+            exit 1
+          fi
+
+      - name: Publish due Sanity articles
+        id: sanity_publish
+        env:
+          SANITY_API_TOKEN: ${{ secrets.SANITY_API_TOKEN }}
+        run: |
+          args=(--json)
+          if [[ "$DRY_RUN" == "true" ]]; then
+            args+=(--dry-run)
+          fi
+          node frontend/scripts/publish-scheduled-articles.mjs "${args[@]}"
+
+      - name: Trigger the GeoReady static deployment
+        if: (steps.sanity_publish.outputs.published_count != '0' || env.FORCE_DEPLOY == 'true') && env.DRY_RUN != 'true'
+        env:
+          GEOREADY_DEPLOY_WEBHOOK_URL: ${{ secrets.GEOREADY_DEPLOY_WEBHOOK_URL }}
+          PUBLISHED_SLUGS: ${{ steps.sanity_publish.outputs.published_slugs }}
+        run: |
+          curl --fail --silent --show-error --retry 3 --retry-all-errors --connect-timeout 10 --max-time 120 \
+            --request POST \
+            --header 'Content-Type: application/json' \
+            --data "{\"event\":\"sanity-scheduled-publish\",\"slugs\":\"$PUBLISHED_SLUGS\",\"sha\":\"$GITHUB_SHA\"}" \
+            "$GEOREADY_DEPLOY_WEBHOOK_URL"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,9 @@
     "preview": "astro preview",
     "astro": "astro",
     "generate:sitemap": "node scripts/generate-sitemap.mjs",
+    "sanity:check-schedule": "node scripts/verify-scheduled-articles.mjs",
+    "sanity:publish-due:dry-run": "node scripts/publish-scheduled-articles.mjs --dry-run",
+    "sanity:publish-due": "node scripts/publish-scheduled-articles.mjs",
     "indexnow:dry-run": "node scripts/indexnow-submit.mjs",
     "indexnow:submit": "node scripts/indexnow-submit.mjs --submit"
   },

--- a/frontend/scripts/publish-scheduled-articles.mjs
+++ b/frontend/scripts/publish-scheduled-articles.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+// Promuove a "published" gli articoli Sanity con scheduledFor gia' trascorso.
+//
+// Sicurezza e operativita':
+// - --dry-run e' sempre consentito e non richiede token: legge solo il dataset pubblico.
+// - la modalita' reale richiede SANITY_API_TOKEN con permesso Editor; il token non viene
+//   mai stampato o scritto su disco.
+// - tutte le patch sono raccolte in una singola transazione, per evitare stati parziali.
+// - il workflow GitHub invoca il deploy solo se la transazione ha pubblicato contenuti.
+//
+// Uso:
+//   npm run sanity:publish-due:dry-run
+//   SANITY_API_TOKEN=... npm run sanity:publish-due
+//   node scripts/publish-scheduled-articles.mjs --json
+
+import { appendFileSync } from 'node:fs';
+import { createSanityPublicationClient, fetchDueScheduledArticles } from './sanity-publication-state.mjs';
+
+function parseArgs(argv) {
+  const flags = { dryRun: false, json: false };
+  for (const arg of argv) {
+    if (arg === '--dry-run') flags.dryRun = true;
+    else if (arg === '--json') flags.json = true;
+    else throw new Error(`Argomento non riconosciuto: ${arg}`);
+  }
+  return flags;
+}
+
+function writeGithubOutput(name, value) {
+  if (!process.env.GITHUB_OUTPUT) return;
+  appendFileSync(process.env.GITHUB_OUTPUT, `${name}=${value}\n`, 'utf8');
+}
+
+function printResult(result, json) {
+  if (json) {
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+    return;
+  }
+
+  const mode = result.dryRun ? 'DRY-RUN' : 'PUBBLICATO';
+  console.log(`Sanity scheduled publishing — ${mode}`);
+  console.log(`${result.dueCount} articolo/i scaduto/i trovato/i.`);
+  for (const article of result.articles) {
+    console.log(`  • ${article.scheduledFor}  ${article.slug || article._id}`);
+  }
+  if (result.dryRun) console.log('Nessuna modifica eseguita.');
+}
+
+async function main() {
+  const { dryRun, json } = parseArgs(process.argv.slice(2));
+  const token = process.env.SANITY_API_TOKEN;
+  if (!dryRun && !token) {
+    throw new Error('SANITY_API_TOKEN e\' obbligatorio per pubblicare gli articoli programmati.');
+  }
+
+  const client = createSanityPublicationClient(token);
+  const articles = await fetchDueScheduledArticles(client);
+  const result = {
+    dryRun,
+    dueCount: articles.length,
+    publishedCount: 0,
+    articles,
+  };
+
+  if (!dryRun && articles.length > 0) {
+    const transaction = client.transaction();
+    for (const article of articles) {
+      transaction.patch(article._id, { set: { status: 'published' } });
+    }
+    await transaction.commit();
+    result.publishedCount = articles.length;
+  }
+
+  writeGithubOutput('due_count', result.dueCount);
+  writeGithubOutput('published_count', result.publishedCount);
+  writeGithubOutput('published_slugs', articles.map((article) => article.slug).filter(Boolean).join(','));
+  printResult(result, json);
+}
+
+main().catch((error) => {
+  console.error(`Pubblicazione Sanity fallita: ${error.message}`);
+  process.exitCode = 1;
+});

--- a/frontend/scripts/sanity-publication-state.mjs
+++ b/frontend/scripts/sanity-publication-state.mjs
@@ -1,0 +1,40 @@
+// Funzioni condivise per verificare lo stato editoriale Sanity prima di una
+// generazione statica. Il dataset pubblico e' sufficiente: gli articoli
+// scheduled scaduti sono intenzionalmente interrogabili senza token.
+
+import { createClient } from '@sanity/client';
+
+const DEFAULT_PROJECT_ID = 'uvzrnk4t';
+const DEFAULT_DATASET = 'production';
+
+export const DUE_ARTICLES_QUERY = `*[
+  _type == "article" &&
+  status == "scheduled" &&
+  defined(scheduledFor) &&
+  dateTime(scheduledFor) <= dateTime(now())
+]{_id, title, "slug": slug.current, scheduledFor} | order(scheduledFor asc)`;
+
+export function createSanityPublicationClient(token) {
+  return createClient({
+    projectId: process.env.PUBLIC_SANITY_PROJECT_ID || DEFAULT_PROJECT_ID,
+    dataset: process.env.PUBLIC_SANITY_DATASET || DEFAULT_DATASET,
+    apiVersion: '2024-01-01',
+    token,
+    useCdn: false,
+  });
+}
+
+export async function fetchDueScheduledArticles(client = createSanityPublicationClient()) {
+  return client.fetch(DUE_ARTICLES_QUERY);
+}
+
+export async function assertNoDueScheduledArticles() {
+  const articles = await fetchDueScheduledArticles();
+  if (articles.length === 0) return;
+
+  const slugs = articles.map((article) => article.slug || article._id).join(', ');
+  throw new Error(
+    `${articles.length} articolo/i programmato/i e gia' scaduto/i: ${slugs}. ` +
+      'Eseguire prima la pubblicazione Sanity, poi rigenerare sitemap e sito.'
+  );
+}

--- a/frontend/scripts/verify-scheduled-articles.mjs
+++ b/frontend/scripts/verify-scheduled-articles.mjs
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+// Blocca le build statiche che altrimenti escluderebbero articoli gia' dovuti ma
+// ancora in stato "scheduled". Non modifica Sanity e non richiede un token.
+
+import { assertNoDueScheduledArticles } from './sanity-publication-state.mjs';
+
+async function main() {
+  await assertNoDueScheduledArticles();
+  console.log("Sanity: nessun articolo programmato scaduto. La build puo' proseguire.");
+}
+
+main().catch((error) => {
+  console.error(`Controllo pubblicazione Sanity fallito: ${error.message}`);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Why this is urgent

GitHub only honours `schedule` and `workflow_dispatch` for workflows present on the **default branch**. This workflow has existed on `marketing-p0-new` since 2026-07-28 and has therefore **never run once** — not on its 10-minute cron, and not manually: it does not even appear in `gh workflow list`.

The cost is a queue. **29 articles** are scheduled through 2026-11-23, and `verify-scheduled-articles.mjs` raises as soon as any of them is past its `scheduledFor` — from both `prebuild` and `generate:sitemap`. So an unpromoted article fails the entire Docker build, silently, every day, with no deploy monitoring to catch it.

**The next one is due 2026-08-13T08:00Z.**

## Scope

Ported surgically — 226 insertions, 0 deletions, nothing modified:

- the workflow itself
- the three scripts it invokes (`publish-scheduled-articles.mjs`, `sanity-publication-state.mjs`, `verify-scheduled-articles.mjs`)
- three `sanity:*` npm scripts

Nothing else from `marketing-p0-new`, which carries 44 commits of unrelated marketing work.

## One deliberate omission: `prebuild`

On `marketing-p0-new`, `prebuild` wires the verify script into every build — that is the gate which fails the deploy. Copying it here would introduce a **new way for main's CI to fail**, on a branch nobody expects it from, to fix a problem that lives on the deploy branch. The workflow calls the scripts directly and does not need the hook.

## Verification

- `@sanity/client` is already a dependency on `main` — no dependency change
- On this branch, `publish-scheduled-articles.mjs --dry-run` reads the production dataset and reports 0 overdue
- `verify-scheduled-articles.mjs` exits 0
- Both repository secrets (`SANITY_API_TOKEN`, `GEOREADY_DEPLOY_WEBHOOK_URL`) are configured

After merge, `workflow_dispatch` becomes available and the 13/08 article can be promoted before its deadline.