### PR TITLE
fix: bring the 4.16.x audit and URL fixes onto the deploy branch

### DIFF
--- a/frontend/src/components/AuditForm.tsx
+++ b/frontend/src/components/AuditForm.tsx
@@ -1,15 +1,6 @@
 import { useState } from 'react';
 import { trackAuditStarted } from '../lib/geo_track';
-
-function isValidUrl(value: string): boolean {
-  if (!value.trim()) return false;
-  try {
-    const parsed = new URL(value);
-    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
-  } catch {
-    return false;
-  }
-}
+import { toAuditableUrl } from '../lib/urlInput';
 
 export default function AuditForm() {
   const [url, setUrl] = useState('');
@@ -26,14 +17,17 @@ export default function AuditForm() {
       return;
     }
 
-    if (!isValidUrl(trimmed)) {
-      setErrorMsg('Enter a valid URL, for example https://example.com.');
+    // toAuditableUrl supplies the scheme, so a bare "example.com" — what the
+    // placeholder shows — reaches the report page as a full URL.
+    const normalized = toAuditableUrl(trimmed);
+    if (!normalized) {
+      setErrorMsg('Enter a valid website address, for example example.com.');
       return;
     }
 
     trackAuditStarted();
     setIsLoading(true);
-    window.location.href = `/report/audit?url=${encodeURIComponent(trimmed)}`;
+    window.location.href = `/report/audit?url=${encodeURIComponent(normalized)}`;
   };
 
   return (
@@ -44,7 +38,8 @@ export default function AuditForm() {
         </label>
         <input
           id="audit-url"
-          type="url"
+          type="text"
+          inputMode="url"
           required
           placeholder="https://example.com"
           value={url}

--- a/frontend/src/components/compare/CompareContainer.tsx
+++ b/frontend/src/components/compare/CompareContainer.tsx
@@ -5,6 +5,7 @@ import ReportHeader from '../report/ReportHeader';
 import ScoreGauge from '../report/ScoreGauge';
 import CategoryBreakdown from '../report/CategoryBreakdown';
 import RecommendationList from '../report/RecommendationList';
+import { toAuditableUrl } from '../../lib/urlInput';
 
 type CompareState =
   | { status: 'idle' }
@@ -119,10 +120,14 @@ export default function CompareContainer() {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (!url1.trim() || !url2.trim()) return;
+    // Normalise before building the query string: the placeholders show bare
+    // hostnames ("site-a.com"), and the raw value used to be forwarded as-is.
+    const first = toAuditableUrl(url1);
+    const second = toAuditableUrl(url2);
+    if (!first || !second) return;
     const u = new URL(window.location.href);
-    u.searchParams.set('url1', url1.trim());
-    u.searchParams.set('url2', url2.trim());
+    u.searchParams.set('url1', first);
+    u.searchParams.set('url2', second);
     window.location.href = u.toString();
   };
 
@@ -203,7 +208,8 @@ export default function CompareContainer() {
               <label htmlFor="url1" className="block text-sm font-medium mb-2">First URL</label>
               <input
                 id="url1"
-                type="url"
+                type="text"
+                inputMode="url"
                 required
                 placeholder="https://site-a.com"
                 value={url1}
@@ -215,7 +221,8 @@ export default function CompareContainer() {
               <label htmlFor="url2" className="block text-sm font-medium mb-2">Second URL</label>
               <input
                 id="url2"
-                type="url"
+                type="text"
+                inputMode="url"
                 required
                 placeholder="https://site-b.com"
                 value={url2}

--- a/frontend/src/components/tools/LlmsTxtGenerator.tsx
+++ b/frontend/src/components/tools/LlmsTxtGenerator.tsx
@@ -9,6 +9,7 @@ import {
   trackLlmsTxtDownloaded,
   trackPlanSelected,
 } from '../../lib/geo_track';
+import { normalizeUrl, toAuditableUrl } from '../../lib/urlInput';
 
 // Stato del flusso di generazione.
 type Status = 'idle' | 'loading' | 'error' | 'success';
@@ -56,14 +57,14 @@ export default function LlmsTxtGenerator() {
     setErrorMsg('');
 
     // Validazione inline: la URL del sito è obbligatoria.
-    const trimmedWebsite = websiteUrl.trim();
+    const trimmedWebsite = toAuditableUrl(websiteUrl);
     if (!trimmedWebsite) {
       setStatus('error');
       setErrorMsg('Enter your website URL, for example https://example.com.');
       return;
     }
 
-    const trimmedSitemap = sitemapUrl.trim();
+    const trimmedSitemap = sitemapUrl.trim() ? normalizeUrl(sitemapUrl) : '';
     const hasCustomSitemap = Boolean(trimmedSitemap);
 
     trackLlmsGeneratorStarted({
@@ -139,7 +140,8 @@ export default function LlmsTxtGenerator() {
           </label>
           <input
             id="llms-website"
-            type="url"
+            type="text"
+            inputMode="url"
             required
             placeholder="https://example.com"
             value={websiteUrl}
@@ -159,7 +161,8 @@ export default function LlmsTxtGenerator() {
           </label>
           <input
             id="llms-sitemap"
-            type="url"
+            type="text"
+            inputMode="url"
             placeholder="https://example.com/sitemap.xml"
             value={sitemapUrl}
             onChange={(e) => setSitemapUrl(e.target.value)}

--- a/frontend/src/lib/urlInput.ts
+++ b/frontend/src/lib/urlInput.ts
@@ -1,0 +1,59 @@
+/**
+ * URL normalisation and validation for user-typed input.
+ *
+ * Every audit form on the site asks for a website, and every placeholder shows a
+ * bare hostname ("example.com"). The inputs used to be `type="url"`, which made
+ * the browser reject exactly that during native constraint validation — before
+ * any submit handler could prepend a scheme. Users had to type "https://" by hand
+ * to get past a field whose own placeholder told them not to.
+ *
+ * The inputs are now `type="text"` with `inputMode="url"` (URL keyboard on mobile,
+ * no scheme requirement), which moves the whole job here. `normalizeUrl` supplies
+ * the scheme; `isValidUrl` has to carry the weight `type="url"` used to, because
+ * prepending "https://" makes `new URL()` accept strings a user never meant as a
+ * site: "a" parses with hostname "a", "..." with hostname "...", and "ftp://x.com"
+ * becomes "https://ftp://x.com" with hostname "ftp".
+ *
+ * The backend normalises independently (`validators.resolve_and_validate_url`), so
+ * this is about giving a readable message instead of a server error — never the
+ * only line of defence.
+ */
+
+/** Prepend `https://` unless the value already carries an http(s) scheme. */
+export function normalizeUrl(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) return '';
+  if (!/^https?:\/\//i.test(trimmed)) {
+    return `https://${trimmed}`;
+  }
+  return trimmed;
+}
+
+/**
+ * True when `value` parses as an http(s) URL with a plausible public hostname.
+ *
+ * Pass an already-normalised value. The hostname pattern requires at least one
+ * dot-separated label plus a two-letter-or-longer TLD, which accepts subdomains,
+ * multi-part TLDs (`site.co.uk`), punycode (`xn--80ak6aa92e.com`) and explicit
+ * ports, while rejecting bare words and single labels like `localhost`.
+ */
+export function isValidUrl(value: string): boolean {
+  if (!value.trim()) return false;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return false;
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return false;
+
+  return /^[a-z0-9-]+(\.[a-z0-9-]+)*\.[a-z]{2,}$/i.test(parsed.hostname);
+}
+
+/** Normalise then validate. Returns the normalised URL, or null if unusable. */
+export function toAuditableUrl(value: string): string | null {
+  const normalized = normalizeUrl(value);
+  return isValidUrl(normalized) ? normalized : null;
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "geo-optimizer-skill"
-version = "4.15.0"
+version = "4.16.2"
 description = "Generative Engine Optimization toolkit — make websites visible to AI search engines"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/geo_optimizer/__init__.py
+++ b/src/geo_optimizer/__init__.py
@@ -21,7 +21,7 @@ from importlib.metadata import version as _pkg_version
 try:
     __version__ = _pkg_version("geo-optimizer-skill")
 except PackageNotFoundError:
-    __version__ = "4.15.0"
+    __version__ = "4.16.2"
 
 # ─── Public API ──────────────────────────────────────────────────────────────
 

--- a/src/geo_optimizer/cli/formatters.py
+++ b/src/geo_optimizer/cli/formatters.py
@@ -373,25 +373,25 @@ def format_audit_text(result: AuditResult) -> str:
         lines.append(f"  [{bar}] {be_pts}/10")
         if be.brand_name_consistent:
             names = ", ".join(be.names_found[:3]) if be.names_found else ""
-            lines.append(f"  ✅ Brand name coerente{f' ({names})' if names else ''}")
+            lines.append(f"  ✅ Brand name consistent{f' ({names})' if names else ''}")
         else:
-            lines.append("  ⚠️  Brand name incoerente tra schema, meta e contenuto")
+            lines.append("  ⚠️  Brand name inconsistent across schema, meta and content")
         if be.kg_pillar_count > 0:
             lines.append(f"  ✅ {be.kg_pillar_count}/4 Knowledge Graph pillars")
         else:
-            lines.append("  ⚠️  Nessun link a Knowledge Graph (Wikipedia, Wikidata, LinkedIn)")
+            lines.append("  ⚠️  No Knowledge Graph links (Wikipedia, Wikidata, LinkedIn)")
         if be.has_about_link:
-            lines.append("  ✅ About page collegata")
+            lines.append("  ✅ About page linked")
         else:
-            lines.append("  ⚠️  About page non rilevata")
+            lines.append("  ⚠️  About page not detected")
         if be.has_contact_info:
-            lines.append("  ✅ Informazioni di contatto presenti")
+            lines.append("  ✅ Contact information present")
         else:
-            lines.append("  ⚠️  Informazioni di contatto mancanti")
+            lines.append("  ⚠️  Contact information missing")
         if be.faq_depth > 0:
-            lines.append(f"  ✅ {be.faq_depth} FAQ trovate")
+            lines.append(f"  ✅ {be.faq_depth} FAQs found")
         if be.has_recent_articles:
-            lines.append("  ✅ Articoli con dateModified trovati")
+            lines.append("  ✅ Articles with dateModified found")
 
     # CDN Check
     if result.cdn_check and result.cdn_check.checked:
@@ -465,13 +465,21 @@ def format_audit_text(result: AuditResult) -> str:
         lines.append(f"  Chunk readiness: {rc.chunk_readiness_score}/100")
 
     # Embedding Proximity (#354)
+    # Printed even when skipped (#509): the check needs the optional
+    # sentence-transformers extra, and silently omitting the section left a hole in
+    # the numbering — 13 followed by 15 — which reads as a bug rather than as a
+    # missing optional dependency. The reason is already recorded upstream in
+    # audit_embedding.py; this only surfaces it.
     ep = getattr(result, "embedding_proximity", None)
-    if ep and ep.checked and not ep.skipped_reason:
+    if ep and ep.checked:
         lines.append("")
         lines.append(_section_header("14. EMBEDDING PROXIMITY"))
-        lines.append(f"  Model: {ep.model_name}")
-        lines.append(f"  Avg similarity: {ep.avg_similarity:.4f} | Top: {ep.top_similarity:.4f}")
-        lines.append(f"  Retrievable chunks: {ep.retrievable_chunks}/{ep.total_chunks}")
+        if ep.skipped_reason:
+            lines.append(f"  ⏭️  Skipped: {ep.skipped_reason}")
+        else:
+            lines.append(f"  Model: {ep.model_name}")
+            lines.append(f"  Avg similarity: {ep.avg_similarity:.4f} | Top: {ep.top_similarity:.4f}")
+            lines.append(f"  Retrievable chunks: {ep.retrievable_chunks}/{ep.total_chunks}")
 
     # Content Decay Predictor (#383)
     cd = getattr(result, "content_decay", None)

--- a/src/geo_optimizer/cli/rich_formatter.py
+++ b/src/geo_optimizer/cli/rich_formatter.py
@@ -391,7 +391,7 @@ def _build_schema_card(result: AuditResult, score: int, max_score: int) -> Panel
     content_parts.append(Text())
 
     if not result.schema.found_types:
-        content_parts.append(Text("  Nessuno schema trovato", style=f"italic {_COLORS['dim']}"))
+        content_parts.append(Text("  No schema found", style=f"italic {_COLORS['dim']}"))
     else:
         # Schemas found as inline tags
         types_text = Text("  ")
@@ -674,9 +674,9 @@ def _build_brand_entity_card(result: AuditResult, score: int, max_score: int) ->
     # Brand name consistency
     coherence = Text("  ")
     if be.brand_name_consistent:
-        coherence.append("✓ Brand name coerente", style=_COLORS["excellent"])
+        coherence.append("✓ Brand name consistent", style=_COLORS["excellent"])
     else:
-        coherence.append("✗ Brand name incoerente", style=_COLORS["critical"])
+        coherence.append("✗ Brand name inconsistent", style=_COLORS["critical"])
     if be.names_found:
         coherence.append(f"  ({', '.join(be.names_found[:3])})", style=_COLORS["dim"])
     content_parts.append(coherence)

--- a/src/geo_optimizer/core/audit.py
+++ b/src/geo_optimizer/core/audit.py
@@ -740,12 +740,16 @@ def run_full_audit(url: str, use_cache: bool = False, project_config=None) -> Au
                 cache.put(base_url, r.status_code, r.text, dict(r.headers))
     else:
         r, err = fetch_url(base_url)  # type: ignore[assignment]
-    if err or not r:
+    # `r is None`, not `not r`: requests.Response.__bool__ is `ok`, so any 4xx/5xx
+    # is falsy and would land here — reporting "Connection failed" for a request
+    # that succeeded, and skipping the status branch below that exists to name the
+    # code and point at a WAF. Fixes the 403 reported as a connection error.
+    if err or r is None:
         result = AuditResult(
             url=base_url,
             error=str(err) if err else "Connection failed",
         )
-        result.recommendations = [f"Unable to reach {base_url}: {err}"]
+        result.recommendations = [f"Unable to reach {base_url}: {err or 'connection failed'}"]
         result.audit_duration_ms = int((time.perf_counter() - _t0) * 1000)
         return result
 

--- a/src/geo_optimizer/core/factual_accuracy.py
+++ b/src/geo_optimizer/core/factual_accuracy.py
@@ -102,7 +102,9 @@ def run_factual_accuracy_audit(url: str, max_source_checks: int = _DEFAULT_MAX_S
         base_url = "https://" + base_url
 
     response, err = fetch_url(base_url)
-    if err or not response:
+    # `response is None`: an HTTP error Response is falsy (requests sets __bool__ to
+    # `ok`), so this used to claim the page was unreachable when it had answered.
+    if err or response is None:
         return FactualAccuracyResult(
             checked=False,
             inconsistencies=[f"Unable to reach {base_url}: {err or 'connection failed'}"],
@@ -266,7 +268,11 @@ def _check_source_links(
     for link in links[: max(0, max_source_checks)]:
         result.source_links_checked += 1
         response, err = fetcher(link)
-        if err or not response:
+        # `response is None`, not `not response`: an HTTP error Response is falsy
+        # (requests sets __bool__ to `ok`). The outcome here was right either way —
+        # a link answering 4xx/5xx is broken — because the status check below
+        # catches it. Being explicit keeps the two cases distinguishable.
+        if err or response is None:
             _append_unique(result.broken_source_links, link)
             continue
 

--- a/src/geo_optimizer/mcp/server.py
+++ b/src/geo_optimizer/mcp/server.py
@@ -225,8 +225,10 @@ def geo_citability(url: str) -> str:
         from geo_optimizer.utils.http import fetch_url
 
         r, err = fetch_url(url)
-        if err or not r:
-            return json.dumps({"error": f"Cannot reach {url}: {err}", "url": url})
+        # `r is None`: a 4xx/5xx Response is falsy (__bool__ is `ok`), which used to
+        # report an unreachable host and interpolate err=None into the message.
+        if err or r is None:
+            return json.dumps({"error": f"Cannot reach {url}: {err or 'connection failed'}", "url": url})
 
         soup = BeautifulSoup(r.text, "html.parser")
         result = audit_citability(soup, url)

--- a/tests/test_coverage_m1.py
+++ b/tests/test_coverage_m1.py
@@ -715,14 +715,17 @@ class TestRichFormatter:
         reason="rich non installato",
     )
     def test_format_audit_rich_schema_nessuno(self):
-        """Senza schema, l'output mostra 'Nessuno schema'."""
+        """Senza schema, l'output segnala l'assenza in inglese."""
         from geo_optimizer.cli.rich_formatter import format_audit_rich
 
         result = _crea_audit_result_vuoto()
         output = format_audit_rich(result)
 
-        # v2: testo in italiano "Nessuno schema trovato"
-        assert "Nessuno schema" in output
+        # Era "Nessuno schema trovato": una delle stringhe italiane hardcoded
+        # nel report inglese, segnalate nella issue #509. Il test asseriva il bug
+        # come comportamento atteso, quindi è stato aggiornato insieme al fix.
+        assert "No schema found" in output
+        assert "Nessuno schema" not in output
 
     def test_score_color_returns_color(self):
         """_score_color() ritorna un colore hex basato sulla percentuale."""

--- a/tests/test_http_error_status_reporting.py
+++ b/tests/test_http_error_status_reporting.py
@@ -1,0 +1,86 @@
+"""An HTTP error is not a connection failure.
+
+`requests.Response.__bool__` is `ok`, i.e. `status_code < 400`. So a perfectly
+valid 403 carrying a full body is *falsy*, and `if err or not r` routed it down
+the "no response at all" branch: the audit reported `error="Connection failed"`
+and `http_status=0` for a request that had completed, and the branch immediately
+below — written to name the status and point at a WAF — became unreachable for
+every status >= 400.
+
+Reported from production: https://www.netsons.com/ answers 200 to a desktop
+browser and 403 to the server, and the report read "Audit failed — Connection
+failed", which sends the user looking for a network problem that does not exist.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from geo_optimizer.core.audit import run_full_audit
+
+
+class _FakeResponse:
+    """Minimal stand-in that reproduces requests' truthiness rule."""
+
+    def __init__(self, status_code: int, text: str = "<html><body>x</body></html>"):
+        self.status_code = status_code
+        self.text = text
+        self.headers: dict[str, str] = {"content-type": "text/html"}
+        self.encoding = "utf-8"
+
+    @property
+    def ok(self) -> bool:
+        return self.status_code < 400
+
+    def __bool__(self) -> bool:
+        # This is the whole point of the test: requests does exactly this.
+        return self.ok
+
+
+class TestErrorStatusIsReportedAsSuch:
+    @pytest.mark.parametrize("status", [403, 401, 404, 429, 500, 503])
+    def test_http_error_reports_the_status_not_a_connection_failure(self, status: int):
+        with patch("geo_optimizer.core.audit.fetch_url", return_value=(_FakeResponse(status), None)):
+            result = run_full_audit("https://blocked.example")
+
+        assert result.error == f"HTTP {status}", f"a {status} must be named, got {result.error!r}"
+        assert result.http_status == status, "the status code must survive into the result"
+        assert "Connection failed" not in (result.error or "")
+
+    def test_the_waf_hint_is_reachable(self):
+        """The recommendation behind the status branch was dead code for 4xx/5xx."""
+        with patch("geo_optimizer.core.audit.fetch_url", return_value=(_FakeResponse(403), None)):
+            result = run_full_audit("https://blocked.example")
+
+        joined = " ".join(result.recommendations)
+        assert "403" in joined
+        assert "WAF" in joined or "Cloudflare" in joined
+
+    def test_a_real_transport_failure_still_reports_one(self):
+        """The fix must not swallow the case the branch was actually for."""
+        with patch(
+            "geo_optimizer.core.audit.fetch_url",
+            return_value=(None, "Connection failed dopo retry esponenziale: timeout"),
+        ):
+            result = run_full_audit("https://unreachable.example")
+
+        assert "Connection failed" in (result.error or "")
+
+    def test_no_response_and_no_error_still_degrades_readably(self):
+        """Defensive: if fetch_url ever returns (None, None), the message must not
+        interpolate a bare None — that was the "Unable to reach X: None" the user
+        saw."""
+        with patch("geo_optimizer.core.audit.fetch_url", return_value=(None, None)):
+            result = run_full_audit("https://nothing.example")
+
+        assert result.error == "Connection failed"
+        assert "None" not in " ".join(result.recommendations)
+
+    @pytest.mark.parametrize("status", [200, 203])
+    def test_success_statuses_are_still_audited(self, status: int):
+        with patch("geo_optimizer.core.audit.fetch_url", return_value=(_FakeResponse(status), None)):
+            result = run_full_audit("https://ok.example")
+
+        assert result.error is None

--- a/tests/test_issue_509_i18n_and_skipped_sections.py
+++ b/tests/test_issue_509_i18n_and_skipped_sections.py
@@ -1,0 +1,113 @@
+"""Issue #509 — no Italian in the English report, and no silent section gaps.
+
+Two defects reported together by a user running 4.15.0 on Windows:
+  * section 8 printed four Italian strings inside an otherwise English report;
+  * the numbering jumped 13 -> 15, which reads as a bug.
+
+The second one was not a bug in the section: EMBEDDING PROXIMITY is conditional on
+the optional sentence-transformers extra. The bug was that the formatter recorded
+why it skipped and then never said so.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parent.parent / "src/geo_optimizer/cli"
+
+# Italian words that leaked. Matched as whole words so English text that merely
+# contains these letter sequences does not trip the test.
+_ITALIAN = (
+    "coerente",
+    "incoerente",
+    "presenti",
+    "mancanti",
+    "trovate",
+    "trovati",
+    "collegata",
+    "rilevata",
+    "Nessuno",
+    "Nessun",
+    "Articoli",
+    "Informazioni",
+)
+
+
+def _user_facing_strings(path: Path) -> list[str]:
+    """String literals from the file, minus comments and docstrings."""
+    text = path.read_text(encoding="utf-8")
+    text = re.sub(r'""".*?"""', "", text, flags=re.DOTALL)
+    text = re.sub(r"^\s*#.*$", "", text, flags=re.MULTILINE)
+    return re.findall(r'"([^"\n]{4,})"', text)
+
+
+class TestNoItalianLeak:
+    def test_text_formatter_is_english(self):
+        offenders = [
+            s for s in _user_facing_strings(_SRC / "formatters.py") if any(re.search(rf"\b{w}\b", s) for w in _ITALIAN)
+        ]
+        assert not offenders, f"Italian strings still in the text formatter: {offenders}"
+
+    def test_rich_formatter_is_english(self):
+        offenders = [
+            s
+            for s in _user_facing_strings(_SRC / "rich_formatter.py")
+            if any(re.search(rf"\b{w}\b", s) for w in _ITALIAN)
+        ]
+        assert not offenders, f"Italian strings still in the rich formatter: {offenders}"
+
+    def test_the_exact_strings_from_the_report_are_gone(self):
+        """The four lines the reporter pasted, verbatim."""
+        blob = (_SRC / "formatters.py").read_text(encoding="utf-8")
+        for reported in (
+            "Brand name coerente",
+            "About page collegata",
+            "Informazioni di contatto presenti",
+            "Knowledge Graph pillars",  # this one stays: it is English
+        ):
+            if reported == "Knowledge Graph pillars":
+                assert reported in blob, "the English label was removed by mistake"
+            else:
+                assert reported not in blob, f"still present: {reported}"
+
+
+class TestSkippedSectionIsExplained:
+    """A conditional section must say it was skipped, not vanish."""
+
+    def _render(self, *, skipped: str | None):
+        """Render a real AuditResult, reusing the fixture helper the suite already
+        has. A hand-rolled stand-in silently diverges from the dataclass and turns a
+        formatter change into an unrelated AttributeError."""
+        from geo_optimizer.cli.formatters import format_audit_text
+        from geo_optimizer.models.results import EmbeddingProximityResult
+        from tests.test_v21_coverage import _make_audit_result
+
+        ep = EmbeddingProximityResult(
+            checked=True,
+            skipped_reason=skipped,
+            model_name="all-MiniLM-L6-v2",
+            avg_similarity=0.42,
+            top_similarity=0.81,
+            retrievable_chunks=3,
+            total_chunks=7,
+        )
+        result = _make_audit_result()
+        result.embedding_proximity = ep
+        return format_audit_text(result)
+
+    def test_skipped_section_states_the_reason(self):
+        out = self._render(skipped="sentence-transformers not installed (pip install geo-optimizer-skill[embedding])")
+        assert "14. EMBEDDING PROXIMITY" in out, "the section header must still appear"
+        assert "Skipped" in out
+        assert "sentence-transformers" in out, "the actionable reason must reach the user"
+
+    def test_numbering_has_no_hole_when_skipped(self):
+        """The reporter's actual symptom: 13 followed by 15."""
+        out = self._render(skipped="sentence-transformers not installed")
+        assert "14." in out
+
+    def test_completed_section_still_prints_the_metrics(self):
+        out = self._render(skipped=None)
+        assert "Model: all-MiniLM-L6-v2" in out
+        assert "Skipped" not in out


### PR DESCRIPTION
`geoready.dev` is served from `marketing-p0-new`, not `main`, so three fixes shipped today were invisible on the site: a 403 still read *"Connection failed"*, every URL field still rejected the bare hostname its own placeholder showed, and the report still leaked Italian strings into English output.

## Ported by explicit path, not merged

`main` is 12 commits ahead of this branch and this branch is 44 ahead of `main`. A merge in either direction moves far more than the fixes. Only files `main` changed **and** this branch had not touched were taken verbatim:

| files | fix |
|---|---|
| `core/audit.py`, `core/factual_accuracy.py`, `mcp/server.py` | HTTP status vs connection failure (#515) |
| `cli/formatters.py`, `cli/rich_formatter.py` | English-only report (#509 / #511) |
| `AuditForm.tsx`, `compare/CompareContainer.tsx`, `urlInput.ts` | bare hostnames (#514) |

## LlmsTxtGenerator.tsx applied by hand

This file carries two conversion-path commits on this branch (`31aba56`, `c2b095f`) that `main` does not have, so checking it out would have **silently reverted marketing work** to fix an input type. Only the two `type="url"` attributes and the two normalisation calls changed — the diff against this branch removes exactly four lines.

## The consent manager is untouched

Zero files under `components/cookie/`, `lib/cookie*` or `Layout.astro` appear in this diff.

Worth stating explicitly, because the standing assumption was wrong: the note that *`main` lacks the GDPR consent manager* is no longer true — all eight files exist on both branches. But this branch is the one that has moved on them since the merge base (`main`: 0 commits touching them, this branch: several), so the fixes travel **toward** this branch and never the other way.

## Version

Bumped `4.15.0` → `4.16.2` in `pyproject.toml` and the `__init__` fallback. The site's version badge reads `pyproject.toml` through `vite.define` at build time, so it picks this up with no further change — confirmed as `4.16.2` in the built bundle.

## Deliberately excluded

The three `feat(cli)` commits from #512 (orphan pages in `geo authority`, TTFB in `geo access`, corrected bot roster). Not urgent, and they widen what needs verifying on a deploy branch.

## Verification

| check | result |
|---|---|
| Suite | **2 failed / 1811 passed** |
| Those 2 failures | **pre-existing on this branch** — confirmed by running the suite against an unmodified checkout |
| `tsc --noEmit` | 5 = 5 against the same baseline |
| `astro build` | clean, 67 pages |
| Built bundle | zero `type:"url"`, `inputMode:"url"` in three chunks, version `4.16.2` |
| Consent manager | untouched, present in three chunks |

The two red tests (`test_frontend_seo`: homepage description over the SEO limit, Sanity scheduled articles) were already failing before this change and are left alone as a separate concern.
