### PR TITLE
chore(ci): bump checkout and setup-python to v7 across every surface

### DIFF
--- a/.github/actions/geo-audit/action.yml
+++ b/.github/actions/geo-audit/action.yml
@@ -44,7 +44,7 @@ runs:
   using: 'composite'
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ inputs.python-version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -60,9 +60,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.12'
           cache: pip

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/geo-audit-example.yml
+++ b/.github/workflows/geo-audit-example.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       # Basic example — audit with JSON output
       - name: Run GEO Audit
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Run GEO Audit (SARIF)
         uses: ./

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -21,7 +21,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Prepare site sources
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,9 +16,9 @@ jobs:
         python-version: ['3.9', '3.12']
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -37,9 +37,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.12'
           cache: pip

--- a/.github/workflows/sanity-scheduled-publish.yml
+++ b/.github/workflows/sanity-scheduled-publish.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-node@v6
         with:

--- a/action.yml
+++ b/action.yml
@@ -57,7 +57,7 @@ runs:
   steps:
     # 1. Setup Python
     - name: Setup Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: "3.12"
 


### PR DESCRIPTION
Supersedes the two Dependabot PRs, which each covered a subset:

- #505 (checkout v7) touched 5 of the 6 workflows that use it. It was opened
  before sanity-scheduled-publish.yml reached the default branch in #512, so
  the workflow that publishes articles would have stayed on v6 — and Dependabot
  would not reopen, since from its side the bump is done.
- #508 (setup-python v7) covered ci.yml, publish.yml and the root action.yml,
  but not .github/actions/geo-audit/action.yml, a nested composite action
  neither PR looked at.

Eight surfaces are now on v7: 9 checkout call sites, 6 setup-python.

Both majors carry a real breaking change; neither reaches us. setup-python v7
drops the `pip-install` input, which we never set. checkout v7 refuses to check
out fork PRs under `pull_request_target` and `workflow_run`, and no workflow
here uses either trigger. setup-python v7 also pruned EOL runtimes from its own
test matrix — checked that this does not remove installable versions: the
manifest still serves 32 builds of 3.9, up to 3.9.25, and 3.9 stays in our
matrix because the package declares support for it.
