### PR TITLE
release: cut v4.16.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Format: [Keep a Changelog](https://keepachangelog.com/) · [SemVer](https://semv
 
 ---
 
+## [4.16.2] — 2026-08-11
+
+### Fixed
+- **An HTTP error status was reported as "Connection failed".** `requests.Response.__bool__` is `ok`, i.e. `status_code < 400`, so a perfectly valid 403 carrying a full body is *falsy*. `if err or not r` therefore routed it down the "no response at all" branch: the audit reported `error="Connection failed"` and `http_status=0` for a request that had completed, and the branch immediately below — written to name the status and point at a Cloudflare/WAF block — was unreachable for every status ≥ 400. Reported from production, where a site answering 200 to a desktop browser and 403 to the server produced "Audit failed — Connection failed", sending the user after a network problem that did not exist. The recommendation string also interpolated a bare `err`, printing "Unable to reach X: None". Now `r is None`: `err` covers transport failures, the status branch covers HTTP errors. Same shape corrected in `mcp/server.py` and `factual_accuracy.py`; left alone in four other call sites where a `status_code != 200` guard or a `continue` immediately follows, so the falsy Response changes nothing observable.
+- **Every URL field rejected a bare hostname.** Five inputs across `AuditForm`, `CompareContainer` and `LlmsTxtGenerator` were `type="url"`, so the browser rejected `example.com` during native constraint validation — which runs *before* any submit handler, making JS normalisation unreachable. Every one of those fields shows a bare hostname as its placeholder, so each form refused exactly what it asked for. Now `type="text"` with `inputMode="url"` (URL keyboard on mobile, no scheme requirement) plus a shared `lib/urlInput.ts` helper, since none of the three components normalised on this branch. The hostname check there carries the weight `type="url"` used to: prepending `https://` makes `new URL()` accept `a`, `...` and `ftp://x.com`, which are now rejected with a readable message instead of a server error.
+
+---
+
 ## [4.16.1] — 2026-08-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![PyPI](https://img.shields.io/pypi/v/geo-optimizer-skill?style=flat-square&color=3b82f6)](https://pypi.org/project/geo-optimizer-skill/)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-3776ab?style=flat-square&logo=python&logoColor=white)](https://python.org)
 [![CI](https://github.com/auriti-labs/geo-optimizer-skill/actions/workflows/ci.yml/badge.svg)](https://github.com/auriti-labs/geo-optimizer-skill/actions)
-[![Tests](https://img.shields.io/badge/tests-1777%20passed-22c55e?style=flat-square)](https://github.com/Auriti-Labs/geo-optimizer-skill/actions/workflows/ci.yml)
+[![Tests](https://img.shields.io/badge/tests-1788%20passed-22c55e?style=flat-square)](https://github.com/Auriti-Labs/geo-optimizer-skill/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-22c55e?style=flat-square)](LICENSE)
 [![MCP Compatible](https://img.shields.io/badge/MCP-compatible-8b5cf6?style=flat-square)](https://modelcontextprotocol.io)
 [![Buy Me a Coffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-support-FFDD00?style=flat-square&logo=buymeacoffee&logoColor=000000)](https://buymeacoffee.com/auritidesign)
@@ -252,7 +252,7 @@ Treat AI visibility like test coverage: gate every deploy on it. The GitHub Acti
 
 ```yaml
 # .github/workflows/geo.yml
-- uses: Auriti-Labs/geo-optimizer-skill@v4.16.1
+- uses: Auriti-Labs/geo-optimizer-skill@v4.16.2
   with:
     url: https://yoursite.com
     min-score: 70        # Fail the build if the GEO score drops below 70

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "geo-optimizer-skill"
-version = "4.16.1"
+version = "4.16.2"
 description = "Generative Engine Optimization toolkit — make websites visible to AI search engines"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/geo_optimizer/__init__.py
+++ b/src/geo_optimizer/__init__.py
@@ -21,7 +21,7 @@ from importlib.metadata import version as _pkg_version
 try:
     __version__ = _pkg_version("geo-optimizer-skill")
 except PackageNotFoundError:
-    __version__ = "4.16.1"
+    __version__ = "4.16.2"
 
 # ─── Public API ──────────────────────────────────────────────────────────────
 

--- a/src/geo_optimizer/web/docs/ci-cd.md
+++ b/src/geo_optimizer/web/docs/ci-cd.md
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: Auriti-Labs/geo-optimizer-skill@v4.16.1
+      - uses: Auriti-Labs/geo-optimizer-skill@v4.16.2
         with:
           url: https://yoursite.com
 ```
@@ -46,7 +46,7 @@ That's it. The action installs Python, installs `geo-optimizer-skill`, runs the 
 ### Enforce a minimum score
 
 ```yaml
-- uses: Auriti-Labs/geo-optimizer-skill@v4.16.1
+- uses: Auriti-Labs/geo-optimizer-skill@v4.16.2
   with:
     url: https://yoursite.com
     min-score: 70
@@ -69,7 +69,7 @@ The step fails if the score drops below 70.
 ### SARIF upload (GitHub Security tab)
 
 ```yaml
-- uses: Auriti-Labs/geo-optimizer-skill@v4.16.1
+- uses: Auriti-Labs/geo-optimizer-skill@v4.16.2
   with:
     url: https://yoursite.com
     format: sarif
@@ -82,7 +82,7 @@ When `format: sarif`, results automatically appear in the **Security** tab of yo
 ### Post results as a PR comment
 
 ```yaml
-- uses: Auriti-Labs/geo-optimizer-skill@v4.16.1
+- uses: Auriti-Labs/geo-optimizer-skill@v4.16.2
   id: geo
   with:
     url: https://yoursite.com
@@ -105,7 +105,7 @@ When `format: sarif`, results automatically appear in the **Security** tab of yo
 ### JUnit output (for CI dashboards)
 
 ```yaml
-- uses: Auriti-Labs/geo-optimizer-skill@v4.16.1
+- uses: Auriti-Labs/geo-optimizer-skill@v4.16.2
   with:
     url: https://yoursite.com
     format: junit
@@ -130,7 +130,7 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: Auriti-Labs/geo-optimizer-skill@v4.16.1
+      - uses: Auriti-Labs/geo-optimizer-skill@v4.16.2
         id: geo
         with:
           url: https://yoursite.com


### PR DESCRIPTION
Patch release for the two defects reported from production today. **No API change.**

Both were the same class of problem: a check that looked right and silently did the wrong thing.

## What it fixes

**A 403 was reported as "Connection failed"** (#515). `requests.Response.__bool__` is `ok`, so an error response is falsy and took the "no response at all" branch — reporting a connection failure for a request that had completed, with `http_status=0`, and making the WAF-hint branch below unreachable for every status ≥ 400.

**Every URL field rejected a bare hostname** (#514). Five inputs were `type="url"`, so native constraint validation ran *before* any JS could add a scheme — each form refused exactly the hostname its own placeholder showed.

## Version bump

Bumped in **both** places again: `pyproject.toml` and the hardcoded fallback in `src/geo_optimizer/__init__.py`. The `@v4.16.1` pins in the README and `docs/ci-cd.md` CI examples follow, since users copy those verbatim.

The tests badge reads 1788, verified by running the suite on this branch rather than copying the number forward.

## Verification

Replicated the `publish.yml` gate rather than trusting the local environment:

| check | result |
|---|---|
| Suite, clean venv, `.[dev]` only (no `fastapi`) | **1665 passed, 26 skipped** |
| Suite, full local env | **1788 passed** |
| **mypy** (the CI Lint step runs it) | **29 = 29** against the `origin/main` baseline — all pre-existing, missing stubs locally |
| ruff | clean |
| `twine check` | PASSED on wheel and sdist |
| Package size | 460K wheel / 572K sdist |

The mypy comparison is not a formality: it caught a `response.ok` call in #515 that failed the CI Lint step while ruff passed locally.

## Note for the deploy side

`geoready.dev` is served from `marketing-p0-new`, currently 13 commits behind `main`. These fixes will not be visible on the site until that branch is aligned — separate change, planned with care because `main` lacks the GDPR consent manager that lives on the deploy branch.
