### PR TITLE
fix(audit): report an HTTP error status instead of "Connection failed"

### DIFF
--- a/src/geo_optimizer/core/audit.py
+++ b/src/geo_optimizer/core/audit.py
@@ -740,12 +740,16 @@ def run_full_audit(url: str, use_cache: bool = False, project_config=None) -> Au
                 cache.put(base_url, r.status_code, r.text, dict(r.headers))
     else:
         r, err = fetch_url(base_url)  # type: ignore[assignment]
-    if err or not r:
+    # `r is None`, not `not r`: requests.Response.__bool__ is `ok`, so any 4xx/5xx
+    # is falsy and would land here — reporting "Connection failed" for a request
+    # that succeeded, and skipping the status branch below that exists to name the
+    # code and point at a WAF. Fixes the 403 reported as a connection error.
+    if err or r is None:
         result = AuditResult(
             url=base_url,
             error=str(err) if err else "Connection failed",
         )
-        result.recommendations = [f"Unable to reach {base_url}: {err}"]
+        result.recommendations = [f"Unable to reach {base_url}: {err or 'connection failed'}"]
         result.audit_duration_ms = int((time.perf_counter() - _t0) * 1000)
         return result
 

--- a/src/geo_optimizer/core/factual_accuracy.py
+++ b/src/geo_optimizer/core/factual_accuracy.py
@@ -102,7 +102,9 @@ def run_factual_accuracy_audit(url: str, max_source_checks: int = _DEFAULT_MAX_S
         base_url = "https://" + base_url
 
     response, err = fetch_url(base_url)
-    if err or not response:
+    # `response is None`: an HTTP error Response is falsy (requests sets __bool__ to
+    # `ok`), so this used to claim the page was unreachable when it had answered.
+    if err or response is None:
         return FactualAccuracyResult(
             checked=False,
             inconsistencies=[f"Unable to reach {base_url}: {err or 'connection failed'}"],
@@ -266,7 +268,10 @@ def _check_source_links(
     for link in links[: max(0, max_source_checks)]:
         result.source_links_checked += 1
         response, err = fetcher(link)
-        if err or not response:
+        # Same falsy-Response trap, but here the outcome is right for the wrong
+        # reason: a link answering 4xx/5xx IS broken. Made explicit so it does not
+        # read as an oversight.
+        if err or response is None or not response.ok:
             _append_unique(result.broken_source_links, link)
             continue
 

--- a/src/geo_optimizer/core/factual_accuracy.py
+++ b/src/geo_optimizer/core/factual_accuracy.py
@@ -268,10 +268,11 @@ def _check_source_links(
     for link in links[: max(0, max_source_checks)]:
         result.source_links_checked += 1
         response, err = fetcher(link)
-        # Same falsy-Response trap, but here the outcome is right for the wrong
-        # reason: a link answering 4xx/5xx IS broken. Made explicit so it does not
-        # read as an oversight.
-        if err or response is None or not response.ok:
+        # `response is None`, not `not response`: an HTTP error Response is falsy
+        # (requests sets __bool__ to `ok`). The outcome here was right either way —
+        # a link answering 4xx/5xx is broken — because the status check below
+        # catches it. Being explicit keeps the two cases distinguishable.
+        if err or response is None:
             _append_unique(result.broken_source_links, link)
             continue
 

--- a/src/geo_optimizer/mcp/server.py
+++ b/src/geo_optimizer/mcp/server.py
@@ -225,8 +225,10 @@ def geo_citability(url: str) -> str:
         from geo_optimizer.utils.http import fetch_url
 
         r, err = fetch_url(url)
-        if err or not r:
-            return json.dumps({"error": f"Cannot reach {url}: {err}", "url": url})
+        # `r is None`: a 4xx/5xx Response is falsy (__bool__ is `ok`), which used to
+        # report an unreachable host and interpolate err=None into the message.
+        if err or r is None:
+            return json.dumps({"error": f"Cannot reach {url}: {err or 'connection failed'}", "url": url})
 
         soup = BeautifulSoup(r.text, "html.parser")
         result = audit_citability(soup, url)

--- a/tests/test_http_error_status_reporting.py
+++ b/tests/test_http_error_status_reporting.py
@@ -1,0 +1,86 @@
+"""An HTTP error is not a connection failure.
+
+`requests.Response.__bool__` is `ok`, i.e. `status_code < 400`. So a perfectly
+valid 403 carrying a full body is *falsy*, and `if err or not r` routed it down
+the "no response at all" branch: the audit reported `error="Connection failed"`
+and `http_status=0` for a request that had completed, and the branch immediately
+below — written to name the status and point at a WAF — became unreachable for
+every status >= 400.
+
+Reported from production: https://www.netsons.com/ answers 200 to a desktop
+browser and 403 to the server, and the report read "Audit failed — Connection
+failed", which sends the user looking for a network problem that does not exist.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from geo_optimizer.core.audit import run_full_audit
+
+
+class _FakeResponse:
+    """Minimal stand-in that reproduces requests' truthiness rule."""
+
+    def __init__(self, status_code: int, text: str = "<html><body>x</body></html>"):
+        self.status_code = status_code
+        self.text = text
+        self.headers: dict[str, str] = {"content-type": "text/html"}
+        self.encoding = "utf-8"
+
+    @property
+    def ok(self) -> bool:
+        return self.status_code < 400
+
+    def __bool__(self) -> bool:
+        # This is the whole point of the test: requests does exactly this.
+        return self.ok
+
+
+class TestErrorStatusIsReportedAsSuch:
+    @pytest.mark.parametrize("status", [403, 401, 404, 429, 500, 503])
+    def test_http_error_reports_the_status_not_a_connection_failure(self, status: int):
+        with patch("geo_optimizer.core.audit.fetch_url", return_value=(_FakeResponse(status), None)):
+            result = run_full_audit("https://blocked.example")
+
+        assert result.error == f"HTTP {status}", f"a {status} must be named, got {result.error!r}"
+        assert result.http_status == status, "the status code must survive into the result"
+        assert "Connection failed" not in (result.error or "")
+
+    def test_the_waf_hint_is_reachable(self):
+        """The recommendation behind the status branch was dead code for 4xx/5xx."""
+        with patch("geo_optimizer.core.audit.fetch_url", return_value=(_FakeResponse(403), None)):
+            result = run_full_audit("https://blocked.example")
+
+        joined = " ".join(result.recommendations)
+        assert "403" in joined
+        assert "WAF" in joined or "Cloudflare" in joined
+
+    def test_a_real_transport_failure_still_reports_one(self):
+        """The fix must not swallow the case the branch was actually for."""
+        with patch(
+            "geo_optimizer.core.audit.fetch_url",
+            return_value=(None, "Connection failed dopo retry esponenziale: timeout"),
+        ):
+            result = run_full_audit("https://unreachable.example")
+
+        assert "Connection failed" in (result.error or "")
+
+    def test_no_response_and_no_error_still_degrades_readably(self):
+        """Defensive: if fetch_url ever returns (None, None), the message must not
+        interpolate a bare None — that was the "Unable to reach X: None" the user
+        saw."""
+        with patch("geo_optimizer.core.audit.fetch_url", return_value=(None, None)):
+            result = run_full_audit("https://nothing.example")
+
+        assert result.error == "Connection failed"
+        assert "None" not in " ".join(result.recommendations)
+
+    @pytest.mark.parametrize("status", [200, 203])
+    def test_success_statuses_are_still_audited(self, status: int):
+        with patch("geo_optimizer.core.audit.fetch_url", return_value=(_FakeResponse(status), None)):
+            result = run_full_audit("https://ok.example")
+
+        assert result.error is None


### PR DESCRIPTION
`requests.Response.__bool__` is `ok`, i.e. `status_code < 400`. So a perfectly valid 403 carrying a full body is **falsy**, and `if err or not r` routed it down the "no response at all" branch. An audit of a site behind a WAF reported `error="Connection failed"` and `http_status=0` for a request that had completed — and the branch immediately below, written to name the status and point at a Cloudflare/WAF block, was **unreachable for every status >= 400**.

## Reported from production

`https://www.netsons.com/` answers 200 to a desktop browser and 403 to the server (datacenter-IP block). The report read *"Audit failed — Connection failed"*, which sends the user looking for a network problem that does not exist.

Confirmed from inside the running container: `status 403`, 5513 bytes of body, `err None`, `bool(r) False`.

Verified on the same server, before and after:

| | before | after |
|---|---|---|
| `error` | `Connection failed` | `HTTP 403` |
| `http_status` | `0` | `403` |
| recommendation | `Unable to reach X: None` | `Site returned HTTP 403. Check for Cloudflare/WAF blocks or server errors.` |

## The fix

`r is None` is the check the code meant. `err` already covers transport failures; the status branch covers HTTP errors. The recommendation string also interpolated a bare `err`, printing `Unable to reach X: None` whenever the response was falsy rather than absent.

Same shape corrected in `mcp/server.py` (message only) and `factual_accuracy.py`. In the broken-source-link loop the outcome was already right for the wrong reason — a link answering 4xx/5xx *is* broken — so the check is now explicit rather than relying on truthiness.

**Left alone:** `audit_robots.py`, `audit_llms.py`, `topic_authority.py` and `llms_generator.py` use the same pattern, but each is immediately followed by a `status_code != 200` guard or a `continue`, so the falsy Response changes nothing observable there.

## Verification

- 11 new tests, parametrised over 401/403/404/429/500/503
- Includes that a real transport failure still reports one, and that `(None, None)` does not print a bare `None`
- **8 of the 11 fail against the unfixed code** — verified by stashing the fix, so they demonstrate the defect rather than describing it
- Suite: 1788 passed, 0 failed. Ruff clean.
