### PR TITLE
fix(ops): sync deploy-reliability fixes from sync/fixes-to-site

### DIFF
--- a/.github/workflows/sanity-scheduled-publish.yml
+++ b/.github/workflows/sanity-scheduled-publish.yml
@@ -76,10 +76,12 @@ jobs:
         if: (steps.sanity_publish.outputs.published_count != '0' || env.FORCE_DEPLOY == 'true') && env.DRY_RUN != 'true'
         env:
           GEOREADY_DEPLOY_WEBHOOK_URL: ${{ secrets.GEOREADY_DEPLOY_WEBHOOK_URL }}
+          DEPLOY_TRIGGER_TOKEN: ${{ secrets.DEPLOY_TRIGGER_TOKEN }}
           PUBLISHED_SLUGS: ${{ steps.sanity_publish.outputs.published_slugs }}
         run: |
           curl --fail --silent --show-error --retry 3 --retry-all-errors --connect-timeout 10 --max-time 120 \
             --request POST \
             --header 'Content-Type: application/json' \
+            --header "Authorization: Bearer $DEPLOY_TRIGGER_TOKEN" \
             --data "{\"event\":\"sanity-scheduled-publish\",\"slugs\":\"$PUBLISHED_SLUGS\",\"sha\":\"$GITHUB_SHA\"}" \
             "$GEOREADY_DEPLOY_WEBHOOK_URL"

--- a/docs/sanity-scheduled-publishing.md
+++ b/docs/sanity-scheduled-publishing.md
@@ -58,11 +58,56 @@ the static rebuild even when the prior run already promoted the documents.
 Documents already promoted to `published` remain safe and the site has no
 route-level exposure of drafts.
 
+### A green workflow does not prove the site was deployed
+
+The claim above holds only when the endpoint actually rejects a bad request. On
+2026-08-13 it did not: `GEOREADY_DEPLOY_WEBHOOK_URL` held a placeholder pointing
+at an echo service, which answers `200` to any POST, so `curl --fail` passed and
+every step reported success while the article stayed `404` for half an hour.
+
+Nothing caught it earlier because the deployment step is guarded by
+`if: published_count != '0'`, and the roughly forty runs since the workflow
+reached the default branch had all found nothing due. A step behind a condition
+that has never been met is not tested code — it is code that has never run. Read
+the step's output, not the job's conclusion.
+
+## Reconciliation (the safety net)
+
+Because publishing is push-based, a broken link anywhere in the chain leaves an
+article promoted in Sanity and absent from the site, with no failure signal. The
+reconciler closes that gap by pulling instead of pushing:
+
+- `frontend/scripts/check-live-drift.mjs` compares the live Sanity articles
+  against the public sitemap and exits `10` when at least one live article is not
+  served, `0` when aligned, `1` on any error. It needs no token, deploys nothing,
+  and cannot deploy anything — it only decides.
+- `frontend/scripts/reconcile-live-site.sh` runs on the server, and calls
+  `rebuild-geo-web.py` only on exit `10`. Install it hourly in cron:
+
+  ```
+  17 * * * * /home/debian/geo-optimizer-skill/frontend/scripts/reconcile-live-site.sh
+  ```
+
+Three properties are deliberate. An error in the check (`1`) never triggers a
+deployment, so an unreachable Sanity or an unparsable sitemap cannot cause a
+rebuild "just in case". A `flock` prevents overlapping runs, since a rebuild
+takes over two minutes. And after the rebuild the check runs again: a rebuild
+that reports success without resolving the drift is logged as needing a human,
+rather than assumed to have worked — which is precisely the failure mode above.
+
+An aligned run logs nothing. Twenty-four "all fine" lines a day would bury the
+ones that matter.
+
+This makes the webhook secret non-critical: with the reconciler installed, a
+broken deployment trigger delays publication by up to an hour instead of
+dropping it silently.
+
 ## Local commands
 
 ```bash
 npm --prefix frontend run sanity:publish-due:dry-run
 npm --prefix frontend run sanity:check-schedule
+npm --prefix frontend run site:check-drift
 SANITY_API_TOKEN=... npm --prefix frontend run sanity:publish-due
 ```
 
