### PR TITLE
content(llms): sync stale entries + draft auto-generator for llms.txt

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "preview": "astro preview",
     "astro": "astro",
     "generate:sitemap": "node scripts/generate-sitemap.mjs",
+    "generate:llms": "node scripts/generate-llms.mjs",
     "generate:feed": "node scripts/generate-feed.mjs",
     "sanity:check-schedule": "node scripts/verify-scheduled-articles.mjs",
     "sanity:publish-due:dry-run": "node scripts/publish-scheduled-articles.mjs --dry-run",

--- a/frontend/public/llms.txt
+++ b/frontend/public/llms.txt
@@ -130,7 +130,7 @@ The GEO Optimizer engine is actively maintained. Scoring weights and audit metho
 - [How to improve AI visibility](https://geoready.dev/guides/how-to-improve-ai-visibility/): Step-by-step playbook for improving crawlability, structured data, entity clarity, quotable content, and measurement after an audit.
 - [llms.txt for WordPress](https://geoready.dev/guides/llms-txt-wordpress/): Practical implementation guide for WordPress sites.
 - [AI Visibility Checklist](https://geoready.dev/guides/ai-visibility-checklist/): All technical and content signals organized by category.
-- [How to check AI citations](https://geoready.dev/guides/ai-citations-check/): Measurement guide for checking whether AI engines mention and cite a brand.
+- [How to check AI citations](https://geoready.dev/guides/ai-citations-check/): Three ways to verify whether ChatGPT and Perplexity mention or cite a brand — manual check, free automated tool, and ongoing monitoring.
 - [Entity Authority](https://geoready.dev/guides/entity-authority/): How consistent entity signals, topical clusters, and public references help AI systems disambiguate a brand.
 - [Multimodal GEO](https://geoready.dev/guides/multimodal-geo/): Image, chart, screenshot, and media optimization patterns for AI visibility.
 - [What is Generative Engine Optimization (GEO)?](https://geoready.dev/guides/what-is-generative-engine-optimization/): What GEO is, how it differs from SEO, and how to measure it.
@@ -148,7 +148,7 @@ The GEO Optimizer engine is actively maintained. Scoring weights and audit metho
 - [AI Overviews and E-E-A-T](https://geoready.dev/guides/ai-overviews-eeat-author-authority/): How Google's E-E-A-T quality signals factor into AI Overview citations.
 - [How to Optimize for Google AI Overviews](https://geoready.dev/guides/google-ai-overviews-optimization/): How sources get selected for Google AI Overviews and the concrete steps to get cited.
 - [Google AI Overviews for Local Businesses](https://geoready.dev/guides/google-ai-overviews-local-business/): What moves the needle for local "near me" queries answered by AI Overviews.
-- [How to Track Google AI Overview Visibility](https://geoready.dev/guides/track-google-ai-overviews-visibility/): A repeatable manual process for tracking AI Overview visibility, plus how to turn it into a scheduled monitoring workflow.
+- [AI Overviews Tracking: What Tools Exist](https://geoready.dev/guides/track-google-ai-overviews-visibility/): No tool pulls AI Overview data directly from Google — what works today is a scheduled manual check paired with automated monitoring of the citation-readiness signals.
 - [AI Crawlers and robots.txt: The 2026 Guide](https://geoready.dev/guides/robots-txt-ai-bots/): Which AI crawlers (GPTBot, OAI-SearchBot, PerplexityBot) to allow or block in robots.txt, and why blocking them makes a site invisible to AI search.
 - [Does robots.txt Block ChatGPT?](https://geoready.dev/guides/does-robots-txt-block-chatgpt/): Which robots.txt rules block ChatGPT and other AI crawlers, and the minimal fix to let them back in.
 - [What Is an AI Crawler? Bot Types Explained](https://geoready.dev/guides/what-is-an-ai-crawler-bot-list/): The difference between training crawlers, retrieval bots, and on-demand fetchers, and which ones to allow.

--- a/frontend/scripts/generate-llms.mjs
+++ b/frontend/scripts/generate-llms.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+// Rigenera il blocco "## Guides" di frontend/public/llms.txt dai contenuti Sanity
+// live, sullo stesso modello di generate-sitemap.mjs: interroga il dataset con lo
+// stesso LIVE_FILTER, sostituisce solo la sezione meccanica e lascia intatto tutto
+// il resto del file (identità prodotto, tool, sezioni curate a mano).
+//
+// BOZZA — non ancora agganciata a Dockerfile.web né a `prebuild`. Prima di farlo,
+// va rivista la scelta editoriale qui sotto: la lista attuale in llms.txt è ordinata
+// a mano per cluster tematico (llms.txt/visibility → AI Overviews → robots.txt →
+// schema → SaaS/e-commerce…), non alfabeticamente né per data. Questo script ordina
+// invece per datePublished decrescente (i più recenti prima), che garantisce
+// freschezza automatica ma perde il raggruppamento tematico curato a mano — è il
+// trade-off da discutere prima di collegarlo alla build.
+//
+// Perché esiste: llms.txt non ha oggi nessuna generazione automatica (a differenza
+// di sitemap.xml), quindi ogni riscrittura di titolo/descrizione su Sanity lascia
+// l'entry corrispondente disallineata finché qualcuno non la corregge a mano —
+// esattamente il tipo di disallineamento silenzioso trovato il 2026-09-03 su
+// track-google-ai-overviews-visibility (titolo riscritto su Sanity, mai sincronizzato
+// qui). Vedi commit "content(llms): sync stale llms.txt entries..." su questo branch.
+//
+// Uso: npm run generate:llms            # sovrascrive frontend/public/llms.txt
+//      npm run generate:llms -- --dry-run   # stampa il diff, non scrive nulla
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createClient } from '@sanity/client';
+
+const SITE = 'https://geoready.dev';
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FRONTEND_ROOT = join(__dirname, '..');
+const LLMS_TXT_PATH = join(FRONTEND_ROOT, 'public', 'llms.txt');
+
+const SECTION_HEADING = '## Guides';
+const NEXT_HEADING_PREFIX = '## '; // qualunque heading di pari livello chiude la sezione
+
+const SANITY_PROJECT_ID = process.env.PUBLIC_SANITY_PROJECT_ID || 'uvzrnk4t';
+const SANITY_DATASET = process.env.PUBLIC_SANITY_DATASET || 'production';
+
+// Stesso filtro "live" di generate-sitemap.mjs (frontend/src/utils/sanity.ts):
+// i documenti legacy senza `status` restano visibili; gli scheduled diventano
+// visibili solo dopo la promozione esplicita a "published".
+const LIVE_FILTER = `(!defined(status) || status == "published")`;
+
+const dryRun = process.argv.includes('--dry-run');
+const warnings = [];
+
+async function fetchGuideEntries() {
+  const client = createClient({
+    projectId: SANITY_PROJECT_ID,
+    dataset: SANITY_DATASET,
+    apiVersion: '2024-01-01',
+    useCdn: false,
+  });
+
+  const articles = await client.fetch(
+    `*[_type == "article" && category == "guides" && defined(slug.current) && ${LIVE_FILTER}]{
+      title, "slug": slug.current, description, llmsContext, datePublished
+    } | order(datePublished desc)`
+  );
+
+  return articles.map((article) => {
+    // Campo dedicato per llms.txt/AI discovery (vedi schema: "One-paragraph
+    // description for llms.txt and AI discovery files"). In sua assenza, fallback
+    // sulla meta description standard — meno mirata ma sempre presente (required).
+    let summary = article.llmsContext?.trim() || article.description?.trim();
+    if (!summary) {
+      warnings.push(`${article.slug}: nessun llmsContext né description, entry saltata.`);
+      return null;
+    }
+    if (!article.llmsContext) {
+      warnings.push(`${article.slug}: llmsContext assente, uso description come fallback.`);
+    }
+    // Solo la prima frase: llmsContext è pensato come paragrafo pieno, ma lo stile
+    // esistente in llms.txt è una riga sola per entry.
+    const firstSentence = summary.split(/(?<=[.!?])\s+/)[0];
+    // Il titolo pagina spesso porta un punto finale (H1 in stile frase); come link
+    // text in una riga "- [Title](url): desc." risulterebbe ridondante col ":" che
+    // segue, quindi lo togliamo.
+    const linkText = article.title.replace(/\.$/, '');
+
+    return `- [${linkText}](${SITE}/guides/${article.slug}/): ${firstSentence}`;
+  }).filter(Boolean);
+}
+
+function replaceSection(fileContent, newLines) {
+  const lines = fileContent.split('\n');
+  const startIdx = lines.findIndex((l) => l.trim() === SECTION_HEADING);
+  if (startIdx === -1) {
+    throw new Error(`Sezione "${SECTION_HEADING}" non trovata in ${LLMS_TXT_PATH}`);
+  }
+  let endIdx = lines.findIndex(
+    (l, i) => i > startIdx && l.startsWith(NEXT_HEADING_PREFIX)
+  );
+  if (endIdx === -1) endIdx = lines.length;
+
+  // Preserva heading + eventuale riga vuota subito dopo, sostituisce solo le entry.
+  const before = lines.slice(0, startIdx + 1);
+  const after = lines.slice(endIdx);
+  return [...before, '', ...newLines, ...after].join('\n');
+}
+
+async function main() {
+  const entries = await fetchGuideEntries();
+  if (entries.length === 0) {
+    throw new Error('Nessuna guida live trovata su Sanity — mi rifiuto di svuotare la sezione Guides.');
+  }
+
+  const current = readFileSync(LLMS_TXT_PATH, 'utf-8');
+  const updated = replaceSection(current, entries);
+
+  for (const w of warnings) console.warn(`WARN  ${w}`);
+  console.log(`${entries.length} guide live trovate su Sanity.`);
+
+  if (dryRun) {
+    console.log(updated === current ? 'Nessuna differenza.' : 'Differenze trovate (--dry-run, nessuna scrittura).');
+    process.exit(0);
+  }
+
+  writeFileSync(LLMS_TXT_PATH, updated, 'utf-8');
+  console.log(`Scritto ${LLMS_TXT_PATH}`);
+}
+
+main().catch((err) => {
+  console.error(`ERRORE: ${err.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## What
1. **Content fix (deploy-ready)**: two `llms.txt` entries were stale relative to today's Sanity content rewrites — `ai-citations-check` and `track-google-ai-overviews-visibility` still showed pre-rewrite titles/descriptions. Fixed by hand to match current live content.
2. **Draft automation (needs a decision, not wired in)**: `llms.txt` has no regeneration step at all today, unlike `sitemap.xml` (`generate:sitemap`, run in `Dockerfile.web`). Added `scripts/generate-llms.mjs` + `npm run generate:llms` as a manual/reviewable draft — mechanically rebuilds the `## Guides` section from live Sanity articles (`llmsContext` field, falling back to `description`).

## Why
Found while auditing today's Sanity publishing changes: a full content rewrite went live on Sanity but `llms.txt` kept serving the old title/description indefinitely, with nothing to catch the drift (unlike `check-live-drift.mjs`, which only checks the sitemap).

## Open question before wiring the generator into the build
The current `llms.txt` Guides list is hand-ordered by topic cluster (llms.txt/visibility → AI Overviews → robots.txt → schema → SaaS/e-commerce…). The draft script orders by `datePublished` desc instead, trading that curated grouping for guaranteed freshness. Dry-run output (42 live guides, 9 without `llmsContext` falling back to `description`) is in the commit history for reference. Needs a call on ordering (and whether to also touch `llms-full.txt`'s hand-picked Guides subset) before this gets added to `prebuild`/`Dockerfile.web`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)