### PR TITLE
feat(analytics): GA4 begin_checkout + cross-domain session stitching

### DIFF
--- a/frontend/src/lib/cookieConsent.ts
+++ b/frontend/src/lib/cookieConsent.ts
@@ -224,7 +224,9 @@ export function loadAnalyticsScript(): void {
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
-    gtag('config', '${GA_MEASUREMENT_ID}');
+    gtag('config', '${GA_MEASUREMENT_ID}', {
+      'linker': { 'domains': ['geoready.dev', 'app.geoready.dev'], 'decorate_forms': true }
+    });
   `;
   document.head.appendChild(inline);
 }

--- a/frontend/src/lib/ctaTracking.ts
+++ b/frontend/src/lib/ctaTracking.ts
@@ -52,12 +52,29 @@ function handlePlanCta(link: HTMLElement): void {
   const planName = link.getAttribute('data-plan-name');
   if (!planId || !planName) return;
 
+  const currency = link.getAttribute('data-plan-currency') || 'USD';
+  const priceStr = normalizePrice(link.getAttribute('data-plan-price'));
+  // GA4 ecommerce requires a numeric value; skip begin_checkout for "custom"
+  // (non-numeric) price strings like the Enterprise plan.
+  const numericPrice = parseFloat(priceStr);
+
+  // GA4 standard ecommerce event — fires before the custom geo_plan_selected
+  // so the funnel step is captured in GA4 reporting. Uses the same consent-gated
+  // pattern as track(): if gtag isn't loaded (consent not given), this is a no-op.
+  if (typeof window !== 'undefined' && typeof window.gtag === 'function' && !isNaN(numericPrice)) {
+    window.gtag('event', 'begin_checkout', {
+      currency,
+      value: numericPrice,
+      items: [{ item_id: planId, item_name: planName, price: numericPrice, quantity: 1 }],
+    });
+  }
+
   trackPlanSelected({
     plan_id: planId,
     plan_name: planName,
     billing_period: link.getAttribute('data-plan-period') || 'one-time',
-    price: normalizePrice(link.getAttribute('data-plan-price')),
-    currency: link.getAttribute('data-plan-currency') || 'USD',
+    price: priceStr,
+    currency,
     cta_location: link.getAttribute('data-cta-location') || 'pricing_page',
   });
 }


### PR DESCRIPTION
## Summary
Cherry-picks the 2 genuinely new commits from the `marketing-p0` remote branch (the rest of that branch's content is already identical to `main` via a prior merge). The third commit on that branch — auto-prepending `https://` to URL inputs — is intentionally **not** included: `main` already solved the same bare-hostname problem differently in v4.16.2 (`type="text"` + `inputMode="url"` + `lib/urlInput.ts`), so picking it would reintroduce a redundant/conflicting approach.

- **feat(analytics): stitch GA4 sessions across geoready.dev and app.geoready.dev** — configures the cross-domain linker (`decorate_forms`) so `client_id` travels via `_ga` between the two domains; without it, every pricing→signup crossing was counted as a fresh Direct session.
- **feat(analytics): emit the GA4 standard begin_checkout on plan CTAs** — adds the standard ecommerce event alongside the existing custom `geo_plan_selected`, so GA4 can place plan clicks in a funnel/ecommerce report. Skipped for non-numeric prices (Enterprise "Custom").

Both stay inside the existing consent-gated `gtag` calls — no-op without analytics consent.

## Test plan
- [x] Reviewed diff — matches original commit intent exactly, no conflicts on rebase onto current `main`
- [ ] Manual check: pricing page CTA click fires `begin_checkout` in GA4 DebugView
- [ ] Manual check: cross-domain client_id persists from geoready.dev → app.geoready.dev signup

🤖 Generated with [Claude Code](https://claude.com/claude-code)