@@ -70,3 +115,5 @@ The dry run uses the public Sanity dataset and never needs a write token. The
 write command requires the token only in the process environment and never
 prints it. `sanity:check-schedule` is read-only and exits with an error while
 one or more scheduled articles are overdue; use it before a manual deployment.
+`site:check-drift` is read-only too and answers a different question: whether
+what is already published is actually being served.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "sanity:check-schedule": "node scripts/verify-scheduled-articles.mjs",
     "sanity:publish-due:dry-run": "node scripts/publish-scheduled-articles.mjs --dry-run",
     "sanity:publish-due": "node scripts/publish-scheduled-articles.mjs",
+    "site:check-drift": "node scripts/check-live-drift.mjs",
     "indexnow:dry-run": "node scripts/indexnow-submit.mjs",
     "indexnow:submit": "node scripts/indexnow-submit.mjs --submit"
   },

--- a/frontend/scripts/check-live-drift.mjs
+++ b/frontend/scripts/check-live-drift.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+// Riporta se esiste un articolo Sanity live che il sito pubblicato non serve ancora.
+//
+// Esiste perché la catena "promuovi su Sanity → ridistribuisci il sito" è push-based e
+// quindi può rompersi in silenzio: il 2026-08-13 il workflow di pubblicazione ha promosso
+// un articolo, ha riportato `success` su tutti gli step, e la pagina è restata 404 per
+// mezz'ora — il secret del webhook di deploy puntava a un URL placeholder, e un endpoint
+// che risponde 200 a qualunque POST non fa fallire `curl --fail`. Con 28 articoli in coda
+// a cadenza di 4 giorni, un fallimento silenzioso per articolo non è accettabile.
+//
+// Questo script non deploya e non può deployare: decide soltanto, e comunica la decisione
+// con l'exit code. Il wrapper che agisce sta sul server, dove vive lo script di rebuild.
+// La separazione è deliberata: il codice versionato resta testabile e senza privilegi.
+//
+// Non richiede token: interroga il dataset pubblico e la sitemap pubblica.
+//
+// Uso:
+//   node scripts/check-live-drift.mjs            # exit 10 se serve un rebuild
+//   node scripts/check-live-drift.mjs --json     # output leggibile da uno script
+//
+// Exit code:
+//   0  allineato, nessuna azione
+//   10 disallineato, serve un rebuild        <- il wrapper agisce solo su questo
+//   1  errore (rete, Sanity, sitemap non parsabile) — NON deployare in caso di dubbio
+
+import { createSanityPublicationClient } from './sanity-publication-state.mjs';
+
+const SITE = 'https://geoready.dev';
+const SITEMAP_URL = `${SITE}/sitemap.xml`;
+const FETCH_TIMEOUT_MS = 20_000;
+
+// Deve restare allineato a CATEGORY_TO_PATH in generate-sitemap.mjs: una categoria
+// assente lì non produce URL, quindi non è un disallineamento da correggere.
+const CATEGORY_TO_PATH = {
+  guides: '/guides/',
+  resources: '/resources/',
+};
+
+// Stesso filtro "live" di generate-sitemap.mjs, che è più restrittivo di quello del sito:
+// solo `published` conta. Un articolo scheduled-e-scaduto genera la pagina ma resta fuori
+// dalla sitemap, ed è il job di pubblicazione a doverlo promuovere — non un rebuild.
+const LIVE_ARTICLES_QUERY = `*[
+  _type == "article" &&
+  defined(slug.current) &&
+  (!defined(status) || status == "published")
+]{"slug": slug.current, category, _updatedAt}`;
+
+function parseArgs(argv) {
+  const flags = { json: false };
+  for (const arg of argv) {
+    if (arg === '--json') flags.json = true;
+    else throw new Error(`Argomento non riconosciuto: ${arg}`);
+  }
+  return flags;
+}
+
+/** Scarica la sitemap pubblica e ne estrae i path, senza dipendenze XML. */
+async function fetchLiveSitemapPaths() {
+  const res = await fetch(SITEMAP_URL, {
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    headers: { 'User-Agent': 'geoready-live-drift-check' },
+  });
+  if (!res.ok) throw new Error(`sitemap HTTP ${res.status}`);
+
+  const xml = await res.text();
+  const locs = [...xml.matchAll(/<loc>\s*([^<\s]+)\s*<\/loc>/g)].map((m) => m[1]);
+  if (locs.length === 0) {
+    // Una sitemap vuota o servita come pagina d'errore non è una prova di
+    // disallineamento: trattarla come tale farebbe partire un rebuild a ogni glitch.
+    throw new Error('la sitemap pubblica non contiene alcun <loc>');
+  }
+
+  return new Set(
+    locs.map((loc) => {
+      try {
+        return new URL(loc).pathname.replace(/\/+$/, '') || '/';
+      } catch {
+        return loc;
+      }
+    }),
+  );
+}
+
+function expectedPathFor(article) {
+  const prefix = CATEGORY_TO_PATH[article.category];
+  if (!prefix) return null;
+  return `${prefix}${article.slug}`.replace(/\/+$/, '');
+}
+
+async function main() {
+  const { json } = parseArgs(process.argv.slice(2));
+
+  const client = createSanityPublicationClient();
+  const [articles, livePaths] = await Promise.all([
+    client.fetch(LIVE_ARTICLES_QUERY),
+    fetchLiveSitemapPaths(),
+  ]);
+
+  const missing = [];
+  const skipped = [];
+  for (const article of articles) {
+    const path = expectedPathFor(article);
+    if (!path) {
+      skipped.push({ slug: article.slug, category: article.category ?? null });
+      continue;
+    }
+    if (!livePaths.has(path)) missing.push({ slug: article.slug, path, updatedAt: article._updatedAt });
+  }
+
+  missing.sort((a, b) => String(a.updatedAt).localeCompare(String(b.updatedAt)));
+
+  const result = {
+    liveArticles: articles.length,
+    sitemapUrls: livePaths.size,
+    missingCount: missing.length,
+    missing,
+    skipped,
+    rebuildNeeded: missing.length > 0,
+  };
+
+  if (json) {
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+  } else {
+    console.log(`Sanity live: ${result.liveArticles} · sitemap pubblica: ${result.sitemapUrls} URL`);
+    if (missing.length === 0) {
+      console.log('Allineato — nessun rebuild necessario.');
+    } else {
+      console.log(`${missing.length} articolo/i live assente/i dalla sitemap pubblica:`);
+      for (const m of missing) console.log(`  • ${m.path}  (Sanity: ${m.updatedAt})`);
+    }
+    for (const s of skipped) {
+      console.log(`  ⏭️  ${s.slug}: categoria "${s.category}" non ha una route dinamica — ignorato`);
+    }
+  }
+
+  process.exitCode = result.rebuildNeeded ? 10 : 0;
+}
+
+main().catch((error) => {
+  // Exit 1, non 10: un errore di rete non è una prova di disallineamento, e il wrapper
+  // deve poter distinguere "serve un rebuild" da "non lo so".
+  console.error(`Controllo drift fallito: ${error.message}`);
+  process.exitCode = 1;
+});

