### PR TITLE
fix(frontend): accept a bare hostname in every URL field

### DIFF
--- a/frontend/src/components/AuditForm.tsx
+++ b/frontend/src/components/AuditForm.tsx
@@ -1,15 +1,6 @@
 import { useState } from 'react';
 import { trackAuditStarted } from '../lib/geo_track';
-
-function isValidUrl(value: string): boolean {
-  if (!value.trim()) return false;
-  try {
-    const parsed = new URL(value);
-    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
-  } catch {
-    return false;
-  }
-}
+import { toAuditableUrl } from '../lib/urlInput';
 
 export default function AuditForm() {
   const [url, setUrl] = useState('');
@@ -26,14 +17,17 @@ export default function AuditForm() {
       return;
     }
 
-    if (!isValidUrl(trimmed)) {
-      setErrorMsg('Enter a valid URL, for example https://example.com.');
+    // toAuditableUrl supplies the scheme, so a bare "example.com" — what the
+    // placeholder shows — reaches the report page as a full URL.
+    const normalized = toAuditableUrl(trimmed);
+    if (!normalized) {
+      setErrorMsg('Enter a valid website address, for example example.com.');
       return;
     }
 
     trackAuditStarted();
     setIsLoading(true);
-    window.location.href = `/report/audit?url=${encodeURIComponent(trimmed)}`;
+    window.location.href = `/report/audit?url=${encodeURIComponent(normalized)}`;
   };
 
   return (
@@ -44,7 +38,8 @@ export default function AuditForm() {
         </label>
         <input
           id="audit-url"
-          type="url"
+          type="text"
+          inputMode="url"
           required
           placeholder="https://example.com"
           value={url}

--- a/frontend/src/components/compare/CompareContainer.tsx
+++ b/frontend/src/components/compare/CompareContainer.tsx
@@ -5,6 +5,7 @@ import ReportHeader from '../report/ReportHeader';
 import ScoreGauge from '../report/ScoreGauge';
 import CategoryBreakdown from '../report/CategoryBreakdown';
 import RecommendationList from '../report/RecommendationList';
+import { toAuditableUrl } from '../../lib/urlInput';
 
 type CompareState =
   | { status: 'idle' }
@@ -119,10 +120,14 @@ export default function CompareContainer() {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (!url1.trim() || !url2.trim()) return;
+    // Normalise before building the query string: the placeholders show bare
+    // hostnames ("site-a.com"), and the raw value used to be forwarded as-is.
+    const first = toAuditableUrl(url1);
+    const second = toAuditableUrl(url2);
+    if (!first || !second) return;
     const u = new URL(window.location.href);
-    u.searchParams.set('url1', url1.trim());
-    u.searchParams.set('url2', url2.trim());
+    u.searchParams.set('url1', first);
+    u.searchParams.set('url2', second);
     window.location.href = u.toString();
   };
 
@@ -203,7 +208,8 @@ export default function CompareContainer() {
               <label htmlFor="url1" className="block text-sm font-medium mb-2">First URL</label>
               <input
                 id="url1"
-                type="url"
+                type="text"
+                inputMode="url"
                 required
                 placeholder="https://site-a.com"
                 value={url1}
@@ -215,7 +221,8 @@ export default function CompareContainer() {
               <label htmlFor="url2" className="block text-sm font-medium mb-2">Second URL</label>
               <input
                 id="url2"
-                type="url"
+                type="text"
+                inputMode="url"
                 required
                 placeholder="https://site-b.com"
                 value={url2}

--- a/frontend/src/components/tools/LlmsTxtGenerator.tsx
+++ b/frontend/src/components/tools/LlmsTxtGenerator.tsx
@@ -8,6 +8,7 @@ import {
   trackLlmsTxtCopied,
   trackLlmsTxtDownloaded,
 } from '../../lib/geo_track';
+import { normalizeUrl, toAuditableUrl } from '../../lib/urlInput';
 
 // Stato del flusso di generazione.
 type Status = 'idle' | 'loading' | 'error' | 'success';
@@ -55,14 +56,14 @@ export default function LlmsTxtGenerator() {
     setErrorMsg('');
 
     // Validazione inline: la URL del sito è obbligatoria.
-    const trimmedWebsite = websiteUrl.trim();
+    const trimmedWebsite = toAuditableUrl(websiteUrl);
     if (!trimmedWebsite) {
       setStatus('error');
-      setErrorMsg('Enter your website URL, for example https://example.com.');
+      setErrorMsg('Enter a valid website address, for example example.com.');
       return;
     }
 
-    const trimmedSitemap = sitemapUrl.trim();
+    const trimmedSitemap = sitemapUrl.trim() ? normalizeUrl(sitemapUrl) : '';
     const hasCustomSitemap = Boolean(trimmedSitemap);
 
     trackLlmsGeneratorStarted({
@@ -138,7 +139,8 @@ export default function LlmsTxtGenerator() {
           </label>
           <input
             id="llms-website"
-            type="url"
+            type="text"
+            inputMode="url"
             required
             placeholder="https://example.com"
             value={websiteUrl}
@@ -158,7 +160,8 @@ export default function LlmsTxtGenerator() {
           </label>
           <input
             id="llms-sitemap"
-            type="url"
+            type="text"
+            inputMode="url"
             placeholder="https://example.com/sitemap.xml"
             value={sitemapUrl}
             onChange={(e) => setSitemapUrl(e.target.value)}

--- a/frontend/src/lib/urlInput.ts
+++ b/frontend/src/lib/urlInput.ts
@@ -1,0 +1,59 @@
+/**
+ * URL normalisation and validation for user-typed input.
+ *
+ * Every audit form on the site asks for a website, and every placeholder shows a
+ * bare hostname ("example.com"). The inputs used to be `type="url"`, which made
+ * the browser reject exactly that during native constraint validation — before
+ * any submit handler could prepend a scheme. Users had to type "https://" by hand
+ * to get past a field whose own placeholder told them not to.
+ *
+ * The inputs are now `type="text"` with `inputMode="url"` (URL keyboard on mobile,
+ * no scheme requirement), which moves the whole job here. `normalizeUrl` supplies
+ * the scheme; `isValidUrl` has to carry the weight `type="url"` used to, because
+ * prepending "https://" makes `new URL()` accept strings a user never meant as a
+ * site: "a" parses with hostname "a", "..." with hostname "...", and "ftp://x.com"
+ * becomes "https://ftp://x.com" with hostname "ftp".
+ *
+ * The backend normalises independently (`validators.resolve_and_validate_url`), so
+ * this is about giving a readable message instead of a server error — never the
+ * only line of defence.
+ */
+
+/** Prepend `https://` unless the value already carries an http(s) scheme. */
+export function normalizeUrl(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) return '';
+  if (!/^https?:\/\//i.test(trimmed)) {
+    return `https://${trimmed}`;
+  }
+  return trimmed;
+}
+
+/**
+ * True when `value` parses as an http(s) URL with a plausible public hostname.
+ *
+ * Pass an already-normalised value. The hostname pattern requires at least one
+ * dot-separated label plus a two-letter-or-longer TLD, which accepts subdomains,
+ * multi-part TLDs (`site.co.uk`), punycode (`xn--80ak6aa92e.com`) and explicit
+ * ports, while rejecting bare words and single labels like `localhost`.
+ */
+export function isValidUrl(value: string): boolean {
+  if (!value.trim()) return false;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return false;
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return false;
+
+  return /^[a-z0-9-]+(\.[a-z0-9-]+)*\.[a-z]{2,}$/i.test(parsed.hostname);
+}
+
+/** Normalise then validate. Returns the normalised URL, or null if unusable. */
+export function toAuditableUrl(value: string): string | null {
+  const normalized = normalizeUrl(value);
+  return isValidUrl(normalized) ? normalized : null;
+}


### PR DESCRIPTION
Five inputs across three components were `type="url"`, so the browser rejected `example.com` during **native constraint validation** — which runs *before* any submit handler. Every one of those fields shows a bare hostname as its placeholder, so the form refused exactly what it asked for, and users had to type `https://` by hand.

| component | inputs | placeholder |
|---|---|---|
| `AuditForm` | 1 | `example.com` |
| `CompareContainer` | 2 | `site-a.com`, `site-b.com` |
| `LlmsTxtGenerator` | 2 | `example.com` |

Now `type="text"` with `inputMode="url"`, which keeps the URL keyboard on mobile without the scheme requirement.

## There was no normalisation to fall back on

Removing native validation moves the whole job to JS, and on `main` none of the three components normalised: `AuditForm` passed the raw value to the report page, `CompareContainer` forwarded both raw values into the query string, `LlmsTxtGenerator` sent `base_url` to the API as typed. New shared helper in `lib/urlInput.ts` — one normalise-then-validate pair instead of three divergent copies.

## isValidUrl has to carry what type="url" did

Prepending `https://` makes `new URL()` accept strings nobody meant as a site: `a` parses with hostname `a`, `...` with hostname `...`, and `ftp://x.com` becomes `https://ftp://x.com` with hostname `ftp`. A dot-separated-label-plus-TLD check rejects those with a readable message rather than letting the backend answer with a server error.

Still accepted: subdomains, multi-part TLDs (`site.co.uk`), punycode (`xn--80ak6aa92e.com`), explicit ports.

## Related backend fix

`POST /api/public/audits` on `app.geoready.dev` answered **422** `Scheme not allowed` to the same input — same root cause, different surface. Fixed separately in the platform repo and already deployed. The backend remains the real validation boundary; this is the client half that made the fix unreachable.

## Verification

- 17/17 behavioural cases on the helper
- `astro build` clean, 58 pages
- `tsc --noEmit` introduces no new error against the `origin/main` baseline
- Built bundle contains **zero** `type:"url"`, with `inputMode:"url"` in three chunks
