### PR TITLE
fix(citability): count Instagram, TikTok and Threads as platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Format: [Keep a Changelog](https://keepachangelog.com/) · [SemVer](https://semv
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **Instagram, TikTok and Threads did not count as platforms.** `_PLATFORM_DOMAINS` in `citability.py` listed nine domains; `SOCIAL_PROOF_DOMAINS` in `config.py` listed eight, and three of those — `instagram.com`, `tiktok.com`, `threads.net` — were absent from the first. A brand whose `sameAs` pointed at them got no credit for a presence it genuinely had. Since `multi_platform` scores by count (5 or more → 4 points, 3 or more → 2), three missing entries could cost a page a whole band, so this moves scores rather than only labels. The two lists are deliberately *not* identical in the other direction — GitHub, Medium, Reddit and Wikipedia are platforms without being social proof — so the new regression test pins `SOCIAL_PROOF_DOMAINS ⊆ _PLATFORM_DOMAINS` as a subset rather than an equality, which is the direction that was a defect. Found while fixing the `@graph` walkers in 4.16.3, where a test had been written asserting `platform_count == 4` on a fixture carrying five platforms, documenting the gap instead of failing on it.
+
+---
+
 ## [4.16.3] — 2026-08-13
 
 Patch release for four defects found by running this project's own audit against its own

--- a/src/geo_optimizer/core/citability.py
+++ b/src/geo_optimizer/core/citability.py
@@ -2215,7 +2215,15 @@ def detect_voice_search(soup) -> MethodScore:
 
 # ─── Multi-Platform Presence (+10%) — Batch A v3.16.0 ────────────────────────
 
-# Recognized platforms for multi-platform presence
+# Recognized platforms for multi-platform presence.
+#
+# Kept deliberately wider than SOCIAL_PROOF_DOMAINS in config.py: GitHub, Medium,
+# Reddit and Wikipedia are platforms a brand can be present on without being social
+# proof, so their absence from that list is correct. The reverse was not — Instagram,
+# TikTok and Threads were in SOCIAL_PROOF_DOMAINS but missing here, so a brand whose
+# `sameAs` pointed at them lost credit for a presence it actually had. Since the
+# scoring is by count (>=5 → 4 points, >=3 → 2), three missing entries could drop a
+# page a whole band.
 _PLATFORM_DOMAINS = {
     "github.com": "GitHub",
     "linkedin.com": "LinkedIn",
@@ -2226,6 +2234,9 @@ _PLATFORM_DOMAINS = {
     "wikipedia.org": "Wikipedia",
     "medium.com": "Medium",
     "facebook.com": "Facebook",
+    "instagram.com": "Instagram",
+    "tiktok.com": "TikTok",
+    "threads.net": "Threads",
 }
 
 

--- a/tests/test_citability.py
+++ b/tests/test_citability.py
@@ -1361,6 +1361,40 @@ class TestMultiPlatform:
         assert not result.detected
         assert result.score == 0
 
+    def test_instagram_tiktok_threads_sono_piattaforme(self):
+        """A `sameAs` pointing at Instagram, TikTok or Threads counts (#4.16.3).
+
+        These three were in SOCIAL_PROOF_DOMAINS but missing from
+        _PLATFORM_DOMAINS, so a brand present on them scored as if it were not.
+        """
+        html = """
+        <html><body>
+            <script type="application/ld+json">
+            {"@type": "Organization", "sameAs": [
+                "https://www.instagram.com/test",
+                "https://www.tiktok.com/@test",
+                "https://www.threads.net/@test"
+            ]}
+            </script>
+        </body></html>
+        """
+        result = detect_multi_platform(_soup(html))
+        assert result.details["platform_count"] == 3
+        assert result.details["platforms_found"] == ["Instagram", "Threads", "TikTok"]
+
+    def test_ogni_social_proof_domain_e_anche_una_piattaforma(self):
+        """SOCIAL_PROOF_DOMAINS must be a subset of _PLATFORM_DOMAINS (#4.16.3).
+
+        Not the reverse: GitHub, Medium, Reddit and Wikipedia are platforms
+        without being social proof, so the wider set is intentional. This pins
+        the direction that is a defect, which is how the three above slipped in.
+        """
+        from geo_optimizer.core.citability import _PLATFORM_DOMAINS
+        from geo_optimizer.models.config import SOCIAL_PROOF_DOMAINS
+
+        missing = sorted(set(SOCIAL_PROOF_DOMAINS) - set(_PLATFORM_DOMAINS))
+        assert not missing, f"social domains absent from _PLATFORM_DOMAINS: {missing}"
+
 
 # ============================================================================
 # TEST: Entity Disambiguation (+8%) — Batch A v3.16.0
@@ -2109,10 +2143,9 @@ class TestGraphUnpacking:
 
     def test_multi_platform_legge_sameas_nel_graph(self):
         result = detect_multi_platform(_soup(_YOAST_GRAPH_HTML))
-        # 4, non 5: instagram.com non è in _PLATFORM_DOMAINS. Difetto separato,
-        # fuori dallo scopo di questo fix; qui conta che i sameAs nel @graph
-        # vengano letti (prima erano 0).
-        assert result.details["platform_count"] == 4
+        # 5 since instagram.com joined _PLATFORM_DOMAINS; before the @graph fix
+        # this was 0, because none of the sameAs URLs were reachable at all.
+        assert result.details["platform_count"] == 5
         assert result.detected is True
 
     def test_blog_structure_trova_article_nel_graph(self):


### PR DESCRIPTION
Instagram, TikTok and Threads were in SOCIAL_PROOF_DOMAINS but missing from _PLATFORM_DOMAINS, so a brand whose sameAs pointed at them got no credit for a presence it had. Since multi_platform scores by count (>=5 → 4 points, >=3 → 2), three missing entries could cost a page a whole band — this moves scores, not just labels.

The two lists stay deliberately different in the other direction: GitHub, Medium, Reddit and Wikipedia are platforms without being social proof. The regression test therefore pins a subset relation, not equality.

Found while fixing the @graph walkers, where a test asserted platform_count == 4 on a fixture carrying five platforms — documenting the gap in a comment instead of failing on it.