--- a/frontend/scripts/reconcile-live-site.sh
+++ b/frontend/scripts/reconcile-live-site.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Riconcilia il sito pubblicato con Sanity: se un articolo live non è servito, rilancia
+# il deploy. Da installare in cron sul server di produzione.
+#
+# Perché in pull invece che via webhook: la catena push-based si è rotta in silenzio il
+# 2026-08-13 (secret del webhook verso un URL placeholder, workflow verde, pagina 404 per
+# mezz'ora). Un controllo che interroga lo stato reale non ha secret da sbagliare, non
+# espone porte, e si autoripara — se un giro fallisce, il successivo riprova.
+#
+# La decisione sta in check-live-drift.mjs, versionato e senza privilegi. Qui c'è solo
+# l'azione, sul server dove vive lo script di rebuild.
+#
+# Installazione (crontab dell'utente che possiede il repo e lo script di rebuild):
+#   17 * * * * /home/debian/geo-optimizer-skill/frontend/scripts/reconcile-live-site.sh
+#
+# Il minuto 17 è deliberato: evita lo :00, dove si accalcano tutti i cron del pianeta,
+# e non collide con il rebuild giornaliero di 08:10.
+
+set -euo pipefail
+
+REPO="${GEO_REPO:-/home/debian/geo-optimizer-skill}"
+REBUILD="${GEO_REBUILD_SCRIPT:-/home/debian/rebuild-geo-web.py}"
+LOG="${GEO_RECONCILE_LOG:-/home/debian/logs/reconcile-live-site.log}"
+LOCK="${GEO_RECONCILE_LOCK:-/tmp/reconcile-live-site.lock}"
+
+log() {
+  printf '[%s] %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$*" >>"$LOG"
+}
+
+# Un solo giro alla volta. Un rebuild dura oltre 120s: senza lock, due esecuzioni
+# sovrapposte competerebbero per lo stesso repo e la stessa immagine Docker.
+exec 9>"$LOCK"
+if ! flock -n 9; then
+  log "SKIP un altro giro è già in corso"
+  exit 0
+fi
+
+cd "$REPO/frontend"
+
+set +e
+DRIFT_JSON="$(node scripts/check-live-drift.mjs --json 2>&1)"
+DRIFT_EXIT=$?
+set -e
+
+case "$DRIFT_EXIT" in
+  0)
+    # Nessun log in caso di allineamento: 24 righe al giorno di "tutto ok"
+    # seppelliscono le righe che contano.
+    exit 0
+    ;;
+  10)
+    log "DRIFT $DRIFT_JSON"
+    ;;
+  *)
+    # Rete giù, Sanity irraggiungibile, sitemap non parsabile: non si deploya nel dubbio.
+    log "ERRORE controllo drift (exit $DRIFT_EXIT): $DRIFT_JSON"
+    exit 1
+    ;;
+esac
+
+if [[ ! -x "$REBUILD" ]]; then
+  log "ERRORE script di rebuild non eseguibile: $REBUILD"
+  exit 1
+fi
+
+log "REBUILD avvio ($REBUILD --trigger reconcile)"
+set +e
+"$REBUILD" --trigger reconcile >>"$LOG" 2>&1
+REBUILD_EXIT=$?
+set -e
+
+if [[ $REBUILD_EXIT -ne 0 ]]; then
+  # Nessun retry qui: lo script di rebuild ha già la sua guardia anti-shrink e il
+  # rollback automatico. Il prossimo giro di cron riprova, che è il retry.
+  log "REBUILD fallito (exit $REBUILD_EXIT) — il prossimo giro riprova"
+  exit 1
+fi
+
+# Verifica l'esito sullo stato reale, non sull'exit code: un rebuild che riporta
+# successo senza risolvere il disallineamento è esattamente il modo in cui il
+# webhook rotto è passato inosservato per due giorni.
+set +e
+node scripts/check-live-drift.mjs --json >/dev/null 2>&1
+VERIFY_EXIT=$?
+set -e
+
+if [[ $VERIFY_EXIT -eq 0 ]]; then
+  log "OK rebuild completato, sito allineato"
+else
+  log "ATTENZIONE rebuild completato ma il disallineamento persiste (exit $VERIFY_EXIT) — serve un occhio umano"
+  exit 1
+fi

