### PR TITLE
release: cut v4.16.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,16 +43,7 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest tests/ -v --tb=short --cov=geo_optimizer --cov-report=xml --cov-report=term-missing
-
-      - name: Upload coverage to Codecov
-        if: matrix.python-version == '3.12'
-        uses: codecov/codecov-action@v6
-        with:
-          files: ./coverage.xml
-          use_oidc: true
-          fail_ci_if_error: false
-          verbose: true
+          pytest tests/ -v --tb=short --cov=geo_optimizer --cov-report=term-missing
 
       - name: Verify CLI entry point
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Format: [Keep a Changelog](https://keepachangelog.com/) · [SemVer](https://semv
 
 ---
 
+## [4.16.1] — 2026-08-11
+
+### Fixed
+- **Report leaked Italian strings into English output (#509).** Twelve user-facing strings were hardcoded in Italian — nine in the text formatter's `BRAND & ENTITY SIGNALS` section (`Brand name coerente`, `About page collegata`, `Informazioni di contatto presenti`, and the six negative branches), three in the rich formatter (`Nessuno schema trovato`, `Brand name coerente/incoerente`). Every English user saw them; nothing configuration-dependent. The `i18n` layer is imported "for future use" only, so these are now plain English literals rather than a half-wired `gettext` call. Reported by a user running 4.15.0 on Windows, who listed the four they happened to hit.
+- **Section 14 vanished without explanation (#509).** `EMBEDDING PROXIMITY` is conditional on the optional `sentence-transformers` extra, and the formatter used `skipped_reason` solely to suppress the section — never to print it. The reason string already existed upstream in `audit_embedding.py`, naming the exact `pip install geo-optimizer-skill[embedding]` command, so users got a hole in the numbering (13 followed by 15) instead of one actionable line. The header now always prints when the check ran, with `⏭️ Skipped: <reason>` when it did not complete. A test in `test_coverage_m1.py` asserted the Italian string as expected output, pinning the bug in place; it was updated alongside the fix.
+
+### Changed
+- **Scheduled-article publishing runs from the default branch (#512).** `.github/workflows/sanity-scheduled-publish.yml` had existed on a feature branch since 2026-07-28 and never executed once: GitHub only honours `schedule` and `workflow_dispatch` for workflows present on the default branch, so neither its 10-minute cron nor a manual dispatch was reachable. With 29 articles scheduled through 2026-11-23 and the build gate raising on any overdue one, an unpromoted article failed the entire site build silently, once per day. The workflow, the three scripts it invokes, and three `sanity:*` npm scripts are now on `main`. The `prebuild` hook was deliberately not ported: it wires the gate into every build, which would add a new CI failure mode on `main` to fix a problem that lives on the deploy branch.
+- **Codecov badge and upload removed.** The badge reported `unknown`: the OIDC upload in `ci.yml` never reached Codecov, so no report was ever ingested. On a project with 1777 passing tests a badge reading `unknown` misinforms, and generating `coverage.xml` on every run served nothing. Local coverage remains available via `pytest --cov=geo_optimizer`.
+
+---
+
 ## [4.16.0] — 2026-08-06 · Ground Truth
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@
 [![PyPI](https://img.shields.io/pypi/v/geo-optimizer-skill?style=flat-square&color=3b82f6)](https://pypi.org/project/geo-optimizer-skill/)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-3776ab?style=flat-square&logo=python&logoColor=white)](https://python.org)
 [![CI](https://github.com/auriti-labs/geo-optimizer-skill/actions/workflows/ci.yml/badge.svg)](https://github.com/auriti-labs/geo-optimizer-skill/actions)
-[![codecov](https://codecov.io/gh/Auriti-Labs/geo-optimizer-skill/branch/main/graph/badge.svg)](https://app.codecov.io/gh/Auriti-Labs/geo-optimizer-skill)
-[![Tests](https://img.shields.io/badge/tests-1720%20passed-22c55e?style=flat-square)](https://github.com/Auriti-Labs/geo-optimizer-skill/actions/workflows/ci.yml)
+[![Tests](https://img.shields.io/badge/tests-1777%20passed-22c55e?style=flat-square)](https://github.com/Auriti-Labs/geo-optimizer-skill/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-22c55e?style=flat-square)](LICENSE)
 [![MCP Compatible](https://img.shields.io/badge/MCP-compatible-8b5cf6?style=flat-square)](https://modelcontextprotocol.io)
 [![Buy Me a Coffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-support-FFDD00?style=flat-square&logo=buymeacoffee&logoColor=000000)](https://buymeacoffee.com/auritidesign)
@@ -253,7 +252,7 @@ Treat AI visibility like test coverage: gate every deploy on it. The GitHub Acti
 
 ```yaml
 # .github/workflows/geo.yml
-- uses: Auriti-Labs/geo-optimizer-skill@v4.16.0
+- uses: Auriti-Labs/geo-optimizer-skill@v4.16.1
   with:
     url: https://yoursite.com
     min-score: 70        # Fail the build if the GEO score drops below 70

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "geo-optimizer-skill"
-version = "4.16.0"
+version = "4.16.1"
 description = "Generative Engine Optimization toolkit — make websites visible to AI search engines"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/geo_optimizer/__init__.py
+++ b/src/geo_optimizer/__init__.py
@@ -21,7 +21,7 @@ from importlib.metadata import version as _pkg_version
 try:
     __version__ = _pkg_version("geo-optimizer-skill")
 except PackageNotFoundError:
-    __version__ = "4.16.0"
+    __version__ = "4.16.1"
 
 # ─── Public API ──────────────────────────────────────────────────────────────
 

--- a/src/geo_optimizer/web/docs/ci-cd.md
+++ b/src/geo_optimizer/web/docs/ci-cd.md
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: Auriti-Labs/geo-optimizer-skill@v4.16.0
+      - uses: Auriti-Labs/geo-optimizer-skill@v4.16.1
         with:
           url: https://yoursite.com
 ```
@@ -46,7 +46,7 @@ That's it. The action installs Python, installs `geo-optimizer-skill`, runs the 
 ### Enforce a minimum score
 
 ```yaml
-- uses: Auriti-Labs/geo-optimizer-skill@v4.16.0
+- uses: Auriti-Labs/geo-optimizer-skill@v4.16.1
   with:
     url: https://yoursite.com
     min-score: 70
@@ -69,7 +69,7 @@ The step fails if the score drops below 70.
 ### SARIF upload (GitHub Security tab)
 
 ```yaml
-- uses: Auriti-Labs/geo-optimizer-skill@v4.16.0
+- uses: Auriti-Labs/geo-optimizer-skill@v4.16.1
   with:
     url: https://yoursite.com
     format: sarif
@@ -82,7 +82,7 @@ When `format: sarif`, results automatically appear in the **Security** tab of yo
 ### Post results as a PR comment
 
 ```yaml
-- uses: Auriti-Labs/geo-optimizer-skill@v4.16.0
+- uses: Auriti-Labs/geo-optimizer-skill@v4.16.1
   id: geo
   with:
     url: https://yoursite.com
@@ -105,7 +105,7 @@ When `format: sarif`, results automatically appear in the **Security** tab of yo
 ### JUnit output (for CI dashboards)
 
 ```yaml
-- uses: Auriti-Labs/geo-optimizer-skill@v4.16.0
+- uses: Auriti-Labs/geo-optimizer-skill@v4.16.1
   with:
     url: https://yoursite.com
     format: junit
@@ -130,7 +130,7 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: Auriti-Labs/geo-optimizer-skill@v4.16.0
+      - uses: Auriti-Labs/geo-optimizer-skill@v4.16.1
         id: geo
         with:
           url: https://yoursite.com


### PR DESCRIPTION
Patch release for the two defects reported in #509, plus the CI-side cleanup that surfaced while fixing them. **No API change.**

## Version bump

Bumped in **two** places on purpose: `pyproject.toml` and the hardcoded fallback in `src/geo_optimizer/__init__.py`. The latter is only reached when the package is not pip-installed (running from a checkout), and the two silently diverge if only one is touched.

The `@v4.16.0` pins in the CI examples are bumped too — 1 in `README.md`, 6 in `docs/ci-cd.md`. Those snippets get copied verbatim, so leaving them on the release carrying the reported bug hands it out.

## Codecov removed

The badge read `unknown`. The OIDC upload in `ci.yml` never reached Codecov, so no report was ever ingested — on a project with 1777 passing tests, a badge reading `unknown` misinforms.

Removed the badge and the upload step. `--cov-report=xml` went with it (it existed only to feed that upload); `--cov-report=term-missing` stays, it's useful in the log. Local coverage is unaffected: `pytest --cov=geo_optimizer`.

Also corrected the hardcoded `tests-1720 passed` badge — it's 1777, verified by running the suite on this branch rather than copying the number forward.

## Verification

Replicated the `publish.yml` gate rather than trusting the local environment, since that workflow installs only `.[dev]` (no `fastapi`):

| check | result |
|---|---|
| Suite, clean venv, `.[dev]` only | **1654 passed, 26 skipped** — the skips are web tests with correct `importorskip` |
| Suite, full local env | **1777 passed, 0 failed** |
| Ruff | clean |
| `twine check` | PASSED on wheel and sdist |
| Package size | 460K wheel / 572K sdist — well under the 5 MB flag |
| sdist hygiene | zero `__pycache__` / `.pyc` |
| `ci.yml` | parses as valid YAML |

## Not included, deliberately

`frontend/src/components/{Navbar,Footer}.astro` and `frontend/src/lib/{mockData,reportMapper}.ts` still carry a hardcoded `4.14.0` on this branch — stale for two releases. The right fix is porting the `vite.define` that reads `pyproject.toml` at build time (already on the deploy branch), not rewriting four string literals that go stale again at the next tag. Separate change, not part of a patch release.