--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -142,6 +142,10 @@ const {
         "@id": "https://geoready.dev/#founder",
         "name": "Juan Camilo Auriti",
         "url": "https://x.com/JuanAuriti",
+        "sameAs": [
+          "https://x.com/JuanAuriti",
+          "https://www.linkedin.com/in/juancamiloauriti/"
+        ],
         "worksFor": { "@id": "https://geoready.dev/#organization" }
       },
       {

--- a/frontend/src/pages/best-geo-tools.astro
+++ b/frontend/src/pages/best-geo-tools.astro
@@ -263,9 +263,9 @@ const faqs = [
       <h2>What sites actually score, measured</h2>
       <p class="mt-4">
         Criteria tell you how to judge a tool. They do not tell you how much room a
-        typical site has to gain. We run the same open-source 100-point rubric across
-        every site audited through GeoReady and publish the aggregate, so the baseline
-        below comes from measurement rather than estimation.
+        typical site has to gain. We measured that: our data shows what sites score when
+        the same open-source 100-point rubric is applied to every site audited through
+        GeoReady. The baseline below is measurement, not estimation.
       </p>
       <figure class="mt-6 rounded-2xl border border-border bg-bg-surface p-6">
         <blockquote class="border-l-2 border-accent pl-4">
@@ -290,10 +290,21 @@ const faqs = [
         is a specific, fixable defect, not a matter of judgment. That is what an audit
         should hand you.
       </p>
-      <p class="mt-4">
-        This is a benchmark of sites audited by GeoReady, not a survey of the whole web.
-        The sample skews toward teams already curious about AI visibility, so read it as
-        a directional baseline among sites that chose to measure — not a universal figure.
+      <h3 class="mt-8">Methodology</h3>
+      <p class="mt-3">
+        Every figure above comes from one audit per domain — the most recent, with
+        scheduled re-audits excluded so an actively monitored site cannot weight the
+        average. Each site is scored with the same published 100-point, 8-category rubric,
+        so the numbers reflect one consistent definition of readiness rather than a blend
+        of methods. Only aggregates are published: no domain, URL, or identifier leaves
+        the sample.
+      </p>
+      <p class="mt-3">
+        The limits are worth stating plainly. This is a benchmark of sites audited by
+        GeoReady, not a survey of the whole web, and the sample skews toward teams already
+        curious about AI visibility — a site whose owner ran an audit is not a random site.
+        Read it as a directional baseline among sites that chose to measure, not a
+        universal figure.
       </p>
     </section>
 

--- a/frontend/src/pages/best-geo-tools.astro
+++ b/frontend/src/pages/best-geo-tools.astro
@@ -7,7 +7,23 @@ const description =
   'Compare GEO and AI visibility tools by audit depth, monitoring, llms.txt support, schema, workflows, and pricing fit. Includes GEO Optimizer.';
 const canonical = 'https://geoready.dev/best-geo-tools/';
 const datePublished = '2026-06-16';
-const dateModified = '2026-06-17';
+const dateModified = '2026-08-13';
+
+// Aggregati della coorte GeoReady, letti da GET /api/public/benchmark.
+// Sono hardcoded di proposito: la build Docker gira prima che l'app sia in piedi,
+// quindi un fetch nel frontmatter fallirebbe, e i numeri caricati via JS (come fa
+// state-of-geo.astro) non entrano nell'HTML che un crawler AI legge senza eseguire
+// script. Il prezzo è che invecchiano: `measuredOn` rende la stagionatura visibile
+// al lettore invece di lasciarla implicita. Riallineare all'endpoint quando cambia.
+const BENCHMARK = {
+  measuredOn: '13 August 2026',
+  sampleLabel: '750+ audited sites',
+  average: '54.3',
+  median: '56',
+  llmsTxtAdoption: '58%',
+  schemaAdoption: '74%',
+  biggestGap: 'AI discovery files',
+} as const;
 
 // Criteri di valutazione di un GEO tool — riusati nella tabella visibile.
 // Ogni criterio è una domanda concreta che un reviewer tecnico può verificare.
@@ -237,6 +253,47 @@ const faqs = [
         Methodology transparency sits at the top for a reason: if you cannot see how a
         score is calculated, you cannot reproduce it, contest it, or learn from it. A
         published scoring model turns a number into a checklist you can act on.
+      </p>
+    </section>
+
+    {/* First-party benchmark — what the audited cohort actually scores.
+        Own measurements, not vendor claims: this is the part of the comparison no
+        competitor can restate, and it gives an answer engine something quotable. */}
+    <section class="mb-12 md:mb-16">
+      <h2>What sites actually score, measured</h2>
+      <p class="mt-4">
+        Criteria tell you how to judge a tool. They do not tell you how much room a
+        typical site has to gain. We run the same open-source 100-point rubric across
+        every site audited through GeoReady and publish the aggregate, so the baseline
+        below comes from measurement rather than estimation.
+      </p>
+      <figure class="mt-6 rounded-2xl border border-border bg-bg-surface p-6">
+        <blockquote class="border-l-2 border-accent pl-4">
+          <p class="text-lg text-text-primary leading-relaxed">
+            The average audited site scores <strong>{BENCHMARK.average} out of 100</strong>,
+            with a median of {BENCHMARK.median}. Only {BENCHMARK.llmsTxtAdoption} publish
+            an llms.txt file and {BENCHMARK.schemaAdoption} ship JSON-LD schema, which
+            makes {BENCHMARK.biggestGap} the single largest readiness gap in the sample.
+          </p>
+        </blockquote>
+        <figcaption class="mt-4 text-sm text-text-muted">
+          GeoReady benchmark, {BENCHMARK.sampleLabel}, measured {BENCHMARK.measuredOn}.
+          Latest audit per domain, aggregates only.
+          <a href="/state-of-geo/" class="underline hover:no-underline">See the live benchmark</a>
+          and the <a href="/methodology/" class="underline hover:no-underline">scoring methodology</a>.
+        </figcaption>
+      </figure>
+      <p class="mt-4">
+        Two things follow. First, a score in the fifties is ordinary rather than alarming
+        — most sites are in the same position. Second, the gaps concentrate in signals a
+        tool can find mechanically: a missing orientation file or absent structured data
+        is a specific, fixable defect, not a matter of judgment. That is what an audit
+        should hand you.
+      </p>
+      <p class="mt-4">
+        This is a benchmark of sites audited by GeoReady, not a survey of the whole web.
+        The sample skews toward teams already curious about AI visibility, so read it as
+        a directional baseline among sites that chose to measure — not a universal figure.
       </p>
     </section>
 
@@ -481,6 +538,27 @@ const faqs = [
         ))}
       </div>
     </section>
+
+    {/* Author attribution — an E-E-A-T signal, and the page's own advice applied:
+        a comparison that asks who computed a score should say who wrote it. */}
+    <section class="mt-12 border-t border-border pt-8 md:mt-16">
+      <h2 class="sr-only">About the author</h2>
+      <div class="rounded-2xl border border-border bg-bg-surface p-6">
+        <p class="font-display font-semibold text-text-primary">Juan Camilo Auriti</p>
+        <p class="mt-2 text-sm">
+          Founder of Auriti Labs and author of GEO Optimizer, the MIT-licensed engine
+          whose scoring weights and 47 citability methods are published in the
+          <a href="https://github.com/Auriti-Labs/geo-optimizer-skill" class="text-accent-teal hover:underline" rel="noopener">public repository</a>.
+          The benchmark figures on this page come from that engine, run across every
+          site audited through GeoReady.
+        </p>
+        <p class="mt-3 text-sm text-text-muted">
+          Reviewed and updated {BENCHMARK.measuredOn} ·
+          <a href="/methodology/" class="underline hover:no-underline">Methodology</a> ·
+          <a href="/about/" class="underline hover:no-underline">About</a>
+        </p>
+      </div>
+    </section>
   </article>
 
   {/* Page-specific schema — Article */}
@@ -492,7 +570,10 @@ const faqs = [
     "url": canonical,
     "datePublished": datePublished,
     "dateModified": dateModified,
-    "author": { "@id": "https://geoready.dev/#organization" },
+    // Il byline visibile è una persona, quindi l'author dello schema punta al
+    // Person #founder già nel @graph di Layout.astro, non all'Organization:
+    // un autore nominato è un segnale E-E-A-T più forte di un autore aziendale.
+    "author": { "@id": "https://geoready.dev/#founder" },
     "publisher": { "@id": "https://geoready.dev/#organization" }
   })} />
 

--- a/frontend/src/pages/index.astro
+++ b/frontend/src/pages/index.astro
@@ -6,6 +6,31 @@ import ScoreSurface from '../components/product/ScoreSurface.astro';
 import RetrievalPath from '../components/product/RetrievalPath.astro';
 import MonitorSurface from '../components/product/MonitorSurface.astro';
 
+// Gli otto pesi di scoring, come pubblicati in models/config.py (SCORING).
+// Sono qui perché la pagina rivendica "auditable scoring": affermarlo e non mostrarlo
+// è la stessa opacità che il prodotto critica. Tenere allineato ai pesi reali.
+const SCORING_WEIGHTS = [
+  ['Robots.txt', 18, 'Whether citation crawlers are allowed to fetch the site at all.'],
+  ['llms.txt', 18, 'Presence and depth of the root-level orientation file, including llms-full.txt.'],
+  ['Schema JSON-LD', 16, 'Valid structured data: Organization, WebSite, Article, FAQ.'],
+  ['Meta tags', 14, 'Title, description, canonical, and Open Graph completeness.'],
+  ['Content', 12, 'Heading hierarchy, word count, lists, front-loaded answers.'],
+  ['Signals', 6, 'Declared language, feed availability, freshness date.'],
+  ['AI discovery', 6, 'The .well-known/ai.txt and /ai/*.json endpoints.'],
+  ['Brand & entity', 10, 'Naming coherence, Knowledge Graph readiness, topic authority.'],
+] as const;
+
+// Aggregati della coorte, da GET /api/public/benchmark. Hardcoded perché la build
+// Docker gira prima che l'app sia in piedi e i numeri caricati via JS non entrano
+// nell'HTML che un crawler AI legge. `measuredOn` rende visibile la stagionatura.
+const BENCHMARK = {
+  measuredOn: '13 August 2026',
+  sampleLabel: '750+ audited sites',
+  average: '54.3',
+  median: '56',
+  llmsTxtAdoption: '58%',
+} as const;
+
 const trustCards = [
   {
     title: 'Open source (MIT)',
@@ -223,9 +248,32 @@ const faqSchema = {
         <div>
           <h3 class="text-lg font-semibold text-text-primary">2. Get a GEO score</h3>
           <p class="mt-2 text-text-secondary leading-relaxed">
-            The audit evaluates 8 signal categories — robots.txt, llms.txt, schema, meta tags,
-            content quality, technical signals, AI discovery, and brand entity — producing a
-            0–100 score with per-category breakdown.
+            The audit evaluates eight signal categories and returns a 0–100 score with a
+            per-category breakdown. These are the published weights — the same numbers the
+            open-source engine uses, so any score can be recomputed by hand:
+          </p>
+          <div class="mt-4 overflow-x-auto rounded-[--radius-lg] border border-border bg-bg-surface">
+            <table class="w-full text-left text-sm">
+              <thead>
+                <tr class="border-b border-border text-text-muted">
+                  <th scope="col" class="px-4 py-3 font-mono text-[11px] uppercase tracking-wider">Category</th>
+                  <th scope="col" class="px-4 py-3 font-mono text-[11px] uppercase tracking-wider">Points</th>
+                  <th scope="col" class="px-4 py-3 font-mono text-[11px] uppercase tracking-wider">What it measures</th>
+                </tr>
+              </thead>
+              <tbody>
+                {SCORING_WEIGHTS.map(([name, points, what]) => (
+                  <tr class="border-b border-border/60 last:border-0 align-top">
+                    <th scope="row" class="px-4 py-3 font-display font-semibold text-text-primary whitespace-nowrap">{name}</th>
+                    <td class="px-4 py-3 font-mono text-accent-teal">{points}</td>
+                    <td class="px-4 py-3 text-text-secondary leading-relaxed">{what}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <p class="mt-3 text-sm text-text-muted">
+            Bands: 86–100 excellent · 68–85 good · 36–67 foundation · 0–35 critical.
           </p>
         </div>
         <div>
@@ -235,6 +283,30 @@ const faqSchema = {
             actionable recommendations with specific file changes and schema additions.
           </p>
         </div>
+      </div>
+
+      {/* First-party baseline — a self-contained, quotable passage. Our own
+          measurement is the one claim on this page no competitor can restate. */}
+      <div class="mt-10 rounded-[--radius-lg] border border-border bg-bg-surface p-6">
+        <h3 class="text-lg font-semibold text-text-primary">What a typical site scores</h3>
+        <figure class="mt-3">
+          <blockquote class="border-l-2 border-accent-teal pl-4">
+            <p class="text-text-secondary leading-relaxed">
+              We measured the sites audited through GeoReady, and our data shows the average
+              scores <strong class="text-text-primary">{BENCHMARK.average} out of 100</strong>,
+              with a median of {BENCHMARK.median}. Only {BENCHMARK.llmsTxtAdoption} publish an
+              llms.txt file. A score in the fifties is therefore ordinary rather than alarming:
+              most sites leave a large share of their AI-visibility points unclaimed, and the
+              gaps sit in signals a tool can find mechanically.
+            </p>
+          </blockquote>
+          <figcaption class="mt-3 text-sm text-text-muted">
+            GeoReady benchmark, {BENCHMARK.sampleLabel}, measured {BENCHMARK.measuredOn}.
+            Latest audit per domain, aggregates only — the sample is self-selected, so read it
+            as a baseline among sites that chose to measure.
+            <a href="/state-of-geo/" class="underline hover:no-underline">See the live benchmark</a>.
+          </figcaption>
+        </figure>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary
Cherry-picks the 5 commits from `sync/fixes-to-site` that are not yet on `main` (the rest of that branch's history is already equivalent to `main`'s current content). Selected via cherry-pick rather than a full branch merge to avoid dragging in ~40 already-integrated commits.

- **fix(ci): auth deploy webhook with bearer token instead of httpbin echo** — the scheduled-publish webhook secret was a placeholder pointing at an echo service that always answers 200, so publish failures were silently masked.
- **feat(ops): reconcile the live site against Sanity instead of trusting the webhook** — adds `check-live-drift.mjs` / `reconcile-live-site.sh` as a safety net for the failure mode above.
- **feat(home): publish the scoring weights and a measured baseline** — homepage claimed "auditable scoring" without showing a single weight.
- **feat(best-geo-tools): state how the benchmark figures were produced** — adds a Methodology subsection.
- **feat(best-geo-tools): add first-party benchmark data and author byline**.

## Test plan
- [x] `pytest tests/ -q` — 1693 passed, 26 skipped, 1 pre-existing failure (`test_batch_audit.py::test_run_batch_audit_async_aggregates_scores`, confirmed failing identically on `main` before this branch — unrelated, no Python source touched here)
- [ ] `astro check` on frontend (running)
- [ ] Visual check of homepage + best-geo-tools page changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)